### PR TITLE
Fix interpolation call and remove unused feature

### DIFF
--- a/base/include/MagneticField.h
+++ b/base/include/MagneticField.h
@@ -21,8 +21,7 @@ class MagneticField : public TVirtualMagField
   void dumpMagFieldMap(double xmin, double xmax, 
                        double ymin, double ymax, 
                        double zmin, double zmax, 
-                       double step, std::string fieldMapFile,
-                       std::string rotatedFieldMapFile);
+                       double step, std::string fieldMapFile);
   void dumpMagFieldFromConfig();
 
 

--- a/base/include/MagneticFieldRegion.h
+++ b/base/include/MagneticFieldRegion.h
@@ -75,7 +75,7 @@ class MagneticFieldRegion
     int k = findGridIndex(z, mZMin, mDZI, mNZ1);
 
     // Perform second-degree interpolation
-    interpolateField(i, j, k, x, y, z, bxbybz);
+    interpolateFieldAdd(i, j, k, x, y, z, bxbybz);
     return true;
   }
 

--- a/base/include/NA6PLayoutParam.h
+++ b/base/include/NA6PLayoutParam.h
@@ -21,7 +21,6 @@ struct NA6PLayoutParam : public na6p::conf::ConfigurableParamHelper<NA6PLayoutPa
   float zMaxFieldDump = 900.f;  // max Z of the magnetic field in cm
   float stepFieldDump = 5.f;    // step in cm for the magnetic field map
   std::string fieldMap = "field_map.txt";
-  std::string rotatedFieldMap = "field_map_rotated.txt";
 
   // VerTel Dipole
   float posDipIP[3] = {0.f, 0.f, 0.f}; // Vertex dipole position

--- a/base/src/MagneticField.cxx
+++ b/base/src/MagneticField.cxx
@@ -44,8 +44,7 @@ void MagneticField::setAsGlobalField()
 void MagneticField::dumpMagFieldMap(double xmin, double xmax,
                                     double ymin, double ymax,
                                     double zmin, double zmax,
-                                    double step, std::string fieldMapFile,
-                                    std::string rotatedFieldMapFile)
+                                    double step, std::string fieldMapFile)
 {
   std::ofstream fieldMap(fieldMapFile.c_str());
   std::ofstream rotatedFieldMap(rotatedFieldMapFile.c_str());
@@ -68,26 +67,7 @@ void MagneticField::dumpMagFieldMap(double xmin, double xmax,
       }
     }
   }
-
-
-  for (double ix = xmin; ix <= xmax; ix += step) {
-    for (double iz = ymin; iz <= ymax; iz += step) {
-      for (double iy = zmin; iy <= zmax; iy += step) {
-        x[0] = ix;
-        x[1] = iy;
-        x[2] = iz;
-
-        Field(x, b);
-        
-        // ACTS uses mm instead of cm
-        rotatedFieldMap << ix*10 << " " << iz*10 << " " << -iy*10 << " "
-            << b[0]/mScale2Unit << " " << b[1]/mScale2Unit << " " << b[2]/mScale2Unit << "\n";
-      }
-    }
-  }
-
   fieldMap.close();
-  rotatedFieldMap.close();
 }
 
 void MagneticField::dumpMagFieldFromConfig()
@@ -97,6 +77,5 @@ void MagneticField::dumpMagFieldFromConfig()
   dumpMagFieldMap(param.xMinFieldDump, param.xMaxFieldDump,
                   param.yMinFieldDump, param.yMaxFieldDump,
                   param.zMinFieldDump, param.zMaxFieldDump,
-                  param.stepFieldDump, param.fieldMap,
-                  param.rotatedFieldMap);
+                  param.stepFieldDump, param.fieldMap);
 }

--- a/base/src/MagneticField.cxx
+++ b/base/src/MagneticField.cxx
@@ -47,8 +47,7 @@ void MagneticField::dumpMagFieldMap(double xmin, double xmax,
                                     double step, std::string fieldMapFile)
 {
   std::ofstream fieldMap(fieldMapFile.c_str());
-  std::ofstream rotatedFieldMap(rotatedFieldMapFile.c_str());
-
+  
   Double_t x[3];
   Double_t b[3];
 


### PR DESCRIPTION
The PR contains two fixes:
1) AddField used the wrong interpolation method.
2) The rotated field was removed because the new ACTS version does not require a rotated field during the seeding of telescope-like detectors.