### PR TITLE
Fix MuonSpecModular hits and update convertACTS.C

### DIFF
--- a/sim/include/NA6PBaseHit.h
+++ b/sim/include/NA6PBaseHit.h
@@ -132,7 +132,7 @@ class NA6PBaseHit
   float mPosIn[3] = {};          // cartesian position of Hit at the entrance
   float mPosOut[3] = {};         // cartesian position of Hit at the exit
   float mMomIn[3] = {};          // momentum at entrance
-  float mMomOut[3] = {};          // momentum at exit
+  float mMomOut[3] = {};         // momentum at exit
   float mTime = 0.f;             // time of flight
   float mHitValue = 0.;          // hit value
   int mTrackID = 0;              // track_id

--- a/sim/include/NA6PBaseHit.h
+++ b/sim/include/NA6PBaseHit.h
@@ -132,7 +132,7 @@ class NA6PBaseHit
   float mPosIn[3] = {};          // cartesian position of Hit at the entrance
   float mPosOut[3] = {};         // cartesian position of Hit at the exit
   float mMomIn[3] = {};          // momentum at entrance
-  float mMomOut[3] = {};          // momentum at entrance
+  float mMomOut[3] = {};          // momentum at exit
   float mTime = 0.f;             // time of flight
   float mHitValue = 0.;          // hit value
   int mTrackID = 0;              // track_id

--- a/sim/include/NA6PBaseHit.h
+++ b/sim/include/NA6PBaseHit.h
@@ -34,7 +34,7 @@ class NA6PBaseHit
   };
 
   NA6PBaseHit() = default;
-  NA6PBaseHit(int trackid, short did, const TVector3& xyzIn, const TVector3& xyzOut, const TVector3& momIn, float time, float val, uint8_t statusStart, uint8_t statusEnd);
+  NA6PBaseHit(int trackid, short did, const TVector3& xyzIn, const TVector3& xyzOut, const TVector3& momIn, const TVector3& momOut, float time, float val, uint8_t statusStart, uint8_t statusEnd);
 
   auto getTrackID() const { return mTrackID; }
   void setTrackID(int id) { mTrackID = id; }
@@ -55,9 +55,13 @@ class NA6PBaseHit
   auto getZ() const { return 0.5 * (mPosIn[2] + mPosOut[2]); }
 
   auto* getMomIn() const { return mMomIn; }
-  auto getPX() const { return mMomIn[0]; }
-  auto getPY() const { return mMomIn[1]; }
-  auto getPZ() const { return mMomIn[2]; }
+  auto* getMomOut() const { return mMomOut; }
+  auto getPXIn() const { return mMomIn[0]; }
+  auto getPYIn() const { return mMomIn[1]; }
+  auto getPZIn() const { return mMomIn[2]; }
+  auto getPXOut() const { return mMomOut[0]; }
+  auto getPYOut() const { return mMomOut[1]; }
+  auto getPZOut() const { return mMomOut[2]; }
 
   auto getHitValue() const { return mHitValue; }
   auto getTime() const { return mTime; }
@@ -114,6 +118,13 @@ class NA6PBaseHit
     mMomIn[2] = v.Z();
   }
 
+  void setMomOut(const TVector3& v)
+  {
+    mMomOut[0] = v.X();
+    mMomOut[1] = v.Y();
+    mMomOut[2] = v.Z();
+  }
+
   void print() const;
   std::string asString() const;
 
@@ -121,6 +132,7 @@ class NA6PBaseHit
   float mPosIn[3] = {};          // cartesian position of Hit at the entrance
   float mPosOut[3] = {};         // cartesian position of Hit at the exit
   float mMomIn[3] = {};          // momentum at entrance
+  float mMomOut[3] = {};          // momentum at entrance
   float mTime = 0.f;             // time of flight
   float mHitValue = 0.;          // hit value
   int mTrackID = 0;              // track_id

--- a/sim/include/NA6PMuonSpec.h
+++ b/sim/include/NA6PMuonSpec.h
@@ -28,7 +28,7 @@ class NA6PMuonSpec : public NA6PModule
 
   const auto& getHits() const { return mHits; }
 
-  NA6PMuonSpecHit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom,
+  NA6PMuonSpecHit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom, const TVector3& endMom,
                           float endTime, float eLoss, unsigned char startStatus, unsigned char endStatus);
 
  private:

--- a/sim/include/NA6PMuonSpecModular.h
+++ b/sim/include/NA6PMuonSpecModular.h
@@ -28,7 +28,7 @@ class NA6PMuonSpecModular : public NA6PModule
 
   const auto& getHits() const { return mHits; }
 
-  NA6PMuonSpecModularHit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom,
+  NA6PMuonSpecModularHit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom, const TVector3& endMom,
                           float endTime, float eLoss, unsigned char startStatus, unsigned char endStatus);
 
  private:

