### PR TITLE
Multiple fixes from F.Prino

### DIFF
--- a/sim/include/NA6PGenerator.h
+++ b/sim/include/NA6PGenerator.h
@@ -24,11 +24,16 @@ class NA6PGenerator : public TObject
   virtual void generate() = 0;
   virtual void init();
   virtual void generatePrimaryVertex(int maxTrials = 1000000);
-  virtual void setOrigin(const std::array<double, 3>& v) { mOrigin = v; }
+  virtual void setOrigin(const std::array<double, 3>& v)
+  {
+    mOrigin = v;
+    mOriginSet = true;
+  }
   template <typename T>
   void setOrigin(T x, T y, T z)
   {
     mOrigin = {x, y, z};
+    mOriginSet = true;
   }
   auto& getOrigin() { return mOrigin; }
   auto& getOrigin() const { return mOrigin; }
@@ -54,8 +59,9 @@ class NA6PGenerator : public TObject
   ULong64_t mRandomSeed = 0;       //  random seed (used if non-0)
   int mVerbosity = 0;              //!
   bool mInitDone = false;
+  bool mOriginSet = false;
 
-  ClassDef(NA6PGenerator, 1);
+  ClassDef(NA6PGenerator, 2);
 };
 
 #endif

--- a/sim/src/NA6PGenerator.cxx
+++ b/sim/src/NA6PGenerator.cxx
@@ -21,12 +21,23 @@ void NA6PGenerator::generatePrimaryVertex(int maxTrials)
 {
   // will generate if not generated yet, otherwise, will set the origin from the MCHeader of the stack
   auto mcH = mStack->getEventHeader();
+  if (mOriginSet) {
+    mcH->setVX(mOrigin[0]);
+    mcH->setVY(mOrigin[1]);
+    mcH->setVZ(mOrigin[2]);
+    mStack->setPVGenerated(true);
+    if (mVerbosity) {
+      LOGP(info, "Use vertex imposed via setOrigin {:.4f},{:4f},{:4f}", mcH->getVX(), mcH->getVY(), mcH->getVZ());
+    }
+    return;
+  }
   if (getStack()->isPVGenerated()) {
     setOrigin(mcH->getVX(), mcH->getVY(), mcH->getVZ());
     if (mVerbosity) {
       LOGP(warn, "{}: the primary vertex was already generated, refusing!", getName());
-      return;
+      LOGP(info, "Use existing vertex at {:.4f},{:4f},{:4f}", mcH->getVX(), mcH->getVY(), mcH->getVZ());
     }
+    return;
   }
   static NA6PTarget* tgt = (NA6PTarget*)NA6PDetector::instance().getModule("Target");
   float x, y, z;
@@ -37,6 +48,7 @@ void NA6PGenerator::generatePrimaryVertex(int maxTrials)
   mcH->setVX(x);
   mcH->setVY(y);
   mcH->setVZ(z);
+  mStack->setPVGenerated(true);
   if (mVerbosity) {
     LOGP(info, "Generated primary vertex at {:.4f},{:4f},{:4f}", x, y, z);
   }

--- a/sim/src/NA6PMC.cxx
+++ b/sim/src/NA6PMC.cxx
@@ -83,6 +83,29 @@ void NA6PMC::forceCharmHadronicDecays()
   Dp_decay_mode[0][1] = 211;  // pi+
   Dp_decay_mode[0][2] = 211;  // pi+
   TVirtualMC::GetMC()->SetDecayMode(411, Dp_BR, Dp_decay_mode);
+  int Ds_decay_mode[6][3] = {{0}};
+  float Ds_BR[6] = {90.f, 10.f, 0.f, 0.f, 0.f, 0.f};
+  Ds_decay_mode[0][0] = 333;  // phi
+  Ds_decay_mode[0][1] = 211;  // pi+
+  Ds_decay_mode[1][0] = -313; // K*0bar
+  Ds_decay_mode[1][1] = 321;  // K
+  TVirtualMC::GetMC()->SetDecayMode(431, Ds_BR, Ds_decay_mode);
+  int Kstar_decay_mode[6][3] = {{0}};
+  float Kstar_BR[6] = {100.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+  Kstar_decay_mode[0][0] = 321;  // K+
+  Kstar_decay_mode[0][1] = -211; // pi-
+  TVirtualMC::GetMC()->SetDecayMode(313, Kstar_BR, Kstar_decay_mode);
+  int Phi_decay_mode[6][3] = {{0}};
+  float Phi_BR[6] = {100.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+  Phi_decay_mode[0][0] = 321;  // K+
+  Phi_decay_mode[0][1] = -321; // K-
+  TVirtualMC::GetMC()->SetDecayMode(333, Phi_BR, Phi_decay_mode);
+  int Lc_decay_mode[6][3] = {{0}};
+  float Lc_BR[6] = {100.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+  Lc_decay_mode[0][0] = -321; // K-
+  Lc_decay_mode[0][1] = 2212; // p
+  Lc_decay_mode[0][2] = 211;  // pi+
+  TVirtualMC::GetMC()->SetDecayMode(4122, Lc_BR, Lc_decay_mode);
 }
 
 void NA6PMC::GeneratePrimaries()
@@ -317,7 +340,25 @@ void NA6PMC::selectTracksToSave()
   }
   for (int i = nPrimIni; i < ntrIni; i++) {
     auto* part = mStack->GetParticle(i);
-    if (NA6PModule::testActiveIDBits(*part)) { // has hits
+    bool isFromHFDecay = false;
+    int idMoth = part->GetFirstMother();
+    int mothPdg = -1;
+    while (idMoth >= 0) {
+      auto* currMoth = mStack->GetParticle(idMoth);
+      int absPdg = std::abs(currMoth->GetPdgCode());
+      if (absPdg == 11 || absPdg == 22 || absPdg == 211 || absPdg == 130 || absPdg == 321 || absPdg == 2212 || absPdg == 2112) {
+        // stop if a "stable" particle is found in the ancestors
+        isFromHFDecay = false;
+        break;
+      }
+      if ((absPdg > 400 && absPdg < 600) || (absPdg > 4000 && absPdg < 6000) || absPdg == 100443 || absPdg == 20443) {
+        isFromHFDecay = true;
+        mothPdg = absPdg;
+        break;
+      }
+      idMoth = currMoth->GetFirstMother();
+    }
+    if (NA6PModule::testActiveIDBits(*part) || isFromHFDecay) { // has hits
       if (mRemap[i] >= 0) {                    // was already accounted
         continue;
       }


### PR DESCRIPTION
* Changes in NA6PGenerator{.h,.cxx}
 - possibility to set the vertex from the outside (needed to compare to ACTS simulations which were done with the vertex in 0,0,0)
 - modifications in generatePrimaryVertex to use the vertex from setOrigin (if it wa set) or the vertex from previous event in a cocktail (needed to have the same origin for all the primary particles produced by the different generators of the cocktail)

* Changes in NA6PMC.cxx
 - force hadronic decays for Lc and Ds (still  with the hard-coded approach used for D0 and D+)
 - store in the kinematics all daughter particles of HF hadrons (needed for acceptance calculation)

* Changes in convert2ACTS.C
 - write down in csv files also the hits in the muon spectrometer
 - implement the geometry_id of planes matching the ACTS geometry
 - write an additional csv file with only primary particles (needed to compare with FATRAS propagation)
 - add an index/counter for secondary vertices (needed to avoid duplicated bar codes for particles sharing the same values of gen and sub)
 - convert units to mm (used in ACTS)