### PR TITLE
Coversion hits -> clusters for VerTel

### DIFF
--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIB_NAME "${MOD_NAME}Lib")
 include_directories(${THIS_INCLUDE_DIR})
 include_directories(${UTILS_INCLUDE_DIR})
 include_directories(${BASE_INCLUDE_DIR})
+include_directories(${SIM_INCLUDE_DIR})
 include_directories(${ROOT_INCLUDE_DIRS})
 include_directories(${Boost_INCLUDE_DIRS})
 
@@ -19,6 +20,8 @@ add_library(${LIB_NAME} SHARED ${THIS_SOURCES} ${THIS_HEADERS} )
 
 set(DICTIONARY_HEADERS
   NA6PBaseCluster.h
+  NA6PReconstruction.h
+  NA6PVerTelReconstruction.h
   ExtTrackPar.h
   NA6PTrack.h
   NA6PFastTrackFitter.h

--- a/rec/include/NA6PBaseCluster.h
+++ b/rec/include/NA6PBaseCluster.h
@@ -31,25 +31,27 @@ class NA6PBaseCluster
   virtual ~NA6PBaseCluster() {}
 
   // Lab frame coordinates
-  auto getXLab() const   {return mPos[0];}
-  auto getYLab() const   {return mPos[1];}
-  auto getZLab() const   {return mPos[2];}
+  auto getXLab()       const {return mPos[0];}
+  auto getYLab()       const {return mPos[1];}
+  auto getZLab()       const {return mPos[2];}
   // Tracking frame coordinates (right-handed):
   // X_tracking = Z_lab, Y_tracking = X_lab, Z_tracking = Y_lab
-  auto getXTF() const   {return mPos[2];}
-  auto getYTF() const   {return mPos[0];}
-  auto getZTF() const   {return mPos[1];}
-  auto getX()    const   {return getXLab();}
-  auto getY()    const   {return getYLab();}
-  auto getZ()    const   {return getZLab();}
-  auto getSigYY() const { return mSigYY; }
-  auto getSigYZ() const { return mSigYZ; }
-  auto getSigZZ() const { return mSigZZ; }
+  auto getXTF()        const {return mPos[2];}
+  auto getYTF()        const {return mPos[0];}
+  auto getZTF()        const {return mPos[1];}
+  auto getX()          const {return getXLab();}
+  auto getY()          const {return getYLab();}
+  auto getZ()          const {return getZLab();}
+  auto getSigYY()      const { return mSigYY; }
+  auto getSigYZ()      const { return mSigYZ; }
+  auto getSigZZ()      const { return mSigZZ; }
   auto getDetectorID() const { return mDetectorID; }
   auto getParticleID() const { return mParticleID; }
+  auto getHitID()      const { return mHitID; }
 
   void setDetectorID(int id) { mDetectorID = id; }
   void setParticleID(int id) { mParticleID = id; }
+  void setHitID(int id) { mHitID = id; }
   void setPos(float x, float y, float z){
     mPos[0] = x; mPos[1] = y; mPos[2] = z;
   }
@@ -71,7 +73,8 @@ class NA6PBaseCluster
   float mSigZZ = 0.f;          // covariance matrix elements
   int   mCluSiz = 0;           // cluster size
   short mDetectorID = 0;       // the detector/sensor id
-  int mParticleID = 0;         // particle ID in Kine tree (MC truth)
+  int   mParticleID = 0;       // particle ID in Kine tree (MC truth)
+  int   mHitID = -1;           // hit ID (for test of hitsToRecPoints)
 
   ClassDefNV(NA6PBaseCluster, 1);
 };

