### PR TITLE
Possibility to impose user vertex generator method

### DIFF
--- a/NA6PSim.cxx
+++ b/NA6PSim.cxx
@@ -35,6 +35,7 @@ int main(int argc, char** argv)
     add_option("nevents,n", bpo::value<int32_t>()->default_value(1), "number of events to generate");
     add_option("generator,g", bpo::value<std::string>()->default_value(""), "generator defintion root C macro, must return NA6PGenerator pointer");
     add_option("user-hooks,u", bpo::value<std::string>()->default_value(""), "root macro C macro with user hooks for initialization");
+    add_option("user-vertex,V", bpo::value<std::string>()->default_value(""), "root macro C macro with user method for vertex generation");
     add_option("rnd-seed,r", bpo::value<int64_t>()->default_value(-1), "random number seed, 0 - do not set, <0: generate from time");
     add_option("save-bfield,b", bpo::value<bool>()->default_value(false)->implicit_value(true), "Save magnetic field to file");
     opt_all.add(opt_general).add(opt_hidden);
@@ -68,6 +69,9 @@ int main(int argc, char** argv)
   mc->setRandomSeed(vm["rnd-seed"].as<int64_t>());
   if (!vm["user-hooks"].as<std::string>().empty()) {
     mc->setupUserHooks(vm["user-hooks"].as<std::string>());
+  }
+  if (!vm["user-vertex"].as<std::string>().empty()) {
+    mc->setupUserVertex(vm["user-vertex"].as<std::string>());
   }
   // mag field definition
   auto magField = new MagneticField();