--- a/sim/include/NA6PVerTel.h
+++ b/sim/include/NA6PVerTel.h
@@ -28,7 +28,7 @@ class NA6PVerTel : public NA6PModule
 
   const auto& getHits() const { return mHits; }
 
-  NA6PVerTelHit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom,
+  NA6PVerTelHit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom, const TVector3& endMom,
                         float endTime, float eLoss, unsigned char startStatus, unsigned char endStatus);
 
  private:

--- a/sim/src/NA6PBaseHit.cxx
+++ b/sim/src/NA6PBaseHit.cxx
@@ -4,17 +4,18 @@
 #include <fmt/format.h>
 #include <fairlogger/Logger.h>
 
-NA6PBaseHit::NA6PBaseHit(int trackid, short did, const TVector3& xyzIn, const TVector3& xyzOut, const TVector3& momIn, float time, float val, uint8_t statusStart, uint8_t statusEnd) : mTime(time), mHitValue(val), mTrackID(trackid), mDetectorID(did), mTrackStatusStart(statusStart), mTrackStatusEnd(statusEnd)
+NA6PBaseHit::NA6PBaseHit(int trackid, short did, const TVector3& xyzIn, const TVector3& xyzOut, const TVector3& momIn, const TVector3& momOut, float time, float val, uint8_t statusStart, uint8_t statusEnd) : mTime(time), mHitValue(val), mTrackID(trackid), mDetectorID(did), mTrackStatusStart(statusStart), mTrackStatusEnd(statusEnd)
 {
   setPosIn(xyzIn);
   setPosOut(xyzOut);
   setMomIn(momIn);
+  setMomOut(momOut);
 }
 
 std::string NA6PBaseHit::asString() const
 {
   return fmt::format("Hit: Det:{} Track:{} T:{} V:{} XYZIn:{:.3f},{:.3f},{:.3f} XYZOut:{:.3f},{:.3f},{:.3f} PIn:{:.3f},{:.3f},{:.3f} Status:{:B}:{:B}",
-                     mDetectorID, mTrackID, mTime, mHitValue, getXIn(), getYIn(), getZIn(), getXOut(), getYOut(), getZOut(), getPX(), getPY(), getPZ(), mTrackStatusStart, mTrackStatusEnd);
+                     mDetectorID, mTrackID, mTime, mHitValue, getXIn(), getYIn(), getZIn(), getXOut(), getYOut(), getZOut(), getPXIn(), getPYIn(), getPZIn(), mTrackStatusStart, mTrackStatusEnd);
 }
 
 void NA6PBaseHit::print() const

--- a/sim/src/NA6PMuonSpec.cxx
+++ b/sim/src/NA6PMuonSpec.cxx
@@ -138,11 +138,12 @@ bool NA6PMuonSpec::stepManager(int volID)
     mTrackData.mHitStarted = true;
   }
   if (stopHit) {
-    TLorentzVector positionStop;
+    TLorentzVector positionStop, momentumStop;
+    mc->TrackMomentum(momentumStop);
     mc->TrackPosition(positionStop);
     // Retrieve the indices with the volume path
     auto* p = addHit(stack->GetCurrentTrackNumber(), sensID, mTrackData.mPositionStart.Vect(), positionStop.Vect(),
-                     mTrackData.mMomentumStart.Vect(), positionStop.T(),
+                     mTrackData.mMomentumStart.Vect(), momentumStop.Vect(), positionStop.T(),
                      mTrackData.mEnergyLoss, mTrackData.mTrkStatusStart, status);
     if (mVerbosity > 0) {
       LOGP(info, "{} Tr{} {}", getName(), stack->GetCurrentTrackNumber(), p->asString());
@@ -154,10 +155,10 @@ bool NA6PMuonSpec::stepManager(int volID)
   return false;
 }
 
-NA6PMuonSpecHit* NA6PMuonSpec::addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom,
+NA6PMuonSpecHit* NA6PMuonSpec::addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom, const TVector3& endMom,
                                       float endTime, float eLoss, unsigned char startStatus, unsigned char endStatus)
 {
-  mHits.emplace_back(trackID, detID, startPos, endPos, startMom, endTime, eLoss, startStatus, endStatus);
+  mHits.emplace_back(trackID, detID, startPos, endPos, startMom, endMom, endTime, eLoss, startStatus, endStatus);
   return &(mHits.back());
 }
 

--- a/sim/src/NA6PMuonSpecModular.cxx
+++ b/sim/src/NA6PMuonSpecModular.cxx
@@ -93,17 +93,13 @@ void NA6PMuonSpecModular::createGeometry(TGeoVolume* world)
 
     auto stnm = fmt::format("MS{}", ist);
 