--- a/rec/include/NA6PReconstruction.h
+++ b/rec/include/NA6PReconstruction.h
@@ -1,0 +1,44 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_RECONSTRUCTION_H
+#define NA6P_RECONSTRUCTION_H
+
+#include <string>
+#include <Rtypes.h>
+
+// Class to steer the reconstruction 
+
+class NA6PReconstruction
+{
+ public:
+
+  NA6PReconstruction(const std::string &name) : mName(name) {}
+  virtual ~NA6PReconstruction() {}
+
+  const std::string& getName() const { return mName; }
+
+  // methods to steer cluster reconstruction
+  virtual void createClustersOutput();
+  virtual void clearClusters();
+  virtual void writeClusters();
+  virtual void closeClustersOutput();
+
+ protected:
+  std::string mName{"MothClass"};                // detector name
+
+  ClassDefNV(NA6PReconstruction, 1);
+};
+
+#endif

--- a/rec/include/NA6PVerTelReconstruction.h
+++ b/rec/include/NA6PVerTelReconstruction.h
@@ -1,0 +1,55 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_VERTEL_RECONSTRUCTION_H
+#define NA6P_VERTEL_RECONSTRUCTION_H
+
+#include <string>
+#include <Rtypes.h>
+
+// Class to steer the VT reconstruction
+
+#include "NA6PReconstruction.h"
+
+class TFile;
+class TTree;
+class NA6PVerTelHit;
+class NA6PBaseCluster;
+
+class NA6PVerTelReconstruction : public NA6PReconstruction
+{
+ public:
+
+  NA6PVerTelReconstruction() : NA6PReconstruction("VerTel") {}
+  ~NA6PVerTelReconstruction() override = default;
+
+  // methods to steer cluster reconstruction
+  void createClustersOutput() override;
+  void clearClusters() override { mClusters.clear(); }
+  void writeClusters() override;
+  void closeClustersOutput() override;
+  // fast method to smear the hits bypassing digitization and cluster finder
+  void setClusterSpaceResolution( double clures ) {mCluRes = clures;}
+  void hitsToRecPoints(const std::vector<NA6PVerTelHit>& vtHits);
+
+ private:
+  std::vector<NA6PBaseCluster> mClusters, *hClusPtr = &mClusters;  // vector of clusters
+  TFile* mClusFile = nullptr;                                      // file with clusters
+  TTree* mClusTree = nullptr;                                      // tree of clusters
+  double mCluRes = 5.e-4;                                          // cluster resolution, cm (for fast simu)
+
+  ClassDefNV(NA6PVerTelReconstruction, 1);
+};
+
+#endif

