### PR TITLE
Add NA6PGenHepMC generator (Enrico and Francesco)

### DIFF
--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(${UTILS_INCLUDE_DIR})
 include_directories(${BASE_INCLUDE_DIR})
 include_directories(${ROOT_INCLUDE_DIRS})
 include_directories(${VMC_INCLUDE_DIRS})
+include_directories(${HEPMC3_INCLUDE_DIR})
 
 file(GLOB THIS_SOURCES ${THIS_SRC_DIR}/*.cxx)
 file(GLOB THIS_HEADERS ${THIS_INCLUDE_DIR}/*.h)
@@ -27,6 +28,7 @@ set(DICTIONARY_HEADERS
   NA6PMCGenHeader.h
   NA6PGenBox.h
   NA6PGenParam.h
+  NA6PGenHepMC.h
   NA6PGenCocktail.h
   NA6PBaseHit.h
   NA6PVerTelHit.h
@@ -62,6 +64,7 @@ target_link_libraries(${LIB_NAME}
     ${VMC_LIBRARIES}
     baseLib
     utilsLib
+    HepMC3
 )
 
 # Installation instructions

--- a/sim/include/NA6PGenCocktail.h
+++ b/sim/include/NA6PGenCocktail.h
@@ -15,6 +15,7 @@ class NA6PGenCocktail : public NA6PGenerator
   void generate() override;
   void init() override;
   void setStack(NA6PMCStack* stack) override;
+  long canGenerateMaxEvents() const override;
   void setOwner(bool v) { mGenerators.SetOwner(v); }
   void addGenerator(NA6PGenerator* g) { mGenerators.AddLast(g); }
 

--- a/sim/include/NA6PGenHepMC.h
+++ b/sim/include/NA6PGenHepMC.h
@@ -1,0 +1,35 @@
+// NA6PCCopyright
+
+#ifndef NA6P_GENHEPMC_H
+#define NA6P_GENHEPMC_H
+
+#include "NA6PGenerator.h"
+#include "HepMC3/ReaderRootTree.h"
+
+class NA6PGenHepMC : public NA6PGenerator
+{
+ public:
+  using NA6PGenerator::NA6PGenerator;
+
+  NA6PGenHepMC() = default;
+  NA6PGenHepMC(const std::string& name, const std::string& filename, bool storeDecayed = true);
+  ~NA6PGenHepMC() override = default;
+  void generate() override;
+
+  void init() override;
+
+  void SetFileName(const std::string& name) { mFileName = name; }
+  long canGenerateMaxEvents() const override;
+
+ protected:
+  inline static const std::string HEPTreeName{"hepmc3_tree"};
+  std::string mFileName = {};
+  bool mStoreDecayedPrimaries = true;
+  long mNEvInTree = -1;
+  long mReadEvents = 0;
+  std::unique_ptr<HepMC3::ReaderRootTree> mHEPRootFileReader;
+
+  ClassDefOverride(NA6PGenHepMC, 1); //
+};
+
+#endif

--- a/sim/include/NA6PGenerator.h
+++ b/sim/include/NA6PGenerator.h
@@ -21,6 +21,7 @@ class NA6PGenerator : public TObject
   auto getStack() { return mStack; }
   auto getStack() const { return mStack; }
 
+  virtual long canGenerateMaxEvents() const { return -1; } // if no limit, return negative number
   virtual void generate() = 0;
   virtual void init();
   virtual void generatePrimaryVertex(int maxTrials = 1000000);

--- a/sim/include/NA6PMC.h
+++ b/sim/include/NA6PMC.h
@@ -35,6 +35,7 @@ class NA6PMC : public TVirtualMCApplication
 
   bool setupGenerator(const std::string& s);
   auto getGenerator() const { return mGenerator.get(); }
+  long canGenerateMaxEvents() const;
 
   void setRandomSeed(Long64_t r);
   auto getRandomSeed() const { return mRandomSeed; }

--- a/sim/include/NA6PMCStack.h
+++ b/sim/include/NA6PMCStack.h
@@ -34,6 +34,11 @@ class TClonesArray;
 class NA6PMCStack : public TVirtualMCStack
 {
  public:
+  enum ParticleStatus {
+    kToBeDone = BIT(16),
+    kPrimary = BIT(17)
+  };
+
   NA6PMCStack(int size);
   NA6PMCStack();
   ~NA6PMCStack() override;

--- a/sim/src/NA6PGenCocktail.cxx
+++ b/sim/src/NA6PGenCocktail.cxx
@@ -38,3 +38,15 @@ void NA6PGenCocktail::generate()
     ((NA6PGenerator*)g)->generate();
   }
 }
+
+long NA6PGenCocktail::canGenerateMaxEvents() const
+{
+  long n = -1;
+  for (auto g : mGenerators) {
+    auto ng = ((NA6PGenerator*)g)->canGenerateMaxEvents();
+    if (ng >= 0 && (n < 0 || n > ng)) {
+      n = ng;
+    }
+  }
+  return n;
+}

--- a/sim/src/NA6PGenHepMC.cxx
+++ b/sim/src/NA6PGenHepMC.cxx
@@ -1,0 +1,144 @@
+// NA6PCCopyright
+
+#include "NA6PGenHepMC.h"
+#include "NA6PMCStack.h"
+#include "HepMC3/GenEvent.h"
+#include "HepMC3/GenParticle.h"
+#include "HepMC3/GenVertex.h"
+#include "HepMC3/FourVector.h"
+#include <TDatabasePDG.h>
+#include <TMath.h>
+#include <cmath>
+
+NA6PGenHepMC::NA6PGenHepMC(const std::string& name, const std::string& filname, bool storeDecayed) : NA6PGenerator(name), mFileName(filname), mStoreDecayedPrimaries(storeDecayed)
+{
+  LOGP(info, "create NA6PGenHepMC {} {}, decayed primaries will {}be stored", name, filname, storeDecayed ? "" : "not ");
+}
+
+long NA6PGenHepMC::canGenerateMaxEvents() const
+{
+  if (mNEvInTree < 0 || isInitDone()) {
+    LOGP(fatal, "Initialization was not done");
+  }
+  return mNEvInTree;
+}
+
+void NA6PGenHepMC::init()
+{
+  LOGP(info, "NA6PGenHepMC init");
+  if (isInitDone()) {
+    return;
+  }
+  try {
+    auto fl = TFile::Open(mFileName.c_str());
+    assert(fl);
+    TTree* tree = (TTree*)fl->Get(HEPTreeName.c_str());
+    assert(tree);
+    mNEvInTree = tree->GetEntries();
+    delete tree;
+    fl->Close();
+  } catch (...) {
+    LOGP(fatal, "Failed to extract the HEPMC tree {} from file {}", HEPTreeName, mFileName);
+  }
+
+  mHEPRootFileReader = std::make_unique<HepMC3::ReaderRootTree>(mFileName);
+  if (mHEPRootFileReader->failed()) {
+    LOGP(fatal, "No HepMC input file found {}", mFileName);
+  }
+  NA6PGenerator::init();
+}
+
+void NA6PGenHepMC::generate()
+{
+  if (mReadEvents >= mNEvInTree) {
+    LOGP(error, "Something is wrong: event {} beyond the available range [0:{}] is requested, wrapping to 0", mReadEvents, mNEvInTree - 1);
+    mReadEvents = 0;
+  }
+  generatePrimaryVertex(); // will generate if not generated yet, otherwise, will set the origin from the MCHeader of the stack.
+  auto mcHead = getStack()->getEventHeader();
+  double xv = mcHead->getVX();
+  double yv = mcHead->getVY();
+  double zv = mcHead->getVZ();
+  std::unordered_map<int, int> partID2StoreID;
+
+  mHEPRootFileReader->skip(mReadEvents);
+  HepMC3::GenEvent evt;
+  mHEPRootFileReader->read_event(evt); // Read one event
+  if (mHEPRootFileReader->failed()) {
+    LOGP(info, " End of file reached . Exit .\n");
+    return;
+  }
+  int nparticlesgood = 0;
+  int pdgCode, status;
+  float phi, pt, pZ, en, sn, cs;
+  float vx, vy, vz, tof; // tof in mm/c
+  int tobetracked = 0;
+
+  std::vector<int> partons = {1, 2, 3, 4, 5, 6, 21}; // to remove quarks and gluons
+  int cnt = 0;
+  // Loop on particles
+  for (const auto p : evt.particles()) {
+    cnt++;
+    auto isParton = [](int pabs) { return (pabs >= 1 & pabs <= 6) || pabs == 21; };
+    auto isDiquark = [](int pabs) { return pabs > 1000 && pabs < 10000 && ((pabs / 10) % 10) == 0; };
+    auto isColorState = [](int pabs) { return pabs > 1e6; };
+
+    // Upstream and downstream vertices
+    auto prod_vtx = p->production_vertex();
+    auto end_vtx = p->end_vertex();
+    auto pidabs = std::abs(p->pid());
+
+    if (prod_vtx) {
+      if (isParton(pidabs) ||  // Remove quarks and gluons
+          isDiquark(pidabs) || // Remove diquarks
+          isColorState(pidabs) // Remove particles like octet states for charmonia and similar
+      ) {
+        continue;
+      }
+      // Intermediate particles have both a production vertex and an end vertex
+      if (end_vtx) {
+        if (!mStoreDecayedPrimaries) {
+          continue;
+        }
+        tobetracked = 0; // decayed particles should not be tracked by GEANT4
+      } else {
+        tobetracked = 1;
+      }
+      partID2StoreID[p->id()] = nparticlesgood++;
+
+      int mothertobestored = -1;
+      for (const auto& mother : prod_vtx->particles_in()) {
+        auto mothEntry = partID2StoreID.find(mother->id());
+        if (mothEntry != partID2StoreID.end()) {
+          mothertobestored = mothEntry->second;
+          break;
+        }
+      }
+
+      phi = p->momentum().phi();
+      pt = p->momentum().perp();
+      pZ = p->momentum().pz();
+      en = p->momentum().e();
+      status = p->status();
+      sn = std::sin(phi);
+      cs = std::cos(phi);
+      pdgCode = p->pid();
+      HepMC3::FourVector pos = prod_vtx->position();
+      vx = pos.x() + xv; // shift to account for generated position of the primary vertex
+      vy = pos.y() + yv;
+      vz = pos.z() + zv;
+      tof = pos.t();
+      int dummy = 0;
+
+      getStack()->PushTrack(tobetracked, mothertobestored, pdgCode, pt * cs, pt * sn, pZ, en, vx, vy, vz, tof, 0., 0., 0., TMCProcess::kPPrimary, dummy, 1., status);
+    } else {
+      LOGP(info, "particle ID# {} with no production vertex\n", p->id());
+      continue;
+    }
+  }
+
+  auto info = fmt::format("{}_x{}", getName(), nparticlesgood);                              // test
+  mcHead->getGenHeaders().emplace_back(nparticlesgood, 0, mcHead->getNPrimaries(), 0, info); // test
+  mcHead->incNPrimaries(nparticlesgood);
+  ++mReadEvents;
+}

--- a/sim/src/simLinkDef.h
+++ b/sim/src/simLinkDef.h
@@ -34,6 +34,7 @@
 
 #pragma link C++ class NA6PGenBox + ;
 #pragma link C++ class NA6PGenParam + ;
+#pragma link C++ class NA6PGenHepMC + ;
 #pragma link C++ class NA6PGenCocktail + ;
 
 #pragma link C++ class std::vector < TParticle> + ;

--- a/test/genHEPMC.C
+++ b/test/genHEPMC.C
@@ -1,0 +1,14 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include "NA6PGenHepMC.h"
+#include <TMath.h>
+#endif
+
+NA6PGenerator* genHEPMC(const std::string& inpFileName, bool storeDecayed = true, const std::string& genName = "genHEPMC")
+{
+  if (inpFileName.empty()) {
+    LOGP(fatal, "HEPMC input file name is not provided");
+  }
+  auto gen = new NA6PGenHepMC(genName, inpFileName, storeDecayed);
+
+  return gen;
+}


### PR DESCRIPTION
Allows to import events in HEPMC format from external root files with hepmc3_tree. The generation can be done via wrapper macro `test/genHEPMC.C`, e.g.
```
na6psim -n <N> -g $NA6PROOT_ROOT/share/test/genHEPMC.C+\(\"<input_file_name>\",false\)
```
In this example, events from the file <input_file_name> will be imported, discarding the intermediate particles already decayed by the generator. The default behaviour is to add them as primaries (without further propagation). 
If the requested number of events <N> is negative or exceeds the number of events in the input file, then it will be internally overridden to the number of available events. Otherwise, only the first <N> events will be imported.