-    // Stazione NON sensibile (solo contenitore)
     auto* station = new TGeoBBox((stnm + "SH").c_str(), param.dimXMSPlane[ist] / 2.0f + EnvelopDXH, param.dimYMSPlane[ist] / 2.0f + EnvelopDYH, pixChipDz / 2.0f + EnvelopDZH);
     auto stationSensVol = new TGeoVolume(stnm.c_str(), station, NA6PTGeoHelper::instance().getMedium(addName(param.medMSPlane[ist])));
 
     LOGP(info, "Creating MS station {} with dimensions: X={} Y={} Z={}", stnm, param.dimXMSPlane[ist], param.dimYMSPlane[ist], pixChipDz);
     placeSensors(param.dimXMSPlane[ist], param.dimYMSPlane[ist], param.msChipDX[ist], param.msChipDY[ist], param.dimXMSPlaneHole[ist], param.dimYMSPlaneHole[ist], stationSensVol, MSSensor);
 
-    // Envelope NON sensibile
     auto stationSensVolEnv = new TGeoVolume((stnm + "Env").c_str(), station, NA6PTGeoHelper::instance().getMedium(addName("Air")));
-    
-    // IMPORTANTE: usa composeNonSensorVolID per il contenitore
     stationSensVolEnv->AddNode(stationSensVol, composeNonSensorVolID(ist));
     world->AddNode(stationSensVolEnv, composeNonSensorVolID(ist), new TGeoTranslation(param.shiftMS[0] + param.posMSPlaneX[ist], param.shiftMS[1] + param.posMSPlaneY[ist], param.shiftMS[2] + param.posMSPlaneZ[ist]));
   }

--- a/sim/src/NA6PVerTel.cxx
+++ b/sim/src/NA6PVerTel.cxx
@@ -215,7 +215,8 @@ bool NA6PVerTel::stepManager(int volID)
     mTrackData.mHitStarted = true;
   }
   if (stopHit) {
-    TLorentzVector positionStop;
+    TLorentzVector positionStop, momentumStop;
+    mc->TrackMomentum(momentumStop);
     mc->TrackPosition(positionStop);
     // Retrieve the indices with the volume path
     int stationID(-1);
@@ -224,7 +225,7 @@ bool NA6PVerTel::stepManager(int volID)
 
     int chipindex = NChipsPerStation * stationID + sensID;
     auto* p = addHit(stack->GetCurrentTrackNumber(), chipindex, mTrackData.mPositionStart.Vect(), positionStop.Vect(),
-                     mTrackData.mMomentumStart.Vect(), positionStop.T(),
+                     mTrackData.mMomentumStart.Vect(), momentumStop.Vect(), positionStop.T(),
                      mTrackData.mEnergyLoss, mTrackData.mTrkStatusStart, status);
     if (mVerbosity > 0) {
       LOGP(info, "{} Tr{} {}", getName(), stack->GetCurrentTrackNumber(), p->asString());
@@ -236,10 +237,10 @@ bool NA6PVerTel::stepManager(int volID)
   return false;
 }
 
-NA6PVerTelHit* NA6PVerTel::addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom,
+NA6PVerTelHit* NA6PVerTel::addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom, const TVector3& endMom,
                                   float endTime, float eLoss, unsigned char startStatus, unsigned char endStatus)
 {
-  mHits.emplace_back(trackID, detID, startPos, endPos, startMom, endTime, eLoss, startStatus, endStatus);
+  mHits.emplace_back(trackID, detID, startPos, endPos, startMom, endMom, endTime, eLoss, startStatus, endStatus);
   return &(mHits.back());
 }
 

