### PR TITLE
Replace carbon foam support of VT planes with carbon fiber plates

### DIFF
--- a/sim/src/NA6PVerTel.cxx
+++ b/sim/src/NA6PVerTel.cxx
@@ -97,19 +97,21 @@ void NA6PVerTel::createGeometry(TGeoVolume* world)
                                          param.shiftVerTel[2] + (param.posVerTelPlaneZ[0] + boxDZ / 2 - boxDZMargin),
                                          NA6PTGeoHelper::rotAroundVector(0.0, 0.0, 0.0, 0.0));
   world->AddNode(vtContainer, composeNonSensorVolID(0), vtTransform);
+
   // pixel station Frame with holes (box with subtracted holes)
-  auto* pixStFrameBox = new TGeoBBox("PixStFrameBox", frameDX / 2, frameDY / 2, frameDZ / 2);
-  auto* beamPipeHole = new TGeoTube("PixStFrameBoxBPHole", 0, frameHoleR, frameDZ);
-  auto* frameSubtraction = new TGeoSubtraction(pixStFrameBox, beamPipeHole);
-  auto* pixStFrameShape = new TGeoCompositeShape("PixStFrameBoxHole0", frameSubtraction);
-  for (size_t ii = 0; ii < chipHoleX.size(); ++ii) {
-    auto* pixChipHole = new TGeoBBox("PixChipHole", pixChipHoleDX / 2, pixChipHoleDY / 2, frameDZ);
-    auto* holeTransform = new TGeoTranslation(chipHoleX[ii], chipHoleY[ii], 0);
-    frameSubtraction = new TGeoSubtraction(pixStFrameShape, pixChipHole, nullptr, holeTransform);
-    pixStFrameShape = new TGeoCompositeShape(Form("PixStFrameBoxHole0%zu", ii), frameSubtraction);
-  }
-  TGeoVolume* pixStFrame = new TGeoVolume("PixStFrame", pixStFrameShape, NA6PTGeoHelper::instance().getMedium(addName("CarbonFoam")));
-  pixStFrame->SetLineColor(NA6PTGeoHelper::instance().getMediumColor(addName("CarbonFoam")));
+  // COMMENTED OUT: to be replaced with the new Al frame
+  // auto* pixStFrameBox = new TGeoBBox("PixStFrameBox", frameDX / 2, frameDY / 2, frameDZ / 2);
+  // auto* beamPipeHole = new TGeoTube("PixStFrameBoxBPHole", 0, frameHoleR, frameDZ);
+  // auto* frameSubtraction = new TGeoSubtraction(pixStFrameBox, beamPipeHole);
+  // auto* pixStFrameShape = new TGeoCompositeShape("PixStFrameBoxHole0", frameSubtraction);
+  // for (size_t ii = 0; ii < chipHoleX.size(); ++ii) {
+  //   auto* pixChipHole = new TGeoBBox("PixChipHole", pixChipHoleDX / 2, pixChipHoleDY / 2, frameDZ);
+  //   auto* holeTransform = new TGeoTranslation(chipHoleX[ii], chipHoleY[ii], 0);
+  //   frameSubtraction = new TGeoSubtraction(pixStFrameShape, pixChipHole, nullptr, holeTransform);
+  //   pixStFrameShape = new TGeoCompositeShape(Form("PixStFrameBoxHole0%zu", ii), frameSubtraction);
+  // }
+  // TGeoVolume* pixStFrame = new TGeoVolume("PixStFrame", pixStFrameShape, NA6PTGeoHelper::instance().getMedium(addName("CarbonFoam")));
+  // pixStFrame->SetLineColor(NA6PTGeoHelper::instance().getMediumColor(addName("CarbonFoam")));
 
   // Silicon Tracker Station
   auto* pixelStationShape = new TGeoBBox("PixelStationShape", pixChipContainerDX / 2, pixChipContainerDY / 2, pixChipContainerDz / 2);


### PR DESCRIPTION
Hi Ruben,

I modified the VT geometry removing the carbon foam support for each plane and adding carbon fiber plates, with thickness of 400 um.
This way the geometry in the acceptance region should match the one of the fast simulation.
For the density of the carbon fiber, I used 1.91 g/cm3, which I took from the ITS geometry in O2.

I run the clang-formatting according to your instructions. I hope I did it right.

Thanks!

Cheers, Francesco