--- a/sim/README.md
+++ b/sim/README.md
@@ -102,4 +102,12 @@ int testHooks(int arg, bool inout)
 }
 ```
 
+## Vertex generation
 
+By default the interaction vertex will be randomly generated on one of the subtargets according to their declared cross-sections and thicknesses, see the `Target` block of the [base/include/NA6PLayoutParam.h](../base/include/NA6PLayoutParam.h).
+One can override this behaviour by providing a user macro `<uservtx>.C` (via `-V` of `--user-vertex` options) with the function having signature `void <uservtx(float& x, float& y, float& z)` which assignes to `x,y,z` the wanted vertex position. An example of such a macro is
+[test/vtxInDump.C](../test/vtxInDump.C), which generates an interaction vertex in the main absorber plug. It can be called e.g. as
+
+```
+na6psim -n <N> -g <your_generator> -V $NA6PROOT_ROOT/share/test/vtxInDump.C+
+```

--- a/sim/include/NA6PGenCocktail.h
+++ b/sim/include/NA6PGenCocktail.h
@@ -16,6 +16,7 @@ class NA6PGenCocktail : public NA6PGenerator
   void init() override;
   void setStack(NA6PMCStack* stack) override;
   long canGenerateMaxEvents() const override;
+  void clear() override;
   void setOwner(bool v) { mGenerators.SetOwner(v); }
   void addGenerator(NA6PGenerator* g) { mGenerators.AddLast(g); }
 

--- a/sim/include/NA6PGenerator.h
+++ b/sim/include/NA6PGenerator.h
@@ -9,6 +9,7 @@
 #include <array>
 
 class NA6PMCStack;
+class TMethodCall;
 
 class NA6PGenerator : public TObject
 {
@@ -16,8 +17,10 @@ class NA6PGenerator : public TObject
   NA6PGenerator(const std::string& name) : mName(name) {}
   NA6PGenerator() = default;
   virtual ~NA6PGenerator() = default;
-
+  virtual void clear();
   virtual void setStack(NA6PMCStack* stack) { mStack = stack; }
+  virtual void setUserVertexMethod(TMethodCall* m) { mUserVertexMethod = m; }
+  auto getUserVertexMethod() const { return mUserVertexMethod; }
   auto getStack() { return mStack; }
   auto getStack() const { return mStack; }
 
@@ -57,6 +60,7 @@ class NA6PGenerator : public TObject
   std::string mName = {};
   std::array<double, 3> mOrigin{}; //! event origin
   NA6PMCStack* mStack = nullptr;   //! externally set stack
+  TMethodCall* mUserVertexMethod = nullptr; //! externally set user method for vertex generation
   ULong64_t mRandomSeed = 0;       //  random seed (used if non-0)
   int mVerbosity = 0;              //!
   bool mInitDone = false;

--- a/sim/include/NA6PMC.h
+++ b/sim/include/NA6PMC.h
@@ -30,6 +30,8 @@ class NA6PMC : public TVirtualMCApplication
   void PreTrack() override {}
   void PostTrack() override {}
 
+  void setupUserVertex(const std::string& s);
+
   void setupUserHooks(const std::string& s);
   int callUserHook(int hookID, bool inout);
 
@@ -60,7 +62,11 @@ class NA6PMC : public TVirtualMCApplication
 
   std::unique_ptr<NA6PMCStack> mStack{};
   std::unique_ptr<NA6PGenerator> mGenerator{};
-  std::unique_ptr<TMethodCall> mUsrHooksMethod;
+
+  std::unique_ptr<TMethodCall> mUserVertexMethod;
+  std::string mUserVertexMacroName{};
+
+  std::unique_ptr<TMethodCall> mUserHooksMethod;
   std::string mUserHookName{};
 
   std::vector<TParticle> mMCTracks, *mMCTracksPtr = &mMCTracks;

--- a/sim/src/NA6PGenCocktail.cxx
+++ b/sim/src/NA6PGenCocktail.cxx
@@ -50,3 +50,11 @@ long NA6PGenCocktail::canGenerateMaxEvents() const
   }
   return n;
 }
+
+void NA6PGenCocktail::clear()
+{
+  mOriginSet = false;
+  for (auto g : mGenerators) {
+    ((NA6PGenerator*)g)->clear();
+  }
+}

--- a/sim/src/NA6PGenerator.cxx
+++ b/sim/src/NA6PGenerator.cxx
@@ -4,6 +4,7 @@
 #include "NA6PMCStack.h"
 #include "NA6PDetector.h"
 #include "NA6PTarget.h"
+#include <TMethodCall.h>
 
 #include <fairlogger/Logger.h>
 
@@ -39,10 +40,16 @@ void NA6PGenerator::generatePrimaryVertex(int maxTrials)
     }
     return;
   }
-  static NA6PTarget* tgt = (NA6PTarget*)NA6PDetector::instance().getModule("Target");
   float x, y, z;
-  if (!tgt->generateVertex(x, y, z, maxTrials)) {
-    LOGP(fatal, "Failed to generate primary vertex");
+  if (getUserVertexMethod()) {
+    const void* args[3] = {&x, &y, &z};
+    int ret = 0;
+    getUserVertexMethod()->Execute(nullptr, args, 3, &ret);
+  } else {
+    static NA6PTarget* tgt = (NA6PTarget*)NA6PDetector::instance().getModule("Target");
+    if (!tgt->generateVertex(x, y, z, maxTrials)) {
+      LOGP(fatal, "Failed to generate primary vertex");
+    }
   }
   setOrigin(x, y, z);
   mcH->setVX(x);
@@ -52,4 +59,9 @@ void NA6PGenerator::generatePrimaryVertex(int maxTrials)
   if (mVerbosity) {
     LOGP(info, "Generated primary vertex at {:.4f},{:4f},{:4f}", x, y, z);
   }
+}
+
+void NA6PGenerator::clear()
+{
+  mOriginSet = false;
 }

--- a/test/vtxInDump.C
+++ b/test/vtxInDump.C
@@ -1,0 +1,23 @@
+#include "NA6PLayoutParam.h"
+#include <TRandom.h>
+#include <TMath.h>
+
+void vtxInDump(float& x, float& y, float& z)
+{
+  static bool first = true;
+  static float lAbs = 0, zAbsStart = 0;
+  if (first) {
+    const auto& layoutPar = NA6PLayoutParam::Instance();
+    for (int i = 0; i < layoutPar.nAbsorberSlices - layoutPar.nAbsorberSlicesWall; i++) {
+      lAbs += layoutPar.thicknessAbsorber[i];
+    }
+    zAbsStart = layoutPar.posZStartAbsorber;
+    first = false;
+  }
+  float lambda = 5; // int.length in cm
+  do {
+    z = -TMath::Log(1. - gRandom->Rndm()) * lambda;
+  } while (z > lAbs);
+  z += zAbsStart;
+  x = y = 0.f;
+}


### PR DESCRIPTION
+ fix: reset vertex set in the generator when resetting the stack.

See updated sim/README.md

```
na6psim -n 10 -g $NA6PROOT_ROOT/share/test/genbox.C+ -V $NA6PROOT_ROOT/share/test/vtxInDump.C+  -v 1 | grep 'Generated primary vertex'
[INFO] Generated primary vertex at 0.0000,0.000000,56.385719
[INFO] Generated primary vertex at 0.0000,0.000000,55.041618
[INFO] Generated primary vertex at 0.0000,0.000000,48.960289
[INFO] Generated primary vertex at 0.0000,0.000000,45.164303
...
```