--- a/test/convert2ACTS.C
+++ b/test/convert2ACTS.C
@@ -133,7 +133,7 @@ void convert2ACTS(const std::string& dirname = "./",
                   const std::string& fnameMCKin = "MCKine.root",
                   const std::string& fnameVTHits = "HitsVerTel.root",
                   const std::string& fnameMSHits = "HitsMuonSpecModular.root",
-                  const std::string& geometryFile = "/home/giacomo/acts_for_NA60+/ACTS-Analysis-Scripts/geometry/fullgeo/geometry-map.json",
+                  const std::string& geometryFile = "geometry-map.json",
                   const std::string& confOpts = "",
                   bool useModularSpec = true)
 {

--- a/test/convert2ACTS.C
+++ b/test/convert2ACTS.C
@@ -1,6 +1,7 @@
 #if !defined(__CINT__) || defined(__MAKECINT__)
 #include "NA6PVerTelHit.h"
 #include "NA6PMuonSpecHit.h"
+#include "NA6PMuonSpecModularHit.h"
 #include "NA6PMCGenHeader.h"
 #include "NA6PMCEventHeader.h"
 #include "ConfigurableParam.h"
@@ -15,41 +16,129 @@
 #include <cstdio>
 #include <bitset>
 
+#include <iostream>
+#include <fstream>
+#include <nlohmann/json.hpp>
 #endif
+
+using json = nlohmann::json;
+
+// Structure to hold the extracted surface data
+struct SurfaceData {
+  uint64_t geo_id = 0;
+  float z = 0.0f;
+  float range_x[2] = {0.0f, 0.0f};
+  float range_y[2] = {0.0f, 0.0f};
+};
+
+// Function to extract specific fields from surface entries
+std::vector<SurfaceData> extractSurfaceData(const std::string& filename)
+{
+  std::ifstream file(filename);
+
+  // Check if file opened successfully
+  if (!file.is_open()) {
+    throw std::runtime_error("Could not open file: " + filename);
+  }
+
+  std::vector<SurfaceData> surfaces;
+  json jsonData;
+
+  try {
+    file >> jsonData;
+
+    if (!jsonData.contains("Surfaces") || !jsonData["Surfaces"].contains("entries")) {
+      std::cerr << "No Surfaces->entries found in JSON" << std::endl;
+      return surfaces;
+    }
+
+    for (const auto& entry : jsonData["Surfaces"]["entries"]) {
+      // Extract sensitive (optional)
+      if (entry.contains("sensitive")) {
+        SurfaceData surface;
+        // Extract from nested "value" object
+        if (entry.contains("value")) {
+          const auto& value = entry["value"];
+          // Extract geo_id
+          if (value.contains("geo_id")) {
+            surface.geo_id = value["geo_id"];
+          }
+
+          // Surface position and ranges
+          if (value.contains("transform")) {
+            surface.z = value["transform"]["translation"][2];
+            surface.range_x[0] = static_cast<float>(value["material"]["binUtility"]["binningdata"][0]["min"]) + static_cast<float>(value["transform"]["translation"][0]);
+            surface.range_x[1] = static_cast<float>(value["material"]["binUtility"]["binningdata"][0]["max"]) + static_cast<float>(value["transform"]["translation"][0]);
+            surface.range_y[0] = static_cast<float>(value["material"]["binUtility"]["binningdata"][1]["min"]) + static_cast<float>(value["transform"]["translation"][1]);
+            surface.range_y[1] = static_cast<float>(value["material"]["binUtility"]["binningdata"][1]["max"]) + static_cast<float>(value["transform"]["translation"][1]);
+            surfaces.push_back(surface);
+          }
+        }
+      }
+    }
+  } catch (const json::parse_error& e) {
+    throw std::runtime_error("JSON parse error: " + std::string(e.what()));
+  }
+
+  file.close();
+  return surfaces;
+}
+
+uint64_t getACTSgeomID(float x, float y, float z, const std::vector<SurfaceData>& surfaces)
+{
+  auto getGeoID = [](float x, float y, float z, const std::vector<SurfaceData>& surfaces) -> uint64_t {
+    for (const auto& surface : surfaces) {
+      if (x >= surface.range_x[0] && x <= surface.range_x[1] &&
+          y >= surface.range_y[0] && y <= surface.range_y[1] &&
+          abs(z - surface.z) < 0.1f) {
+        return surface.geo_id;
+      }
+    }
+    return 0; // Return 0 if no matching surface is found
+  };
+  return getGeoID(x, y, z, surfaces);
+}
 
 TChain* loadUserChain(const char* inpData, const char* chName, bool recursive = false);
 void addRootFileDirectory(TChain* chain, const char* flName, const char* chName, bool recursive = false);
 
-uint64_t getACTSgeomID(uint64_t layer, uint64_t sensitive)
+// Template function per convertire gli hit generici
+template <typename MSHitType>
+void convert2ACTSImpl(int iev,
+                      const std::vector<TParticle>& mcParts,
+                      const std::vector<NA6PVerTelHit>& vtHits,
+                      const std::vector<MSHitType>& msHits,
+                      const std::vector<SurfaceData>& actsSurfaces);
+
+// Wrapper functions per entrambi i tipi
+void convert2ACTS(int iev,
+                  const std::vector<TParticle>& mcParts,
+                  const std::vector<NA6PVerTelHit>& vtHits,
+                  const std::vector<NA6PMuonSpecModularHit>& msHits,
+                  const std::vector<SurfaceData>& actsSurfaces)
 {
-  // layer numbered as 1, 2, 3 ...
-  // sensitive numbered as 1,2,3,4 for VT, 1 for MS
-  uint64_t volume = 1;
-  uint64_t boundar = 0;
-  uint64_t approach = 0;
-  uint64_t channel = 0;
-  uint64_t id = 0;
-  layer *= 2;
-  id += volume << 56;
-  id += boundar << 48;
-  id += layer << 36;
-  id += approach << 28;
-  id += sensitive << 8;
-  id += channel;
-  return id;
+  convert2ACTSImpl(iev, mcParts, vtHits, msHits, actsSurfaces);
 }
 
 void convert2ACTS(int iev,
                   const std::vector<TParticle>& mcParts,
                   const std::vector<NA6PVerTelHit>& vtHits,
-                  const std::vector<NA6PMuonSpecHit>& msHits);
+                  const std::vector<NA6PMuonSpecHit>& msHits,
+                  const std::vector<SurfaceData>& actsSurfaces)
+{
+  convert2ACTSImpl(iev, mcParts, vtHits, msHits, actsSurfaces);
+}
 
 void convert2ACTS(const std::string& dirname = "./",
                   const std::string& fnameMCKin = "MCKine.root",
                   const std::string& fnameVTHits = "HitsVerTel.root",
-                  const std::string& fnameMCHits = "HitsMuonSpec.root",
-                  const std::string& confOpts = "")
+                  const std::string& fnameMSHits = "HitsMuonSpecModular.root",
+                  const std::string& geometryFile = "/home/giacomo/acts_for_NA60+/ACTS-Analysis-Scripts/geometry/fullgeo/geometry-map.json",
+                  const std::string& confOpts = "",
+                  bool useModularSpec = true)
 {
+  auto actsSurfaces = extractSurfaceData(geometryFile);
+
   std::string dirnameL = dirname;
   if (dirnameL.empty()) {
     dirnameL = ".";
@@ -59,29 +148,56 @@ void convert2ACTS(const std::string& dirname = "./",
   if (!confOpts.empty()) {
     na6p::conf::ConfigurableParam::updateFromString(confOpts);
   }
+
   NA6PMCEventHeader mcHeader, *mcHeaderPtr = &mcHeader;
   std::vector<TParticle> mcParts, *mcPartsPtr = &mcParts;
-  std::vector<NA6PMuonSpecHit> msHits, *msHitsPtr = &msHits;
   std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
 
   TChain* treeKin = loadUserChain(fmt::format("{}{}", dirnameL, fnameMCKin).c_str(), "mckine");
   TChain* treeVTH = loadUserChain(fmt::format("{}{}", dirnameL, fnameVTHits).c_str(), "hitsVerTel");
-  TChain* treeMSH = loadUserChain(fmt::format("{}{}", dirnameL, fnameMCHits).c_str(), "hitsMuonSpec");
+
+  // Determina quale branch name usare
+  const char* msBranchName = useModularSpec ? "hitsMuonSpecModular" : "hitsMuonSpec";
+  const char* msTreeName = useModularSpec ? "MuonSpecModular" : "MuonSpec";
+
+  TChain* treeMSH = loadUserChain(fmt::format("{}{}", dirnameL, fnameMSHits).c_str(), msBranchName);
+
   int nent = 0;
-  if (!treeKin || !treeVTH || !treeMSH || !(nent = treeKin->GetEntries()) || treeVTH->GetEntries() != nent || treeMSH->GetEntries() != nent) {
+  if (!treeKin || !treeVTH || !treeMSH || !(nent = treeKin->GetEntries()) ||
+      treeVTH->GetEntries() != nent || treeMSH->GetEntries() != nent) {
     LOGP(fatal, "Problem in opening input file or empty input");
   }
+
   treeKin->SetBranchAddress("header", &mcHeaderPtr);
   treeKin->SetBranchAddress("tracks", &mcPartsPtr);
   treeVTH->SetBranchAddress("VerTel", &vtHitsPtr);
-  treeMSH->SetBranchAddress("MuonSpec", &msHitsPtr);
-  for (int iev = 0; iev < nent; iev++) {
-    treeKin->GetEntry(iev);
-    treeVTH->GetEntry(iev);
-    treeMSH->GetEntry(iev);
-    LOGP(info, "Event#{} Vtx:[{:.2f},{:.2f},{:.2f}] {} Tracks ({} primaries), Hits: VT: {} MS: {}", iev, mcHeader.getVX(), mcHeader.getVY(), mcHeader.getVZ(), mcHeader.getNTracks(), mcHeader.getNPrimaries(), vtHits.size(), msHits.size());
 
-    convert2ACTS(iev, mcParts, vtHits, msHits);
+  if (useModularSpec) {
+    std::vector<NA6PMuonSpecModularHit> msHits, *msHitsPtr = &msHits;
+    treeMSH->SetBranchAddress(msTreeName, &msHitsPtr);
+
+    for (int iev = 0; iev < nent; iev++) {
+      treeKin->GetEntry(iev);
+      treeVTH->GetEntry(iev);
+      treeMSH->GetEntry(iev);
+      LOGP(info, "Event#{} Vtx:[{:.2f},{:.2f},{:.2f}] {} Tracks ({} primaries), Hits: VT: {} MS: {}",
+           iev, mcHeader.getVX(), mcHeader.getVY(), mcHeader.getVZ(),
+           mcHeader.getNTracks(), mcHeader.getNPrimaries(), vtHits.size(), msHits.size());
+      convert2ACTS(iev, mcParts, vtHits, msHits, actsSurfaces);
+    }
+  } else {
+    std::vector<NA6PMuonSpecHit> msHits, *msHitsPtr = &msHits;
+    treeMSH->SetBranchAddress(msTreeName, &msHitsPtr);
+
+    for (int iev = 0; iev < nent; iev++) {
+      treeKin->GetEntry(iev);
+      treeVTH->GetEntry(iev);
+      treeMSH->GetEntry(iev);
+      LOGP(info, "Event#{} Vtx:[{:.2f},{:.2f},{:.2f}] {} Tracks ({} primaries), Hits: VT: {} MS: {}",
+           iev, mcHeader.getVX(), mcHeader.getVY(), mcHeader.getVZ(),
+           mcHeader.getNTracks(), mcHeader.getNPrimaries(), vtHits.size(), msHits.size());
+      convert2ACTS(iev, mcParts, vtHits, msHits, actsSurfaces);
+    }
   }
 }
 
@@ -155,10 +271,12 @@ void addRootFileDirectory(TChain* chain, const char* flName, const char* chName,
   }
 }
 
-void convert2ACTS(int iev,
-                  const std::vector<TParticle>& mcParts,
-                  const std::vector<NA6PVerTelHit>& vtHits,
-                  const std::vector<NA6PMuonSpecHit>& msHits)
+template <typename MSHitType>
+void convert2ACTSImpl(int iev,
+                      const std::vector<TParticle>& mcParts,
+                      const std::vector<NA6PVerTelHit>& vtHits,
+                      const std::vector<MSHitType>& msHits,
+                      const std::vector<SurfaceData>& actsSurfaces)
 {
   std::string eventFileName = fmt::format("event{:09}-particles.csv", iev);
   std::string primFileName = fmt::format("event{:09}-primaries.csv", iev);
@@ -166,11 +284,13 @@ void convert2ACTS(int iev,
   std::FILE* fpcsvKin = std::fopen(eventFileName.c_str(), "w");
   std::FILE* fpcsvPrim = std::fopen(primFileName.c_str(), "w");
 
-  fprintf(fpcsvKin, "particle_id,particle_type,process,vx,vy,vz,vt,px,py,pz,m,q\n");
-  fprintf(fpcsvPrim, "particle_id,particle_type,process,vx,vy,vz,vt,px,py,pz,m,q\n");
+  fprintf(fpcsvKin, "particle_id_pv,particle_id_sv,particle_id_part,particle_id_gen,particle_id_subpart,particle_type,process,vx,vy,vz,vt,px,py,pz,m,q,nhits,nhits_vs,nhits_ms\n");
+  fprintf(fpcsvPrim, "particle_id_pv,particle_id_sv,particle_id_part,particle_id_gen,particle_id_subpart,particle_type,process,vx,vy,vz,vt,px,py,pz,m,q,nhits,nhits_vs,nhits_ms\n");
   int decCount = 0;
   std::vector<uint64_t> doneBC;
   doneBC.resize(mcParts.size());
+  std::vector<uint64_t> donePDG;
+  donePDG.resize(mcParts.size());
   std::vector<uint64_t> secV;
   secV.resize(mcParts.size());
   printf("Loop on %d particles\n", (int)mcParts.size());
@@ -188,7 +308,7 @@ void convert2ACTS(int iev,
     };
     // clang-format on
 
-    auto storePart = [iev, ipartTop, fpcsvKin, fpcsvPrim, &doneBC, &secV, &decCount, &mcParts, getBarCode](int ip, int gen, int sub, int imoth, const auto& self) -> void {
+    auto storePart = [iev, ipartTop, fpcsvKin, fpcsvPrim, &doneBC, &donePDG, &secV, &decCount, &mcParts, &vtHits, &msHits, getBarCode](int ip, int gen, int sub, int imoth, const auto& self) -> void {
       if (doneBC[ip]) {
         //	printf("Particle %d already stored\n",ip);
         return;
@@ -196,20 +316,49 @@ void convert2ACTS(int iev,
       const auto& part = mcParts[ip];
       const auto pdgPart = part.GetPDG();
       double fcmtomm = 10.f;
+
       if (!pdgPart) {
         LOGP(info, "Skipping unknown particle {}", part.GetPdgCode());
         return;
       }
       doneBC[ip] = getBarCode(gen, sub, imoth);
+      donePDG[ip] = std::abs(part.GetPdgCode());
+      // Count hits for this particle
+      int vtHitCount = 0;
+      int msHitCount = 0;
+      int totalHitCount = 0;
 
-      fprintf(fpcsvKin, "%lu,%d,%d,%f,%f,%f,%f,%f,%f,%f,%f,%f\n", doneBC[ip], std::abs(part.GetPdgCode()), 0,
-              part.Vx() * fcmtomm, part.Vy() * fcmtomm, part.Vz() * fcmtomm, part.T(),
-              part.Px(), part.Py(), part.Pz(), part.GetCalcMass(), pdgPart->Charge() / 3);
-      if (part.IsPrimary()) {
-        fprintf(fpcsvPrim, "%lu,%d,%d,%f,%f,%f,%f,%f,%f,%f,%f,%f\n", doneBC[ip], std::abs(part.GetPdgCode()), 0,
-                part.Vx() * fcmtomm, part.Vy() * fcmtomm, part.Vz() * fcmtomm, part.T(),
-                part.Px(), part.Py(), part.Pz(), part.GetCalcMass(), pdgPart->Charge() / 3);
+      //  Count vertex telescope hits
+      for (const auto& hit : vtHits) {
+        if (hit.getTrackID() == ip) {
+          vtHitCount++;
+        }
       }
+
+      // Count muon spectrometer hits
+      for (const auto& hit : msHits) {
+        if (hit.getTrackID() == ip) {
+          msHitCount++;
+        }
+      }
+
+      totalHitCount = vtHitCount + msHitCount;
+
+      // Modified fprintf to include hit counts - adding totalHitCount, vtHitCount, msHitCount
+      fprintf(fpcsvKin, "%i,%i,%i,%i,%i,%d,%d,%f,%f,%f,%f,%f,%f,%f,%f,%f,%d,%d,%d\n",
+              iev + 1, imoth, ipartTop, gen, sub, std::abs(part.GetPdgCode()), 0,
+              part.Vx() * fcmtomm, part.Vy() * fcmtomm, part.Vz() * fcmtomm, part.T(),
+              part.Px(), part.Py(), part.Pz(), part.GetCalcMass(), pdgPart->Charge() / 3,
+              totalHitCount, vtHitCount, msHitCount);
+
+      if (part.IsPrimary()) {
+        fprintf(fpcsvPrim, "%i,%i,%i,%i,%i,%d,%d,%f,%f,%f,%f,%f,%f,%f,%f,%f,%d,%d,%d\n",
+                iev + 1, imoth, ipartTop, gen, sub, std::abs(part.GetPdgCode()), 0,
+                part.Vx() * fcmtomm, part.Vy() * fcmtomm, part.Vz() * fcmtomm, part.T(),
+                part.Px(), part.Py(), part.Pz(), part.GetCalcMass(), pdgPart->Charge() / 3,
+                totalHitCount, vtHitCount, msHitCount);
+      }
+
       int dtF = part.GetFirstDaughter();
       int dtL = part.GetLastDaughter();
       if (dtF > -1) {
@@ -228,18 +377,21 @@ void convert2ACTS(int iev,
   std::fclose(fpcsvPrim);
 
   std::FILE* fpcsvHits = std::fopen(hitsFileName.c_str(), "w");
-  fprintf(fpcsvHits, "particle_id,geometry_id,tx,ty,tz,tt,tpx,tpy,tpz,te,deltapx,deltapy,deltapz,deltae,index\n");
-
-  auto getGeomID = [](int sensID) {
-    const auto& param = NA6PLayoutParam::Instance();
-    uint64_t b = 0;
-    return b;
-  };
+  fprintf(fpcsvHits, "particle_id_pv,particle_id_sv,particle_id_part,particle_id_gen,particle_id_subpart,geometry_id,tx,ty,tz,tt,tpx,tpy,tpz,te,deltapx,deltapy,deltapz,deltae,index\n");
+  std::map<uint64_t, int> hitPerPart;
   double fcmtomm = 10.f;
+  auto decodeBarCode = [](uint64_t b) {
+    uint64_t sub = b & ((1ULL << 16) - 1);
+    uint64_t gen = (b >> 16) & ((1ULL << 8) - 1);
+    uint64_t ipartTop = (b >> 24) & ((1ULL << 16) - 1);
+    uint64_t isv = (b >> 40) & ((1ULL << 12) - 1);
+    uint64_t iev1 = (b >> 52) & ((1ULL << 12) - 1); // this is (iev + 1)
+
+    return std::make_tuple(iev1, isv, ipartTop, gen, sub);
+  };
   for (const auto& hit : vtHits) {
-    int det = hit.getDetectorID();
     double m = mcParts[hit.getTrackID()].GetCalcMass();
-    double en = std::sqrt(hit.getPX() * hit.getPX() + hit.getPY() * hit.getPY() + hit.getPZ() * hit.getPZ() + m * m);
+    double en = std::sqrt(hit.getPXIn() * hit.getPXIn() + hit.getPYIn() * hit.getPYIn() + hit.getPZIn() * hit.getPZIn() + m * m);
     auto particle_id = doneBC[hit.getTrackID()];
     if (particle_id == 0) {
       int idP = hit.getTrackID();
@@ -247,26 +399,41 @@ void convert2ACTS(int iev,
       const auto pdgPart = part.GetPDG();
       printf("Hit w/o particle: %lu %d pdgPart=%x, pdgcode=%d\n", particle_id, hit.getTrackID(), pdgPart, part.GetPdgCode());
     }
-    int layer = det / 4 + 1; // layer from 1 to 5
-    int sens = det % 4 + 1;  // sens from 1 to 4
-    uint64_t geometry_id = getACTSgeomID(layer, sens);
-    fprintf(fpcsvHits, "%lu,%lu,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%i\n", particle_id, geometry_id,
-            hit.getX() * fcmtomm, hit.getY() * fcmtomm, hit.getZ() * fcmtomm, hit.getTime(),
-            hit.getPX(), hit.getPY(), hit.getPZ(), en,
-            0., 0., 0., 0., 0);
+    uint64_t geometry_id = getACTSgeomID(hit.getX() * fcmtomm, hit.getY() * fcmtomm, hit.getZ() * fcmtomm, actsSurfaces);
+    if (geometry_id) {
+
+      if (hitPerPart.find(particle_id) == hitPerPart.end()) {
+        hitPerPart[particle_id] = 0;
+      } else {
+        hitPerPart[particle_id]++;
+      }
+      auto [iev1, isv, ipartTop, gen, sub] = decodeBarCode(particle_id);
+
+      fprintf(fpcsvHits, "%lu,%lu,%lu,%lu,%lu,%lu,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%i\n", iev1, isv, ipartTop, gen, sub, geometry_id,
+              hit.getX() * fcmtomm, hit.getY() * fcmtomm, hit.getZ() * fcmtomm, hit.getTime(),
+              hit.getPXIn(), hit.getPYIn(), hit.getPZIn(), en,
+              hit.getPXIn() - hit.getPXOut(), hit.getPYIn() - hit.getPYOut(), hit.getPZIn() - hit.getPZOut(), hit.getHitValue(), hitPerPart[particle_id]);
+    }
   }
   for (const auto& hit : msHits) {
-    int det = hit.getDetectorID();
     double m = mcParts[hit.getTrackID()].GetCalcMass();
-    double en = std::sqrt(hit.getPX() * hit.getPX() + hit.getPY() * hit.getPY() + hit.getPZ() * hit.getPZ() + m * m);
+    double en = std::sqrt(hit.getPXIn() * hit.getPXIn() + hit.getPYIn() * hit.getPYIn() + hit.getPZIn() * hit.getPZIn() + m * m);
     auto particle_id = doneBC[hit.getTrackID()];
-    int layer = det + NA6PLayoutParam::Instance().nVerTelPlanes + 1;
-    int sens = 1;
-    uint64_t geometry_id = getACTSgeomID(layer, sens);
-    fprintf(fpcsvHits, "%lu,%lu,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%i\n", particle_id, geometry_id,
-            hit.getX() * fcmtomm, hit.getY() * fcmtomm, hit.getZ() * fcmtomm, hit.getTime(),
-            hit.getPX(), hit.getPY(), hit.getPZ(), en,
-            0., 0., 0., 0., 0);
+
+    uint64_t geometry_id = getACTSgeomID(hit.getX() * fcmtomm, hit.getY() * fcmtomm, hit.getZ() * fcmtomm, actsSurfaces);
+    if (geometry_id) {
+      if (hitPerPart.find(particle_id) == hitPerPart.end()) {
+        hitPerPart[particle_id] = 0;
+      } else {
+        hitPerPart[particle_id]++;
+      }
+      auto [iev1, isv, ipartTop, gen, sub] = decodeBarCode(particle_id);
+
+      fprintf(fpcsvHits, "%lu,%lu,%lu,%lu,%lu,%lu,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%i\n", iev1, isv, ipartTop, gen, sub, geometry_id,
+              hit.getX() * fcmtomm, hit.getY() * fcmtomm, hit.getZ() * fcmtomm, hit.getTime(),
+              hit.getPXIn(), hit.getPYIn(), hit.getPZIn(), en,
+              hit.getPXIn() - hit.getPXOut(), hit.getPYIn() - hit.getPYOut(), hit.getPZIn() - hit.getPZOut(), hit.getHitValue(), hitPerPart[particle_id]);
+    }
   }
   std::fclose(fpcsvHits);
 }


### PR DESCRIPTION
Fix bug in MuonSpecModular that was returning multiple hits per particle.
Add the momentum at the exit of the plane to properly fill all ACTS SimHit variables.

Update convertACTS.C:
- The geometryId is now taken from the ACTS geometry file, so the geometry can be changed without modifying convertACTS.C.
- Add missing features: delta momentum and delta energy.
- Update to the latest ACTS CSV format.
- Add additional information for the NA60+ custom ACTS code.