--- a/rec/src/NA6PReconstruction.cxx
+++ b/rec/src/NA6PReconstruction.cxx
@@ -1,0 +1,25 @@
+// NA6PCCopyright
+
+#include <fairlogger/Logger.h>
+#include "NA6PReconstruction.h"
+
+void NA6PReconstruction::createClustersOutput()
+{
+  LOGP(warning, "createClustersOutput called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::clearClusters()
+{
+  LOGP(warning, "clearClusters called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::writeClusters()
+{
+  LOGP(warning, "writeClusters called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::closeClustersOutput()
+{
+  LOGP(warning, "closeClustersOutput called for {}, this should not happen", getName());
+}
+

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -1,0 +1,68 @@
+// NA6PCCopyright
+
+#include <TFile.h>
+#include <TTree.h>
+#include <TRandom3.h>
+#include <fairlogger/Logger.h>
+#include "NA6PBaseCluster.h"
+#include "NA6PVerTelHit.h"
+#include "NA6PVerTelReconstruction.h"
+
+void NA6PVerTelReconstruction::createClustersOutput()
+{
+  auto nm = fmt::format("Clusters{}.root", getName());
+  mClusFile = TFile::Open(nm.c_str(), "recreate");
+  mClusTree = new TTree(fmt::format("clusters{}", getName()).c_str(), fmt::format("{} Clusters", getName()).c_str());
+  mClusTree->Branch(getName().c_str(), &hClusPtr);
+  LOGP(info, "Will store {} clusters in {}", getName(), nm);
+}
+
+void NA6PVerTelReconstruction::writeClusters()
+{
+  if (mClusTree) {
+    mClusTree->Fill();
+  }
+  LOGP(info, "Saved {} clusters in tree with {} entries", mClusters.size(),mClusTree->GetEntries());
+}
+
+void NA6PVerTelReconstruction::closeClustersOutput()
+{
+  if (mClusTree && mClusFile) {
+    mClusFile->cd();
+    mClusTree->Write();
+    delete mClusTree;
+    mClusTree = nullptr;
+    mClusFile->Close();
+    delete mClusFile;
+    mClusFile = nullptr;
+  }
+}
+
+void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>& vtHits)
+{
+  int nHits = vtHits.size();
+  for(int jHit = 0; jHit < nHits; ++jHit) {
+    const auto& hit = vtHits[jHit];
+    double x = hit.getX();
+    double y = hit.getY();
+    double z = hit.getZ();
+    if (mCluRes > 0) {
+      x = gRandom->Gaus(hit.getX(),mCluRes);
+      y = gRandom->Gaus(hit.getY(),mCluRes);
+    }
+    double eloss = hit.getHitValue();
+    // very rough cluster size settings
+    int clusiz = 2;
+    if (eloss > 2.e-5 && eloss < 5.e-5) clusiz = 3;
+    else if (eloss > 5.e-5) clusiz = 4;
+    int nDet=hit.getDetectorID();
+    int idPart=hit.getTrackID();    
+    mClusters.emplace_back(x, y, z, clusiz);
+    auto& clu = mClusters.back();
+    clu.setErr(mCluRes*mCluRes,0.,mCluRes*mCluRes);
+    clu.setDetectorID(nDet);
+    clu.setParticleID(idPart);
+    clu.setHitID(jHit);    
+  }
+}
+

--- a/rec/src/recLinkDef.h
+++ b/rec/src/recLinkDef.h
@@ -9,6 +9,8 @@
 #pragma link C++ class NA6PBaseCluster + ;
 #pragma link C++ class std::vector < NA6PBaseCluster> + ;
 
+#pragma link C++ class NA6PReconstruction + ;
+#pragma link C++ class NA6PVerTelReconstruction + ;
 #pragma link C++ class ExtTrackPar + ;
 #pragma link C++ class NA6PTrack + ;
 #pragma link C++ class NA6PFastTrackFitter + ;

--- a/test/convertHitsToRecPoints.C
+++ b/test/convertHitsToRecPoints.C
@@ -1,0 +1,34 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <Riostream.h>
+#include <TTree.h>
+#include <TFile.h>
+#include <TParticle.h>
+#include <TParticlePDG.h>
+#include <TVector3.h>
+#include <TRandom3.h>
+#include "NA6PVerTelHit.h"
+#include "NA6PBaseCluster.h"
+#include "ConfigurableParam.h"
+#include <fairlogger/Logger.h>
+#include "NA6PVerTelReconstruction.h"
+#endif
+
+void ConvertHitsToRecPoints(){
+  TFile* fh=new TFile("HitsVerTel.root");
+  TTree* th=(TTree*)fh->Get("hitsVerTel");
+  std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
+  th->SetBranchAddress("VerTel", &vtHitsPtr);
+  int nEv=th->GetEntriesFast();
+
+  NA6PVerTelReconstruction* recVT = new NA6PVerTelReconstruction();
+  recVT->createClustersOutput();
+  for(int jEv=0; jEv<nEv; jEv++){
+    th->GetEvent(jEv);
+    int nHits=vtHits.size();
+    printf("Event %d nHits=%d\n",jEv,nHits);
+    recVT->clearClusters();
+    recVT->hitsToRecPoints(vtHits);
+    recVT->writeClusters();
+  }
+  recVT->closeClustersOutput();
+}


### PR DESCRIPTION
This is a first draft of a class to steer the reconstruction. For the time being it contains only a hit -> cluster step for the VT which I am using to convert hits into clusters in order to use them as a starting point for the tracking. The structure of the TTree of clusters is the same as that of Hits.