### PR TITLE
First implementation of the Cellular Automaton track finder for the VT

### DIFF
--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -24,6 +24,7 @@ set(DICTIONARY_HEADERS
   NA6PVerTelReconstruction.h
   ExtTrackPar.h
   NA6PTrack.h
+  NA6PTrackerCA.h
   NA6PFastTrackFitter.h
   ) # Add all class headers requiring dictionary
   

--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -20,10 +20,10 @@ add_library(${LIB_NAME} SHARED ${THIS_SOURCES} ${THIS_HEADERS} )
 
 set(DICTIONARY_HEADERS
   NA6PBaseCluster.h
-  NA6PReconstruction.h
-  NA6PVerTelReconstruction.h
   ExtTrackPar.h
   NA6PTrack.h
+  NA6PReconstruction.h
+  NA6PVerTelReconstruction.h
   NA6PTrackerCA.h
   NA6PFastTrackFitter.h
   ) # Add all class headers requiring dictionary

--- a/rec/include/NA6PFastTrackFitter.h
+++ b/rec/include/NA6PFastTrackFitter.h
@@ -21,10 +21,11 @@
 // Fast track fit based on Kalman filter
 
 class TGeoManager;
+class NA6PTrack;
+class NA6PBaseCluster;
 
 class NA6PFastTrackFitter
 {
- public:
 
  public:
   enum {kTwoPointSeed = 0,kThreePointSeed = 1};

--- a/rec/include/NA6PFastTrackFitter.h
+++ b/rec/include/NA6PFastTrackFitter.h
@@ -93,7 +93,7 @@ class NA6PFastTrackFitter
   double mPrimVertZ = 0.0;               // primary vertex z
   bool   mIsPrimVertSet = false;         // flag for presence of prim vert z
   bool   mCorrectForMaterial = true;     // flag for material corrections
-  TGeoManager* mGeoManager = nullptr;    // geometry, pointer not owned by the fitter class
+
   std::vector<std::unique_ptr<NA6PBaseCluster>> mClusters; // array with clusters
 
  protected:

--- a/rec/include/NA6PReconstruction.h
+++ b/rec/include/NA6PReconstruction.h
@@ -29,15 +29,22 @@ class NA6PReconstruction
 
   const std::string& getName() const { return mName; }
 
+  virtual bool init(const char* filename, const char* geoname = "NA6P");
+  
   // methods to steer cluster reconstruction
   virtual void createClustersOutput();
   virtual void clearClusters();
   virtual void writeClusters();
   virtual void closeClustersOutput();
+  // methods to steer tracking
+  virtual void createTracksOutput();
+  virtual void clearTracks();
+  virtual void writeTracks();
+  virtual void closeTracksOutput();
 
  protected:
   std::string mName{"MothClass"};                // detector name
-
+  bool        mIsInitialized = false;            // flag for initialization
   ClassDefNV(NA6PReconstruction, 1);
 };
 

--- a/rec/include/NA6PTrack.h
+++ b/rec/include/NA6PTrack.h
@@ -57,6 +57,8 @@ class NA6PTrack
   int          getVTClusterIndex(int lr)   const {return lr < kMaxVTLr ? mClusterIndices[lr] : -1; }
   int          getParticleLabel(int lr)    const {return lr < kMaxVTLr ? mClusterPartID[lr] : -2; }
   int          getParticleID()             const {return mParticleID;}
+  int          getCAIteration()            const {return mCAIteration;}
+  
   double       getAlpha()                  const {return mExtTrack.getAlpha();}
   double       getCharge()                 const {return mExtTrack.Charge();}
   bool         negDir()                    const {return std::abs(mExtTrack.getAlpha()) > M_PI/2.;}
@@ -88,7 +90,8 @@ class NA6PTrack
   void   setParticleLabel(int idx, int lr)  { if (lr < kMaxVTLr) mClusterPartID[lr] = idx;}
   void   setVTClusterIndex(int idx, int lr) { if (lr < kMaxVTLr) mClusterIndices[lr] = idx;}
   void   setParticleID(int idx)    {mParticleID = idx;}
-  
+  void   setCAIteration(int iter)  {mCAIteration = iter;}
+
   static void lab2trk(const double *vLab, double *vTrk); 
   static void trk2lab(const double *vTrk, double *vLab); 
 
@@ -118,6 +121,7 @@ class NA6PTrack
   std::array<int, kMaxVTLr> mClusterIndices{};   // cluster indices
   std::array<int, kMaxVTLr> mClusterPartID{};    // particle ID (per cluster)
   int      mParticleID = -1;                     // particle ID (MC truth)
+  int      mCAIteration = -1;                    //! CA iteration (for debug)
   ExtTrackPar mExtTrack;                         // track params
   
   ClassDefNV(NA6PTrack,1)

--- a/rec/include/NA6PTrack.h
+++ b/rec/include/NA6PTrack.h
@@ -46,16 +46,17 @@ class NA6PTrack
   int           getNVTLayers()             const {return mNVTLayers;}
   double        getChi2()                  const {return mChi2;}
   double        getChi2VT()                const {return mChi2VT;}
-  const ExtTrackPar& getTrackExtParam()    const { return mExtTrack; }
-  const double* getCovariance()            const { return mExtTrack.getCovariance(); }
+  const ExtTrackPar& getTrackExtParam()    const {return mExtTrack; }
+  const double* getCovariance()            const {return mExtTrack.getCovariance(); }
   int          getNVTHits()                const {return mNClustersVT;}
   int          getNMSHits()                const {return mNClustersMS;}
   int          getNTRHits()                const {return mNClustersTR;}
   int          getNHits()                  const {return mNClusters;}
   uint32_t     getClusterMap()             const {return mClusterMap;}
   bool         hasClusterOnVTLayer(int lr) const {return (lr<mNVTLayers) ?  mClusterMap&(1<<lr) : false;}
-  int          getVTClusterIndex(int lr)   const { return lr < kMaxVTLr ? mClusterIndices[lr] : -1; }
-  int          getParticleLabel(int lr)    const { return lr < kMaxVTLr ? mParticleID[lr] : -2; }
+  int          getVTClusterIndex(int lr)   const {return lr < kMaxVTLr ? mClusterIndices[lr] : -1; }
+  int          getParticleLabel(int lr)    const {return lr < kMaxVTLr ? mClusterPartID[lr] : -2; }
+  int          getParticleID()             const {return mParticleID;}
   double       getAlpha()                  const {return mExtTrack.getAlpha();}
   double       getCharge()                 const {return mExtTrack.Charge();}
   bool         negDir()                    const {return std::abs(mExtTrack.getAlpha()) > M_PI/2.;}
@@ -79,12 +80,15 @@ class NA6PTrack
   double       getNormChi2()               const {return mNClusters<3 ? 0 :  mChi2 / ( (mNClusters<<1)-kNDOF);}
   double       getNormChi2VT()             const {return mNClustersVT<3 ? 0 :  mChi2VT / ( (mNClustersVT<<1)-kNDOF);}
   double       getPredictedChi2(double* p, double* cov) const {return mExtTrack.getPredictedChi2(p,cov);}
-
+  
   void   setMass(double m)         {mMass = m;}
   void   setNVTLayers(int n)       {mNVTLayers = n;}
   void   setChi2(double chi2)      {mChi2 = chi2;}
   void   setChi2VT(double chi2)    {mChi2VT = chi2;}
-
+  void   setParticleLabel(int idx, int lr)  { if (lr < kMaxVTLr) mClusterPartID[lr] = idx;}
+  void   setVTClusterIndex(int idx, int lr) { if (lr < kMaxVTLr) mClusterIndices[lr] = idx;}
+  void   setParticleID(int idx)    {mParticleID = idx;}
+  
   static void lab2trk(const double *vLab, double *vTrk); 
   static void trk2lab(const double *vTrk, double *vLab); 
 
@@ -111,10 +115,11 @@ class NA6PTrack
   int      mNClustersVT = 0;                     // total VT hits
   int      mNClustersMS = 0;                     // total MS hits
   int      mNClustersTR = 0;                     // total TR hits
-  std::array<int, kMaxVTLr> mClusterIndices{};  // cluster indices
-  std::array<int, kMaxVTLr> mParticleID{};      // particle ID (MC truth)
-  ExtTrackPar mExtTrack;                        // track params
-
+  std::array<int, kMaxVTLr> mClusterIndices{};   // cluster indices
+  std::array<int, kMaxVTLr> mClusterPartID{};    // particle ID (per cluster)
+  int      mParticleID = -1;                     // particle ID (MC truth)
+  ExtTrackPar mExtTrack;                         // track params
+  
   ClassDefNV(NA6PTrack,1)
 };
 

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -78,7 +78,8 @@ public:
   }
   bool loadGeometry(const char* filename, const char* geoname = "NA6P");
   void findTracks(std::vector<NA6PBaseCluster>& cluArr, TVector3 primVert);
-
+  std::vector<NA6PTrack> getTracks();
+  
 protected:
   // methods used in tracking
   void sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -67,15 +67,29 @@ enum class ExtendDirection { kInward, kOutward };
 class NA6PTrackerCA
 {
 public:
-  static constexpr int maxIterationsCA = 10;
+  static constexpr int kMaxIterationsCA = 10;
 
   NA6PTrackerCA();
   ~NA6PTrackerCA();
 
   // setters for configurable parameters
   void setNLayers(int n) {mNLayers = n;}
-  void SetMaxNumberOfSharedClusters(int n) {mMaxSharedClusters = n;
-  }
+  void SetMaxNumberOfSharedClusters(int n) {mMaxSharedClusters = n;}
+  void setNumberOfIterations(int nIter);
+  void setIterationParams(int iter,
+			  double maxDeltaThetaTracklets,
+			  double maxDeltaPhiTracklets,
+			  double maxDeltaTanLCells,
+			  double maxDeltaPhiCells,
+			  double maxDeltaPxPzCells,
+			  double maxDeltaPyPzCells,
+			  double maxChi2TrClCells,
+			  double maxChi2ndfCells,
+			  double maxChi2ndfTracks,
+			  int    minNClusTracks);
+
+
+  void printConfiguration() const;
   bool loadGeometry(const char* filename, const char* geoname = "NA6P");
   void findTracks(std::vector<NA6PBaseCluster>& cluArr, TVector3 primVert);
   std::vector<NA6PTrack> getTracks();
@@ -161,16 +175,16 @@ private:
   std::vector<TrackFitted> mFinalTracks = {};
   int    mMaxSharedClusters = 0;
   int    mNIterationsCA = 2;
-  double maxDeltaThetaTrackletsCA[maxIterationsCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double maxDeltaPhiTrackletsCA[maxIterationsCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double maxDeltaTanLCellsCA[maxIterationsCA] = {4., 9., 18., 40., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double maxDeltaPhiCellsCA[maxIterationsCA] = {0.4, 0.6, 1.2, 2.4, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double maxDeltaPxPzCellsCA[maxIterationsCA] = {0.02, 0.05, 0.1, 0.2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double maxDeltaPyPzCellsCA[maxIterationsCA] = {2e-3, 7.5e-3, 1.5e-2, 3.e-2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double maxChi2TrClCellsCA[maxIterationsCA] = {5., 10., 10., 10.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double maxChi2ndfCellsCA[maxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double maxChi2ndfTracksCA[maxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  int    minNClusTracksCA[maxIterationsCA] = {5, 3, 0, 0, 0, 0, 0, 0, 0, 0};
+  double mMaxDeltaThetaTrackletsCA[kMaxIterationsCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxDeltaPhiTrackletsCA[kMaxIterationsCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxDeltaTanLCellsCA[kMaxIterationsCA] = {4., 9., 18., 40., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxDeltaPhiCellsCA[kMaxIterationsCA] = {0.4, 0.6, 1.2, 2.4, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxDeltaPxPzCellsCA[kMaxIterationsCA] = {0.02, 0.05, 0.1, 0.2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxDeltaPyPzCellsCA[kMaxIterationsCA] = {2e-3, 7.5e-3, 1.5e-2, 3.e-2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxChi2TrClCellsCA[kMaxIterationsCA] = {5., 10., 10., 10.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxChi2ndfCellsCA[kMaxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxChi2ndfTracksCA[kMaxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  int    mMinNClusTracksCA[kMaxIterationsCA] = {5, 3, 0, 0, 0, 0, 0, 0, 0, 0};
 
 
 

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -1,0 +1,182 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_TRACKER_CA_H
+#define NA6P_TRACKER_CA_H
+
+#include <string>
+#include <Rtypes.h>
+#include "NA6PTrack.h"
+#include <TVector3.h>
+
+// Cellular Automaton track finder
+
+class NA6PFastTrackFitter;
+
+// structures for temporary objects used in track finding
+struct TrackletCandidate {
+  int startingLayer;
+  int firstClusterIndex;
+  int secondClusterIndex;
+  double tanL;
+  double phi;
+  double pxpz;
+  double pypz;
+};
+
+struct CellCandidate {
+  int startingLayer;
+  int firstTrackletIndex;
+  int secondTrackletIndex;
+  std::array<int,3> cluIDs;
+  NA6PTrack trackFitFast;
+  //    genfit::Track trackFit;
+};
+
+struct TrackCandidate {
+  int innerLayer;
+  int innerCellIndex;
+  int outerLayer;
+  int outerCellIndex;
+  std::vector<int> cluIDs;
+};
+
+struct TrackFitted{
+  int innerLayer;
+  int outerLayer;
+  int nClus;
+  std::vector<int> cluIDs;
+  NA6PTrack trackFitFast;
+  //    genfit::Track trackFit;
+  double chi2ndf;
+};
+
+enum class ExtendDirection { kInward, kOutward };
+
+class NA6PTrackerCA
+{
+public:
+  static constexpr int maxIterationsCA = 10;
+
+  NA6PTrackerCA();
+  ~NA6PTrackerCA();
+
+  // setters for configurable parameters
+  void setNLayers(int n) {mNLayers = n;}
+  void SetMaxNumberOfSharedClusters(int n) {mMaxSharedClusters = n;
+  }
+  bool loadGeometry(const char* filename, const char* geoname = "NA6P");
+  void findTracks(std::vector<NA6PBaseCluster>& cluArr, TVector3 primVert);
+
+protected:
+  // methods used in tracking
+  void sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,
+				 std::vector<int>& firstIndex,
+				 std::vector<int>& lastIndex);
+  void sortTrackletsByLayerAndIndex(std::vector<TrackletCandidate>& tracklets,
+				    std::vector<int>& firstIndex,
+				    std::vector<int>& lastIndex);
+  void sortCellsByLayerAndIndex(std::vector<CellCandidate>& cells,
+				std::vector<int>& firstIndex,
+				std::vector<int>& lastIndex);
+  void computeLayerTracklets(const std::vector<NA6PBaseCluster>& cluArr,
+			     const std::vector<int>& firstIndex,
+			     const std::vector<int>& lastIndex,
+			     std::vector<TrackletCandidate>& tracklets,
+			     double deltaThetaMax,
+			     double deltaPhiMax);
+  void computeLayerCells(const std::vector<TrackletCandidate>& tracklets,
+			 const std::vector<int>& firstIndex,
+			 const std::vector<int>& lastIndex,
+			 const std::vector<NA6PBaseCluster>& cluArr,
+			 std::vector<CellCandidate>& cells,
+			 double deltaTanLMax,
+			 double deltaPhiMax,
+			 double deltaPxPzMax,
+			 double deltaPyPzMax,
+			 double maxChi2TrClu,
+			 double maxChi2NDF);
+  double computeTrackToClusterChi2(const NA6PTrack& track,
+				   const NA6PBaseCluster& clu);
+  bool fitTrackPointsFast(const std::vector<int>& cluIDs,
+			  const std::vector<NA6PBaseCluster>& cluArr,
+			  NA6PTrack& fitTrack,
+			  double maxChi2TrClu,
+			  double maxChi2NDF);
+  void findCellsNeighbours(const std::vector<CellCandidate>& cells,
+			   const std::vector<int>& firstIndex,
+			   const std::vector<int>& lastIndex,
+			   std::vector<std::pair<int,int>>& cneigh,
+			   const std::vector<NA6PBaseCluster>& cluArr,
+			   double maxChi2TrClu);
+  std::vector<TrackCandidate> prolongSeed(const TrackCandidate& seed,
+					  const std::vector<CellCandidate>& cells,
+					  const std::vector<int>& firstIndex,
+					  const std::vector<int>& lastIndex,
+					  const std::vector<NA6PBaseCluster>& cluArr,
+					  double maxChi2TrClu,
+					  ExtendDirection dir);
+  void findRoads(const std::vector<std::pair<int,int>>& cneigh,
+		 const std::vector<CellCandidate>& cells,
+		 const std::vector<int>& firstIndex,
+		 const std::vector<int>& lastIndex,
+		 const std::vector<TrackletCandidate>& tracklets,
+		 const std::vector<NA6PBaseCluster>& cluArr,
+		 std::vector<TrackCandidate>& trackCands,
+		 double maxChi2TrClu);
+  void fitAndSelectTracks(const std::vector<TrackCandidate>& trackCands,
+			  const std::vector<NA6PBaseCluster>& cluArr,
+			  std::vector<TrackFitted>& tracks,
+			  double maxChi2TrClu,
+			  int minNClu,
+			  double maxChi2NDF);
+  template<typename T>
+  void printStats(const std::vector<T>& candidates,
+		  const std::vector<NA6PBaseCluster>& cluArr,
+		  const std::vector<CellCandidate>& cells,
+		  const std::string& label,
+		  int requiredClus = -1);
+
+
+
+
+private:
+  
+  int    mNLayers = 5;
+  double mPrimVertPos[3] = {};
+  NA6PFastTrackFitter* mTrackFitter = nullptr;
+  std::vector<bool> mIsClusterUsed = {};
+  std::vector<TrackFitted> mFinalTracks = {};
+  int    mMaxSharedClusters = 0;
+  int    mNIterationsCA = 2;
+  double maxDeltaThetaTrackletsCA[maxIterationsCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double maxDeltaPhiTrackletsCA[maxIterationsCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double maxDeltaTanLCellsCA[maxIterationsCA] = {4., 9., 18., 40., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double maxDeltaPhiCellsCA[maxIterationsCA] = {0.4, 0.6, 1.2, 2.4, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double maxDeltaPxPzCellsCA[maxIterationsCA] = {0.02, 0.05, 0.1, 0.2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double maxDeltaPyPzCellsCA[maxIterationsCA] = {2e-3, 7.5e-3, 1.5e-2, 3.e-2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double maxChi2TrClCellsCA[maxIterationsCA] = {5., 10., 10., 10.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double maxChi2ndfCellsCA[maxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double maxChi2ndfTracksCA[maxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  int    minNClusTracksCA[maxIterationsCA] = {5, 3, 0, 0, 0, 0, 0, 0, 0, 0};
+
+
+
+ 
+  
+
+  ClassDefNV(NA6PTrackerCA, 1);
+};
+
+#endif

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -74,7 +74,7 @@ public:
 
   // setters for configurable parameters
   void setNLayers(int n) {mNLayers = n;}
-  void SetMaxNumberOfSharedClusters(int n) {mMaxSharedClusters = n;}
+  void setMaxNumberOfSharedClusters(int n) {mMaxSharedClusters = n;}
   void setNumberOfIterations(int nIter);
   void setIterationParams(int iter,
 			  double maxDeltaThetaTracklets,
@@ -87,12 +87,14 @@ public:
 			  double maxChi2ndfCells,
 			  double maxChi2ndfTracks,
 			  int    minNClusTracks);
-
+  void setVerbosity(bool opt = true) {mVerbose = opt;}
 
   void printConfiguration() const;
+  int  getNIterations() const {return mNIterationsCA;}
   bool loadGeometry(const char* filename, const char* geoname = "NA6P");
   void findTracks(std::vector<NA6PBaseCluster>& cluArr, TVector3 primVert);
   std::vector<NA6PTrack> getTracks();
+
   
 protected:
   // methods used in tracking
@@ -174,6 +176,7 @@ private:
   std::vector<bool> mIsClusterUsed = {};
   std::vector<TrackFitted> mFinalTracks = {};
   int    mMaxSharedClusters = 0;
+  bool   mVerbose = false;
   int    mNIterationsCA = 2;
   double mMaxDeltaThetaTrackletsCA[kMaxIterationsCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   double mMaxDeltaPhiTrackletsCA[kMaxIterationsCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};

--- a/rec/include/NA6PVerTelReconstruction.h
+++ b/rec/include/NA6PVerTelReconstruction.h
@@ -17,15 +17,18 @@
 
 #include <string>
 #include <Rtypes.h>
+#include <TVector3.h>
 
 // Class to steer the VT reconstruction
 
+#include "NA6PBaseCluster.h"
+#include "NA6PTrack.h"
 #include "NA6PReconstruction.h"
 
 class TFile;
 class TTree;
 class NA6PVerTelHit;
-class NA6PBaseCluster;
+class NA6PTrackerCA;
 
 class NA6PVerTelReconstruction : public NA6PReconstruction
 {
@@ -34,6 +37,7 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   NA6PVerTelReconstruction() : NA6PReconstruction("VerTel") {}
   ~NA6PVerTelReconstruction() override = default;
 
+  bool init(const char* filename, const char* geoname = "NA6P") override;
   // methods to steer cluster reconstruction
   void createClustersOutput() override;
   void clearClusters() override { mClusters.clear(); }
@@ -43,11 +47,30 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   void setClusterSpaceResolution( double clures ) {mCluRes = clures;}
   void hitsToRecPoints(const std::vector<NA6PVerTelHit>& vtHits);
 
+  void setPrimaryVertexPosition(double x, double y, double z){
+    mPrimaryVertex.SetXYZ(x, y, z);
+  }
+  // methods to steer tracking
+  void setClusters(const std::vector<NA6PBaseCluster>& clusters) {
+    mClusters = clusters;
+    hClusPtr = &mClusters;
+  }
+  void createTracksOutput() override;
+  void clearTracks() override{ mTracks.clear(); }
+  void writeTracks() override;
+  void closeTracksOutput() override;
+  void runTracking();
+  
  private:
   std::vector<NA6PBaseCluster> mClusters, *hClusPtr = &mClusters;  // vector of clusters
   TFile* mClusFile = nullptr;                                      // file with clusters
   TTree* mClusTree = nullptr;                                      // tree of clusters
   double mCluRes = 5.e-4;                                          // cluster resolution, cm (for fast simu)
+  TVector3 mPrimaryVertex{0.0,0.0,0.0};                            // primary vertex position
+  std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;           // vector of tracks
+  TFile* mTrackFile = nullptr;                                     // file with tracks
+  TTree* mTrackTree = nullptr;                                     // tree of tracks
+  NA6PTrackerCA *mVTTracker = nullptr;                             // tracker
 
   ClassDefNV(NA6PVerTelReconstruction, 1);
 };

--- a/rec/src/NA6PReconstruction.cxx
+++ b/rec/src/NA6PReconstruction.cxx
@@ -1,7 +1,46 @@
 // NA6PCCopyright
 
 #include <fairlogger/Logger.h>
+#include <TGeoManager.h>
+#include <TFile.h>
+#include <TSystem.h>
+#include "MagneticField.h"
 #include "NA6PReconstruction.h"
+
+ClassImp(NA6PReconstruction)
+
+
+bool NA6PReconstruction::init(const char* filename, const char* geoname){
+  // initialize magnetic field
+  if (mIsInitialized) {
+    LOGP(info,"Reconstruction alreary intialized");
+    return true;
+  }
+  if (TGeoGlobalMagField::Instance()->GetField() == nullptr) {
+    auto magField = new MagneticField();
+    magField->loadField();
+    magField->setAsGlobalField();
+  }
+  // load geometry
+  if (gGeoManager){
+    LOGP(info,"Geometry was already loaded");
+    mIsInitialized = true;
+    return true;
+  }
+  if (gSystem->Exec(Form("ls -l %s > /dev/null",filename)) != 0){
+    LOGP(error,"filename {} does not exist",filename);
+    return false;
+  }
+  TFile* f = TFile::Open(filename);
+  gGeoManager = (TGeoManager*)f->Get(geoname);
+  if (gGeoManager){
+    mIsInitialized = true;
+    return true;
+  }else{
+    LOGP(error,"No geometry with name {} found in file {}",geoname,filename);
+    return false;
+  }
+}
 
 void NA6PReconstruction::createClustersOutput()
 {
@@ -21,5 +60,25 @@ void NA6PReconstruction::writeClusters()
 void NA6PReconstruction::closeClustersOutput()
 {
   LOGP(warning, "closeClustersOutput called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::createTracksOutput()
+{
+  LOGP(warning, "createTracksOutput called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::clearTracks()
+{
+  LOGP(warning, "clearTracks called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::writeTracks()
+{
+  LOGP(warning, "writeTracks called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::closeTracksOutput()
+{
+  LOGP(warning, "closeTracksOutput called for {}, this should not happen", getName());
 }
 

--- a/rec/src/NA6PTrack.cxx
+++ b/rec/src/NA6PTrack.cxx
@@ -20,11 +20,12 @@ NA6PTrack::NA6PTrack() :
   mNClustersMS{0},
   mNClustersTR{0},
   mClusterIndices{},
-  mParticleID{},
+  mClusterPartID{},
+  mParticleID{-2},
   mExtTrack{}
 {
   mClusterIndices.fill(-1);
-  mParticleID.fill(-2);
+  mClusterPartID.fill(-2);
 }
 
 //_______________________________________________________________________
@@ -39,12 +40,13 @@ NA6PTrack::NA6PTrack(const double* xyz, const double* pxyz, int sign, double err
   mNClustersMS{0},
   mNClustersTR{0},
   mClusterIndices{},
-  mParticleID{},
+  mClusterPartID{},
+  mParticleID{-2},
   mExtTrack{}
 {
   // initialize arrays
   mClusterIndices.fill(-1);
-  mParticleID.fill(-2);
+  mClusterPartID.fill(-2);
   // initialize the track parameters and covariance
   init(xyz, pxyz, sign, errLoose);
 }
@@ -58,8 +60,9 @@ void NA6PTrack::reset()
   mClusterMap = 0;
   mExtTrack.Reset();
   resetCovariance();
+  mParticleID = -2;
   mClusterIndices.fill(-1);
-  mParticleID.fill(-2);
+  mClusterPartID.fill(-2);
   mNClusters = mNClustersVT = mNClustersMS = mNClustersTR = 0;
 }
   
@@ -246,7 +249,7 @@ void NA6PTrack::addCluster(const NA6PBaseCluster* clu, int cluIndex, double chi2
     int nLay = nDet / 4;
     mChi2VT += chi2;
     mNClustersVT++;
-    mParticleID[nLay] = trackID;
+    mClusterPartID[nLay] = trackID;
     mClusterIndices[nLay] = cluIndex;
     mClusterMap |= (1<<nLay);
   }

--- a/rec/src/NA6PTrackerCA.cxx
+++ b/rec/src/NA6PTrackerCA.cxx
@@ -1,0 +1,758 @@
+// NA6PCCopyright
+
+#include <fmt/format.h>
+#include <fairlogger/Logger.h>
+#include <TGeoManager.h>
+#include <TSystem.h>
+#include "NA6PBaseCluster.h"
+#include "MagneticField.h"
+#include "NA6PFastTrackFitter.h"
+#include "NA6PTrackerCA.h"
+
+ClassImp(NA6PTrackerCA)
+
+
+//______________________________________________________________________
+
+NA6PTrackerCA::NA6PTrackerCA() :
+  mNLayers(5),
+  mPrimVertPos{0.,0.,0.},
+  mTrackFitter{nullptr},
+  mIsClusterUsed{false},
+  mMaxSharedClusters{0},
+  mNIterationsCA{2}
+{
+  mTrackFitter = new NA6PFastTrackFitter();
+  mTrackFitter->loadGeometry("geometry.root");
+  mTrackFitter->setNLayersVT(mNLayers);
+  mTrackFitter->setPropagateToPrimaryVertex(false);
+}
+//______________________________________________________________________
+
+
+NA6PTrackerCA::~NA6PTrackerCA() 
+{
+  if (mTrackFitter) delete mTrackFitter;
+  mTrackFitter = nullptr;
+}
+//______________________________________________________________________
+
+bool NA6PTrackerCA::loadGeometry(const char* filename, const char* geoname){
+
+  if (!mTrackFitter) {
+    LOGP(error,"Fitter not yet instantiated");
+    return false;
+  }
+  if (gSystem->Exec(Form("ls -l %s",filename)) != 0){
+    LOGP(error,"filename {} does not exist",filename);
+    return false;
+  }
+  return mTrackFitter->loadGeometry(filename, geoname);
+}
+
+//______________________________________________________________________
+
+void NA6PTrackerCA::sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,
+					      std::vector<int>& firstIndex,
+					      std::vector<int>& lastIndex){
+  
+  // count clus per layer
+  std::vector<int> count(mNLayers, 0);
+  for (const auto& clu : cluArr) {
+    int jDet=clu.getDetectorID();
+    int jLay=jDet/4;
+    if (jLay >= 0 && jLay < mNLayers) {
+      count[jLay]++;
+    }
+  }
+  // starting offset for each layer
+  firstIndex.resize(mNLayers);
+  lastIndex.resize(mNLayers);
+  firstIndex[0] = 0;
+  lastIndex[0] = count[0];
+  for (int jLay = 1; jLay < mNLayers; jLay++) {
+    firstIndex[jLay] = firstIndex[jLay - 1] + count[jLay - 1];
+    lastIndex[jLay] = firstIndex[jLay] + count[jLay];
+  }
+  // Create a reordered vector based on layer grouping
+  std::vector<int> countReord = firstIndex;
+  std::vector<NA6PBaseCluster> reordered(cluArr.size());
+  for (const auto& clu : cluArr) {
+    int jLay=clu.getDetectorID()/4;
+    if(jLay >= 0 && jLay < mNLayers) reordered[countReord[jLay]++] = clu;
+  }
+  cluArr = std::move(reordered);
+  // sort by theta within each layer (use z^2/r^2 as a proxy of theta to avoid sqrt and atan)
+  const double pvx = mPrimVertPos[0];
+  const double pvy = mPrimVertPos[1];
+  const double pvz = mPrimVertPos[2];
+  for (int jLay = 0; jLay < mNLayers; jLay++) {
+    auto first = cluArr.begin() + firstIndex[jLay];
+    auto last  = cluArr.begin() + lastIndex[jLay];
+    std::sort(first, last, [pvx, pvy, pvz](const NA6PBaseCluster& a, const NA6PBaseCluster& b) {
+      double xa = a.getX() - pvx;
+      double ya = a.getY() - pvy;
+      double za = a.getZ() - pvz;
+      double xb = b.getX() - pvx;
+      double yb = b.getY() - pvy;
+      double zb = b.getZ() - pvz;
+      double r2a = xa*xa + ya*ya;
+      double r2b = xb*xb + yb*yb;
+      return za*za * r2b < zb*zb * r2a;
+    });
+  }
+}
+
+//______________________________________________________________________
+
+void NA6PTrackerCA::sortTrackletsByLayerAndIndex(std::vector<TrackletCandidate>& tracklets,
+						 std::vector<int>& firstIndex,
+						 std::vector<int>& lastIndex){
+  
+  // count clusters per layer
+  std::vector<int> count(mNLayers-1, 0);
+  for (const auto& trkl : tracklets) {
+    int jLay=trkl.startingLayer;
+    if (jLay >= 0 && jLay < mNLayers-1) {
+      count[jLay]++;
+    }
+  }
+  // starting offset for each layer
+  firstIndex.resize(mNLayers-1);
+  lastIndex.resize(mNLayers-1);
+  firstIndex[0] = 0;
+  lastIndex[0] = count[0];
+  for (int jLay = 1; jLay < mNLayers-1; jLay++) {
+    firstIndex[jLay] = firstIndex[jLay - 1] + count[jLay - 1];
+    lastIndex[jLay] = firstIndex[jLay] + count[jLay];
+  }
+  // Create a reordered vector based on layer grouping
+  std::vector<int> countReord = firstIndex;
+  std::vector<TrackletCandidate> reordered(tracklets.size());
+  for (const auto& trkl :tracklets) {
+    int jLay=trkl.startingLayer;
+    if(jLay >= 0 && jLay < mNLayers-1) reordered[countReord[jLay]++] = trkl;
+  }
+  tracklets = std::move(reordered);
+  // sort by cluster index within each layer 
+  for (int jLay = 0; jLay < mNLayers-1; jLay++) {
+    auto first = tracklets.begin() + firstIndex[jLay];
+    auto last  = tracklets.begin() + lastIndex[jLay];
+    std::sort(first, last, [](const TrackletCandidate& a, const TrackletCandidate& b) {
+      return a.firstClusterIndex < b.firstClusterIndex || (a.firstClusterIndex == b.firstClusterIndex && a.secondClusterIndex < b.secondClusterIndex);
+    });
+  }
+}
+
+
+//______________________________________________________________________
+
+void NA6PTrackerCA::sortCellsByLayerAndIndex(std::vector<CellCandidate>& cells,
+					     std::vector<int>& firstIndex,
+					     std::vector<int>& lastIndex){
+  
+  // count cells per layer
+  std::vector<int> count(mNLayers-2, 0);
+  for (const auto& cell : cells) {
+    int jLay=cell.startingLayer;
+    if (jLay >= 0 && jLay < mNLayers-2) {
+      count[jLay]++;
+    }
+  }
+  // starting offset for each layer
+  firstIndex.resize(mNLayers-2);
+  lastIndex.resize(mNLayers-2);
+  firstIndex[0] = 0;
+  lastIndex[0] = count[0];
+  for (int jLay = 1; jLay < mNLayers-2; jLay++) {
+    firstIndex[jLay] = firstIndex[jLay - 1] + count[jLay - 1];
+    lastIndex[jLay] = firstIndex[jLay] + count[jLay];
+  }
+  // Create a reordered vector based on layer grouping
+  std::vector<int> countReord = firstIndex;
+  std::vector<CellCandidate> reordered(cells.size());
+  for (const auto& cell : cells) {
+    int jLay=cell.startingLayer;
+    if(jLay >= 0 && jLay < mNLayers-2) reordered[countReord[jLay]++] = cell;
+  }
+  cells = std::move(reordered);
+  // sort by tracklet index within each layer 
+  for (int jLay = 0; jLay < mNLayers-2; jLay++) {
+    auto first = cells.begin() + firstIndex[jLay];
+    auto last  = cells.begin() + lastIndex[jLay];
+    std::sort(first, last, [](const CellCandidate& a, const CellCandidate& b) {
+      return a.firstTrackletIndex < b.firstTrackletIndex || (a.firstTrackletIndex == b.firstTrackletIndex && a.secondTrackletIndex < b.secondTrackletIndex);
+    });
+  }
+}
+
+
+//______________________________________________________________________
+
+void NA6PTrackerCA::computeLayerTracklets(const std::vector<NA6PBaseCluster>& cluArr,
+					  const std::vector<int>& firstIndex,
+					  const std::vector<int>& lastIndex,
+					  std::vector<TrackletCandidate>& tracklets,
+					  double deltaThetaMax,
+					  double deltaPhiMax){
+  
+  tracklets.clear();
+  const double pvx = mPrimVertPos[0];
+  const double pvy = mPrimVertPos[1];
+  const double pvz = mPrimVertPos[2];
+
+  for (int iLayer = 0; iLayer < mNLayers - 1; ++iLayer) {
+    auto layerBegin = cluArr.begin() + firstIndex[iLayer+1];
+    auto layerEnd = cluArr.begin() + lastIndex[iLayer+1];
+    for (int jClu1 = firstIndex[iLayer]; jClu1 < lastIndex[iLayer]; ++jClu1) {
+      if (mIsClusterUsed[jClu1]) continue;
+      const NA6PBaseCluster& clu1 = cluArr[jClu1];
+      double x1 = clu1.getX() - pvx;
+      double y1 = clu1.getY() - pvy;
+      double z1 = clu1.getZ() - pvz;
+      double r1 = std::sqrt(x1*x1 + y1*y1);
+      double theta1 = std::atan2(z1, r1);
+      double phi1 = std::atan2(y1,x1);
+      double tanth2Min = std::tan(theta1 - 1.2 * deltaThetaMax); // 1.2 is a safety margin
+      double tanth2Max = std::tan(theta1 + 1.2 * deltaThetaMax);
+      auto lower = std::partition_point(layerBegin, layerEnd, 
+					[pvx, pvy, pvz, tanth2Min](const NA6PBaseCluster& clu){
+					  double x = clu.getX() - pvx;
+					  double y = clu.getY() - pvy;
+					  double z = clu.getZ() - pvz;
+					  double r2 = x*x + y*y;
+					  double tan2 = z*z / r2;
+					  return tan2 < tanth2Min*tanth2Min;
+					});
+
+      auto upper = std::partition_point(layerBegin, layerEnd, 
+					[pvx, pvy, pvz, tanth2Max](const NA6PBaseCluster& clu){
+					  double x = clu.getX() - pvx;
+					  double y = clu.getY() - pvy;
+					  double z = clu.getZ() - pvz;
+					  double r2 = x*x + y*y;
+					  double tan2 = z*z / r2;
+					  return tan2 <= tanth2Max*tanth2Max;  
+					});
+      int lowerIdx = std::distance(cluArr.begin(), lower);
+      int upperIdx = std::distance(cluArr.begin(), upper);
+      for (int jClu2 = lowerIdx; jClu2 < upperIdx; ++jClu2) {
+	if (mIsClusterUsed[jClu2]) continue;
+	const NA6PBaseCluster& clu2 = cluArr[jClu2];
+	double x2 = clu2.getX() - pvx;
+	double y2 = clu2.getY() - pvy;
+	double z2 = clu2.getZ() - pvz;
+	double r2 = std::sqrt(x2*x2 + y2*y2);
+	double theta2 = std::atan2(z2, r2);
+	double phi2 = std::atan2(y2,x2);
+	double dphi = phi2-phi1;
+	if (dphi > M_PI) dphi -= 2*M_PI;
+	else if (dphi < -M_PI) dphi += 2*M_PI;
+	if (std::abs(theta2-theta1) < deltaThetaMax && std::abs(dphi) < deltaPhiMax){
+	  double phi = std::atan2(y2 - y1, x2 - x1);
+	  double tanL = (z2 - z1) / (r2 - r1);
+	  double pxpz = (x2 - x1) / (z2 - z1);
+	  double pypz = (y2 - y1) / (z2 - z1);
+	  tracklets.emplace_back(iLayer, jClu1, jClu2, tanL, phi,pxpz,pypz);
+	  // do not assign the clusters as used, it will be done when the tracklets are used into tracks
+	  // mIsClusterUsed[jClu1] = true;
+	  // mIsClusterUsed[jClu2] = true;
+	}
+      }
+    }
+  }
+}
+
+//______________________________________________________________________
+
+void NA6PTrackerCA::computeLayerCells(const std::vector<TrackletCandidate>& tracklets,
+				      const std::vector<int>& firstIndex,
+				      const std::vector<int>& lastIndex,
+				      const std::vector<NA6PBaseCluster>& cluArr,
+				      std::vector<CellCandidate>& cells,
+				      double deltaTanLMax,
+				      double deltaPhiMax,
+				      double deltaPxPzMax,
+				      double deltaPyPzMax,
+				      double maxChi2TrClu,
+				      double maxChi2NDF){
+
+  cells.clear();
+  for (int iLayer = 0; iLayer < mNLayers - 2; ++iLayer) {
+    auto layerBegin = tracklets.begin() + firstIndex[iLayer+1];
+    auto layerEnd = tracklets.begin() + lastIndex[iLayer+1];
+    for (int jTrkl1 = firstIndex[iLayer]; jTrkl1 < lastIndex[iLayer]; ++jTrkl1) {
+      const TrackletCandidate& trkl1 = tracklets[jTrkl1];
+      const int nextLayerClusterIndex = trkl1.secondClusterIndex;
+      auto lower = std::partition_point(layerBegin, layerEnd,
+					[nextLayerClusterIndex](const TrackletCandidate& trkl){
+					  return trkl.firstClusterIndex < nextLayerClusterIndex;
+					});
+      auto upper = std::partition_point(layerBegin, layerEnd,
+					[nextLayerClusterIndex](const TrackletCandidate& trkl){
+					  return trkl.firstClusterIndex <= nextLayerClusterIndex;
+					});
+      for (auto it = lower; it != upper; ++it) {
+	int jTrkl2 = it - tracklets.begin();
+	const TrackletCandidate& trkl2 = *it;
+	if (trkl2.firstClusterIndex != nextLayerClusterIndex) continue;
+	const double deltaTanLambda = std::abs(trkl2.tanL - trkl1.tanL);
+	double dphi = trkl2.phi - trkl1.phi;
+	if (dphi > M_PI) dphi -= 2*M_PI;
+	else if (dphi < -M_PI) dphi += 2*M_PI;
+	double deltapxpz = std::abs(trkl2.pxpz - trkl1.pxpz);
+	double deltapypz = std::abs(trkl2.pypz - trkl1.pypz);
+	if (deltapypz < deltaPyPzMax && deltapxpz < deltaPxPzMax && deltaTanLambda < deltaTanLMax && std::abs(dphi) < deltaPhiMax) {
+	  std::array<int, 3> cluIDs = {trkl1.firstClusterIndex,trkl2.firstClusterIndex,trkl2.secondClusterIndex};
+	  NA6PTrack fitTrackFast;
+	  //	  genfit::Track fitTrack;
+	  if(fitTrackPointsFast(std::vector<int>(cluIDs.begin(), cluIDs.end()),cluArr, fitTrackFast, maxChi2TrClu, maxChi2NDF)){
+	    cells.emplace_back(iLayer, jTrkl1, jTrkl2, std::move(cluIDs), fitTrackFast);
+	  }
+	}
+      }
+    }
+  }
+}
+
+//______________________________________________________________________
+
+double NA6PTrackerCA::computeTrackToClusterChi2(const NA6PTrack& track,
+				 const NA6PBaseCluster& clu){
+  
+  double meas[2] = {clu.getYTF(), clu.getZTF()}; // ideal cluster coordinate, tracking (AliExtTrParam frame)
+  double measErr2[3] = {clu.getSigYY(), clu.getSigYZ(), clu.getSigZZ()};
+  NA6PTrack copyToProp = track;
+  copyToProp.propagateToZBxByBz(clu.getZ()); // no material correction temporarily
+  double cluchi2 = copyToProp.getPredictedChi2(meas,measErr2);
+  return cluchi2;
+}
+
+//______________________________________________________________________
+
+bool NA6PTrackerCA::fitTrackPointsFast(const std::vector<int>& cluIDs,
+				       const std::vector<NA6PBaseCluster>& cluArr,
+				       NA6PTrack& fitTrack,
+				       double maxChi2TrClu,
+				       double maxChi2NDF){
+  
+  int nClus = cluIDs.size();
+  mTrackFitter->cleanupAndStartFit();
+  mTrackFitter->setMaxChi2Cl(maxChi2TrClu);
+  std::vector<NA6PBaseCluster*> clusters;
+  clusters.reserve(nClus);
+  for (int jClu = 0; jClu < nClus; jClu++){
+    int cluID =  cluIDs[jClu];
+    const auto& clu = cluArr[cluID];
+    int nLay=clu.getDetectorID()/4;
+    NA6PBaseCluster* cluForFit = new NA6PBaseCluster(clu);
+    // no need to delete these pointer: the fitter will take ownership
+    clusters.push_back(cluForFit);
+    mTrackFitter->addClusterVT(nLay,cluForFit);
+  }
+  
+  std::unique_ptr<NA6PTrack> fitTrackPtr(mTrackFitter->fitTrackPointsVT());
+  if (!fitTrackPtr) return false;
+  
+  double chi2ndf = fitTrackPtr->getNormChi2();
+  if (chi2ndf > maxChi2NDF) return false;
+
+  fitTrack = *fitTrackPtr;
+  for (int jClu = 0; jClu < nClus; jClu++){
+    double meas[2] = {clusters[jClu]->getYTF(), clusters[jClu]->getZTF()}; // tracking (ExtTrParam) frame)
+    double measErr2[3] = {clusters[jClu]->getSigYY(), clusters[jClu]->getSigYZ(), clusters[jClu]->getSigZZ()};
+    mTrackFitter->propagateToZ(fitTrackPtr.get(),clusters[jClu]->getZLab());
+    double cluchi2 = fitTrackPtr->getPredictedChi2(meas,measErr2);
+    if (cluchi2 > maxChi2TrClu) return false;
+  }
+  return true;  
+}
+
+//______________________________________________________________________
+
+void NA6PTrackerCA::findCellsNeighbours(const std::vector<CellCandidate>& cells,
+					const std::vector<int>& firstIndex,
+					const std::vector<int>& lastIndex,
+					std::vector<std::pair<int,int>>& cneigh,
+					const std::vector<NA6PBaseCluster>& cluArr,
+					double maxChi2TrClu){
+  
+  cneigh.clear();
+
+  for (int iLayer = 0; iLayer < mNLayers - 3; ++iLayer) {
+    auto layerBegin = cells.begin() + firstIndex[iLayer+1];
+    auto layerEnd = cells.begin() + lastIndex[iLayer+1];
+    for (int jCe1 = firstIndex[iLayer]; jCe1 < lastIndex[iLayer]; ++jCe1) {
+      const CellCandidate& cell1 = cells[jCe1];
+      const int nextLayerTrackletIndex = cell1.secondTrackletIndex;
+      auto lower = std::partition_point(layerBegin, layerEnd,
+                                        [&](const CellCandidate& c){ return c.firstTrackletIndex < nextLayerTrackletIndex; });
+      auto upper = std::partition_point(layerBegin, layerEnd,
+                                        [&](const CellCandidate& c){ return c.firstTrackletIndex <= nextLayerTrackletIndex; });
+      for (auto it = lower; it != upper; ++it) {
+	int jCe2 = it - cells.begin();
+	const CellCandidate& cell2 = *it;
+	if (cell2.firstTrackletIndex != nextLayerTrackletIndex) continue;
+	if (cell1.cluIDs[1] != cell2.cluIDs[0] || cell1.cluIDs[2] != cell2.cluIDs[1]){
+	  printf("ERROR: mismatch in cluIDs\n");
+	  continue;
+	}
+	int jClu2 = cell2.cluIDs[2];
+	const auto& clu2 = cluArr[jClu2];
+	double cluchi2a = computeTrackToClusterChi2(cell1.trackFitFast, clu2);
+	if (cluchi2a > maxChi2TrClu) continue;
+	int jClu0 = cell1.cluIDs[0];
+	const auto& clu0 = cluArr[jClu0];
+	double cluchi2b = computeTrackToClusterChi2(cell2.trackFitFast, clu0);
+	if (cluchi2b > maxChi2TrClu) continue;
+	cneigh.push_back(std::make_pair(jCe1, jCe2));
+      }
+    }
+  }
+}
+
+//______________________________________________________________________
+std::vector<TrackCandidate> NA6PTrackerCA::prolongSeed(const TrackCandidate& seed,
+						       const std::vector<CellCandidate>& cells,
+						       const std::vector<int>& firstIndex,
+						       const std::vector<int>& lastIndex,
+						       const std::vector<NA6PBaseCluster>& cluArr,
+						       double maxChi2TrClu,
+						       ExtendDirection dir){
+  
+  std::vector<TrackCandidate> current = {seed};
+  std::vector<TrackCandidate> next;
+  std::vector<TrackCandidate> result;
+  
+  int step = (dir == ExtendDirection::kInward) ? -1 : 1;
+  int startLayer = (dir == ExtendDirection::kInward) ? seed.innerLayer - 1 : seed.outerLayer + 1;
+  int endLayer = (dir == ExtendDirection::kInward) ? -1 : mNLayers;
+  int maxValidLayerToSearch = firstIndex.size();
+  
+  for (int iLayer = startLayer; iLayer != endLayer; iLayer += step) {
+    next.clear();
+    bool foundAnyProlongation = false;
+    for (auto& cand : current) {
+      const CellCandidate& refCell = (dir == ExtendDirection::kInward) ? cells[cand.innerCellIndex] : cells[cand.outerCellIndex];
+      const int nextLayerTrackletIndex = (dir == ExtendDirection::kInward) ? refCell.firstTrackletIndex : refCell.secondTrackletIndex;
+      // in case of outward prolongation, pick up firstIndex and lastIndex at iLayer-2 (the cell contains 3 clus in layers: iLayer-2, iLayer-1 and iLayer)
+      int layToSearch =  (dir == ExtendDirection::kInward) ? iLayer : iLayer-2;
+      if (layToSearch < 0 || layToSearch >= maxValidLayerToSearch){
+	printf("ERROR in prolongSeed direction %d: layToSearch out of range %d\n",step,layToSearch);
+	continue;
+      }
+      for (int jCe = firstIndex[layToSearch]; jCe < lastIndex[layToSearch]; ++jCe) {
+	const CellCandidate& ccNext = cells[jCe];
+	if ((dir == ExtendDirection::kInward && ccNext.secondTrackletIndex != nextLayerTrackletIndex) ||
+	    (dir == ExtendDirection::kOutward && ccNext.firstTrackletIndex != nextLayerTrackletIndex)) continue;
+	// --- CluID continuity checks ---
+	if (dir == ExtendDirection::kInward) {
+	  if (ccNext.cluIDs[1] != refCell.cluIDs[0] || ccNext.cluIDs[2] != refCell.cluIDs[1]){
+	    printf("ERROR: mismatch in CluIDs in prolongSeed in inward direction\n");
+	    continue;
+	  }
+	} else {
+	  if (ccNext.cluIDs[0] != refCell.cluIDs[1] || ccNext.cluIDs[1] != refCell.cluIDs[2]){
+	    printf("ERROR: mismatch in CluIDs in prolongSeed in outward direction\n");
+	    continue;
+	  }
+	}
+	// --- Chi2 checks ---
+	const auto& fitNext = ccNext.trackFitFast;
+	int cluRefIndex = (dir == ExtendDirection::kInward) ? 2 : 0;
+	const auto& cluRef = cluArr[refCell.cluIDs[cluRefIndex]];
+	double chi2a = computeTrackToClusterChi2(fitNext, cluRef);
+	if (chi2a > maxChi2TrClu) continue;
+	const auto& fitRef = refCell.trackFitFast;
+	int cluNextIndex = (dir == ExtendDirection::kInward) ? 0 : 2;
+	const auto& cluNext = cluArr[ccNext.cluIDs[cluNextIndex]];
+	double chi2b = computeTrackToClusterChi2(fitRef, cluNext);
+	if (chi2b > maxChi2TrClu) continue;
+	// create new prolonged track
+	TrackCandidate extended = cand;
+	if (dir == ExtendDirection::kInward) {
+	  extended.innerCellIndex = jCe;
+	  extended.innerLayer = ccNext.startingLayer;
+	  int nLay = cluArr[ccNext.cluIDs[0]].getDetectorID() / 4;
+	  extended.cluIDs[nLay] = ccNext.cluIDs[0];
+	} else {
+	  extended.outerCellIndex = jCe;
+	  extended.outerLayer = ccNext.startingLayer;
+	  int nLay = cluArr[ccNext.cluIDs[2]].getDetectorID() / 4;
+	  extended.cluIDs[nLay] = ccNext.cluIDs[2];
+	}
+	next.push_back(std::move(extended));
+	foundAnyProlongation = true;
+      }
+    }
+    if (!foundAnyProlongation) break;
+    current.swap(next);
+  }
+  // add remaining candidates from last layer
+  for (auto& cand : current) result.push_back(cand);
+  return result;
+}
+  
+//______________________________________________________________________
+void NA6PTrackerCA::findRoads(const std::vector<std::pair<int,int>>& cneigh,
+			      const std::vector<CellCandidate>& cells,
+			      const std::vector<int>& firstIndex,
+			      const std::vector<int>& lastIndex,
+			      const std::vector<TrackletCandidate>& tracklets,
+			      const std::vector<NA6PBaseCluster>& cluArr,
+			      std::vector<TrackCandidate>& trackCands,
+			      double maxChi2TrClu){
+
+  trackCands.clear();
+  int nCellPairs = cneigh.size();
+  for (int jPair = 0; jPair < nCellPairs; jPair++){
+    const auto& thisPair =cneigh[jPair];
+    int jCe1 = thisPair.first;
+    int jCe2 = thisPair.second;
+    const CellCandidate& cc1 = cells[jCe1];
+    const CellCandidate& cc2 = cells[jCe2];
+    bool cc1Inner = (cc1.startingLayer < cc2.startingLayer);
+    const int innerIndex = cc1Inner ? jCe1 : jCe2;
+    const int outerIndex = cc1Inner ? jCe2 : jCe1;
+    const CellCandidate& inner = cells[innerIndex];
+    const CellCandidate& outer = cells[outerIndex];
+
+    // build initial candidate
+    std::vector<int> cluIDsFull(mNLayers,-1);
+    int nClusIn = inner.cluIDs.size();
+    int innerLay = 99;
+    for(int jClu = 0; jClu < nClusIn; jClu++){
+      int cluID =  inner.cluIDs[jClu];
+      int nLay = cluArr[cluID].getDetectorID()/4;
+      cluIDsFull[nLay] = cluID;
+      if (nLay < innerLay) innerLay = nLay;
+    }
+    int nClusOut = outer.cluIDs.size();
+    int outerLay = 0;
+    for(int jClu = 0; jClu < nClusOut; jClu++){
+      int cluID =  outer.cluIDs[jClu];
+      int nLay = cluArr[cluID].getDetectorID()/4;
+      if(cluIDsFull[nLay] != -1 && cluIDsFull[nLay] != cluID){
+	printf("ERROR: clu mismatch in layer %d!\n",nLay);
+	continue;
+      }
+      cluIDsFull[nLay] = cluID;
+      if (nLay > outerLay) outerLay = nLay;
+    }
+    // consistency checks
+    if (innerLay != inner.startingLayer){
+      printf("ERROR mismatch on inner layer\n");
+      continue;
+    }
+    if (outerLay != outer.startingLayer+2){
+      printf("ERROR mismatch on outer layer\n");
+      continue;
+    }
+    TrackCandidate seed{innerLay, innerIndex, outerLay, outerIndex, cluIDsFull};
+    auto inwardTracks = prolongSeed(seed, cells, firstIndex, lastIndex, cluArr, maxChi2TrClu, ExtendDirection::kInward);
+    for (const auto& track : inwardTracks) {
+      auto fullTracks = prolongSeed(track, cells, firstIndex, lastIndex, cluArr, maxChi2TrClu, ExtendDirection::kOutward);
+      for (auto& finalTrack : fullTracks) {
+ 	trackCands.push_back(std::move(finalTrack));
+      }
+    }
+  }
+  // remove duplicated roads
+  std::sort(trackCands.begin(), trackCands.end(), [](const TrackCandidate& a, const TrackCandidate& b) {
+    return a.cluIDs < b.cluIDs;  
+  });
+  auto last = std::unique(trackCands.begin(), trackCands.end(), [](const TrackCandidate& a, const TrackCandidate& b){
+    return a.cluIDs == b.cluIDs;
+  });
+  trackCands.erase(last, trackCands.end());
+}
+
+//______________________________________________________________________
+
+void NA6PTrackerCA::fitAndSelectTracks(const std::vector<TrackCandidate>& trackCands,
+				       const std::vector<NA6PBaseCluster>& cluArr,
+				       std::vector<TrackFitted>& tracks,
+				       double maxChi2TrClu,
+				       int minNClu,
+				       double maxChi2NDF){
+
+  std::vector<TrackFitted> fittedTracks;
+  fittedTracks.reserve(trackCands.size());
+
+  // fit all track candidates
+  for (const auto& cand : trackCands) {
+    int nClus = 0;
+    std::vector<int> cluIDsForfit;
+    for (int cluID : cand.cluIDs) {
+      if (cluID >= 0) { // cluID == -1 correspond to no clu on that layer
+	nClus++;
+	cluIDsForfit.push_back(cluID);
+      }
+    }
+    // fit the track
+    //    genfit::Track fitTrack;
+    NA6PTrack fitTrackFast;
+    //    bool fitSuccess = fitTrackPoints(cluIDsForfit,cluArr,fitter,fitTrack,9999999.,maxChi2NDF);
+    bool fitSuccess = fitTrackPointsFast(cluIDsForfit,cluArr,fitTrackFast,maxChi2TrClu,maxChi2NDF);
+    if (!fitSuccess) continue; // skip if fit failed
+    nClus = fitTrackFast.getNHits(); // some clusters could have been rejected in the fit
+    if (nClus < minNClu) continue; 
+    // const genfit::AbsTrackRep* rep = fitTrack.getTrackRep(0);
+    // double chi2 = fitTrack.getFitStatus(rep)->getChi2();
+    // double ndf = fitTrack.getFitStatus(rep)->getNdf();
+    // double chi2ndf = (ndf > 0) ? chi2 / ndf : 9999.0;
+    double chi2ndf = fitTrackFast.getNormChi2();
+    fittedTracks.emplace_back(cand.innerLayer,cand.outerLayer,nClus,cand.cluIDs,std::move(fitTrackFast),chi2ndf);
+  }
+  // sort by chi2 in view of selection
+  std::sort(fittedTracks.begin(), fittedTracks.end(), [](const TrackFitted& a, const TrackFitted& b) {
+    return a.chi2ndf < b.chi2ndf;
+  });
+  // treat tracks with shared clus: in case of sharing keep the track with lower chi2
+  for (auto& track : fittedTracks) {
+    int nShared = 0;
+    for (int cluID : track.cluIDs) {
+      if (cluID >= 0 && mIsClusterUsed[cluID]) nShared++;
+    }
+    if (nShared > mMaxSharedClusters){
+      // tracks should not be stored in the list of selected tracks
+      continue;
+    }
+    // mark the clusters of the selected track as used
+    for (int cluID : track.cluIDs) {
+      if (cluID >= 0) mIsClusterUsed[cluID] = true;
+    }
+    tracks.push_back(std::move(track));
+  }
+}
+
+//______________________________________________________________________
+
+void NA6PTrackerCA::findTracks(std::vector<NA6PBaseCluster>& cluArr, TVector3 primVert) {
+
+  uint nClus=cluArr.size();
+  mPrimVertPos[0] = primVert.X();
+  mPrimVertPos[1] = primVert.Y();
+  mPrimVertPos[2] = primVert.Z();
+  printf("--- Process event with nClusters = %d, primary vertex in z = %.2f cm ---\n",nClus,mPrimVertPos[2]);
+  mIsClusterUsed.resize(nClus);
+  for(uint jClu = 0; jClu < nClus; jClu++) mIsClusterUsed[jClu] = false;
+  std::vector<int> firstCluPerLay;
+  std::vector<int> lastCluPerLay;
+  sortClustersByLayerAndEta(cluArr,firstCluPerLay,lastCluPerLay);
+  std::vector<TrackletCandidate> foundTracklets;
+  std::vector<CellCandidate> foundCells;
+  std::vector<std::pair<int, int>> cellsNeighbours;
+  std::vector<TrackCandidate> trackCandidates;
+  std::vector<TrackFitted> iterationTracks;
+  for (int jIteration = 0; jIteration < mNIterationsCA; ++jIteration){
+    printf("-> Iteration %d <-\n",jIteration);
+    foundTracklets.clear();
+    foundCells.clear();
+    cellsNeighbours.clear();
+    trackCandidates.clear();
+    iterationTracks.clear();
+    computeLayerTracklets(cluArr,firstCluPerLay,lastCluPerLay,foundTracklets,maxDeltaThetaTrackletsCA[jIteration],maxDeltaPhiTrackletsCA[jIteration]);
+    std::vector<int> firstTrklPerLay;
+    std::vector<int> lastTrklPerLay;
+    sortTrackletsByLayerAndIndex(foundTracklets,firstTrklPerLay,lastTrklPerLay);
+    printStats(foundTracklets,cluArr,foundCells,"tracklets");
+    //
+    computeLayerCells(foundTracklets,firstTrklPerLay,lastTrklPerLay,cluArr,foundCells,maxDeltaTanLCellsCA[jIteration],maxDeltaPhiCellsCA[jIteration],maxDeltaPxPzCellsCA[jIteration],maxDeltaPyPzCellsCA[jIteration],maxChi2TrClCellsCA[jIteration],maxChi2ndfCellsCA[jIteration]);
+    std::vector<int> firstCellPerLay;
+    std::vector<int> lastCellPerLay;
+    sortCellsByLayerAndIndex(foundCells,firstCellPerLay,lastCellPerLay);
+    printStats(foundCells,cluArr,foundCells,"cells");
+    //
+    findCellsNeighbours(foundCells,firstCellPerLay,lastCellPerLay,cellsNeighbours,cluArr,maxChi2TrClCellsCA[jIteration]);
+    printStats(cellsNeighbours,cluArr,foundCells,"cell pairs");
+    //
+    findRoads(cellsNeighbours,foundCells,firstCellPerLay,lastCellPerLay,foundTracklets,cluArr,trackCandidates,maxChi2TrClCellsCA[jIteration]);
+    printStats(trackCandidates,cluArr,foundCells,"track candidates");
+    //
+    fitAndSelectTracks(trackCandidates,cluArr,iterationTracks,maxChi2TrClCellsCA[jIteration],minNClusTracksCA[jIteration],maxChi2ndfTracksCA[jIteration]);
+    printStats(iterationTracks,cluArr,foundCells,"selected tracks");
+    printStats(iterationTracks,cluArr,foundCells,"selected tracks",5);
+    printStats(iterationTracks,cluArr,foundCells,"selected tracks",4);
+    mFinalTracks.insert(mFinalTracks.end(),iterationTracks.begin(),iterationTracks.end());
+  }
+}
+
+//______________________________________________________________________
+
+template<typename T>
+void NA6PTrackerCA::printStats(const std::vector<T>& candidates,
+			       const std::vector<NA6PBaseCluster>& cluArr,
+			       const std::vector<CellCandidate>& cells,
+			       const std::string& label,
+			       int requiredClus){
+  
+  int nFound = candidates.size();
+  if(requiredClus < 0) printf("Number of %s = %d\n",label.c_str(),nFound);
+  int nGood = 0;
+  int nSelected = 0;
+  double aveClus = 0;
+  for (int j = 0; j < nFound; ++j) {
+    const auto& tr = candidates[j];
+    int nClus = -1;
+    int idClus[10];
+    int startLay = -1;
+    if constexpr (std::is_same_v<T, TrackletCandidate>) {
+      nClus = 2;
+      idClus[0] = tr.firstClusterIndex;
+      idClus[1] =  tr.secondClusterIndex;
+      startLay = tr.startingLayer;
+    } else if constexpr (std::is_same_v<T, std::pair<int,int>>) {
+      int jCe1 = tr.first;
+      int jCe2 = tr.second;
+      CellCandidate cc1 = cells[jCe1];
+      CellCandidate cc2 = cells[jCe2];
+      nClus = cc1.cluIDs.size()+1;
+      for (int jClu = 0; jClu < nClus; jClu++){
+	if(jClu < nClus-1) idClus[jClu] = cc1.cluIDs[jClu];
+	else idClus[jClu] = cc2.cluIDs[2];
+      }
+      startLay = std::min(cc1.startingLayer,cc2.startingLayer);
+    } else if constexpr (std::is_same_v<T, TrackCandidate> || std::is_same_v<T, TrackFitted>) {
+      nClus = tr.cluIDs.size();
+      for (int jClu = 0; jClu < nClus; jClu++) idClus[jClu] = tr.cluIDs[jClu];
+      startLay = tr.innerLayer;
+    }else{
+      nClus = tr.cluIDs.size();
+      for (int jClu = 0; jClu < nClus; jClu++) idClus[jClu] = tr.cluIDs[jClu];
+      startLay = tr.startingLayer;
+    }
+    int idPartTrack = -9999999;
+    int nTrueClus = 0;      
+    for (int jClu = 0; jClu < nClus; jClu++) {
+      int cluID = idClus[jClu];
+      if(cluID >= 0){
+	++nTrueClus;
+	const auto& clu = cluArr[cluID];
+	int jLay = clu.getDetectorID()/ 4;
+	if (jClu == 0 && jLay != startLay)
+	  printf("ERROR: mismatch in %s layers: %d %d\n",label.c_str(), jLay, startLay);
+	int idPartClu = clu.getParticleID();
+	if (jClu == 0) idPartTrack = idPartClu;
+	else if (idPartClu != idPartTrack && idPartTrack > 0) idPartTrack *= (-1);
+      }
+    }
+    if(requiredClus > 0 && nTrueClus != requiredClus) continue;
+    nSelected++;
+    if (idPartTrack > 0) nGood++;
+    aveClus += nTrueClus;
+  }
+  if(requiredClus > 0) {
+    if(nSelected > 0) {
+      printf("%s with %d clus: Fraction of good = %d / %d = %f  --- average clus = %f\n",
+	     label.c_str(), requiredClus, nGood, nSelected, (double)nGood / (double)nSelected,aveClus / (double)nSelected);
+    }else{
+      printf("No %s having %d clus\n",label.c_str(),requiredClus);
+    }
+  }else{
+    if (nFound > 0)
+      printf("Fraction of good %s = %d / %d = %f  --- average clus = %f\n",
+	     label.c_str(), nGood, nFound, (double)nGood / (double)nFound,aveClus / (double)nFound);
+  }
+}
+

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -4,9 +4,7 @@
 #include <TTree.h>
 #include <TRandom3.h>
 #include <fairlogger/Logger.h>
-#include "NA6PBaseCluster.h"
 #include "NA6PVerTelHit.h"
-#include "NA6PTrack.h"
 #include "NA6PTrackerCA.h"
 #include "NA6PVerTelReconstruction.h"
 

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -46,9 +46,13 @@ void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>&
     double x = hit.getX();
     double y = hit.getY();
     double z = hit.getZ();
+    double ex2clu = 5.e-4;
+    double ey2clu = 5.e-4;
     if (mCluRes > 0) {
       x = gRandom->Gaus(hit.getX(),mCluRes);
       y = gRandom->Gaus(hit.getY(),mCluRes);
+      ex2clu = mCluRes*mCluRes;
+      ey2clu = mCluRes*mCluRes;
     }
     double eloss = hit.getHitValue();
     // very rough cluster size settings
@@ -59,7 +63,7 @@ void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>&
     int idPart=hit.getTrackID();    
     mClusters.emplace_back(x, y, z, clusiz);
     auto& clu = mClusters.back();
-    clu.setErr(mCluRes*mCluRes,0.,mCluRes*mCluRes);
+    clu.setErr(ex2clu,0.,ey2clu);
     clu.setDetectorID(nDet);
     clu.setParticleID(idPart);
     clu.setHitID(jHit);    

--- a/rec/src/recLinkDef.h
+++ b/rec/src/recLinkDef.h
@@ -13,6 +13,7 @@
 #pragma link C++ class NA6PVerTelReconstruction + ;
 #pragma link C++ class ExtTrackPar + ;
 #pragma link C++ class NA6PTrack + ;
+#pragma link C++ class NA6PTrackerCA + ;
 #pragma link C++ class NA6PFastTrackFitter + ;
 
 #endif

--- a/rec/src/recLinkDef.h
+++ b/rec/src/recLinkDef.h
@@ -8,11 +8,12 @@
 
 #pragma link C++ class NA6PBaseCluster + ;
 #pragma link C++ class std::vector < NA6PBaseCluster> + ;
+#pragma link C++ class NA6PTrack + ;
+#pragma link C++ class std::vector < NA6PTrack> + ;
 
 #pragma link C++ class NA6PReconstruction + ;
 #pragma link C++ class NA6PVerTelReconstruction + ;
 #pragma link C++ class ExtTrackPar + ;
-#pragma link C++ class NA6PTrack + ;
 #pragma link C++ class NA6PTrackerCA + ;
 #pragma link C++ class NA6PFastTrackFitter + ;
 

--- a/test/convertHitsToRecPoints.C
+++ b/test/convertHitsToRecPoints.C
@@ -13,7 +13,7 @@
 #include "NA6PVerTelReconstruction.h"
 #endif
 
-void ConvertHitsToRecPoints(){
+void convertHitsToRecPoints(){
   TFile* fh=new TFile("HitsVerTel.root");
   TTree* th=(TTree*)fh->Get("hitsVerTel");
   std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;

--- a/test/runTrackFinderCA.C
+++ b/test/runTrackFinderCA.C
@@ -1,0 +1,236 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <TTree.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TVector3.h>
+#include <TParticle.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+#include "NA6PBaseCluster.h"
+#include "NA6PTrack.h"
+#include "NA6PTrackerCA.h"
+#include "MagneticField.h"
+#include "NA6PVerTelHit.h"
+#endif
+
+const int maxIterationsCA = NA6PTrackerCA::kMaxIterationsCA;
+
+void runTrackFinderCA(int firstEv = 0,
+		      int lastEv = 9999,
+		      const char *dirSimu = "../testN6Proot/pions/latesttag",
+		      int nLayers = 5){
+
+  auto magField = new MagneticField();
+  magField->loadField();
+  magField->setAsGlobalField();
+
+
+  int nMomBins = 40;
+  TH1F* hMomGen = new TH1F("hMomGen",";p (GeV/c);counts",nMomBins,0.,10.);
+  TH1F* hEtaGen = new TH1F("hEtaGen",";#eta;counts",20,1.,5.);
+  TH1F* hMomReco = new TH1F("hMomReco",";p (GeV/c);counts",nMomBins,0.,10.);
+  TH1F* hEtaReco = new TH1F("hEtaReco",";#eta;counts",20,1.,5.);
+  TH1F* hMomGoodReco = new TH1F("hMomGoodReco",";p (GeV/c);counts",nMomBins,0.,10.);
+  TH1F* hEtaGoodReco = new TH1F("hEtaGoodReco",";#eta;counts",20,1.,5.);
+  TH1F** hMomRecoIterCA = new TH1F*[maxIterationsCA];
+  TH1F** hEtaRecoIterCA = new TH1F*[maxIterationsCA];
+  int colors[maxIterationsCA] = {kMagenta+1, kBlue, kGreen+1, kOrange+1, kRed+1, kRed, kRed-9, kGray+2, kGray+1, kGray};
+  for (int jIteration = 0; jIteration < maxIterationsCA; ++jIteration){
+    hMomRecoIterCA[jIteration] = new TH1F(Form("hMomRecoIterCA%d",jIteration),";p (GeV/c);counts",nMomBins,0.,10.);
+    hEtaRecoIterCA[jIteration] = new TH1F(Form("hEtaRecoIterCA%d",jIteration),";#eta;counts",20,1.,5.);
+  }
+
+
+  NA6PTrackerCA* tracker = new NA6PTrackerCA();
+  if (!tracker->loadGeometry(Form("%s/geometry.root",dirSimu))) return;
+  TFile* fk=new TFile(Form("%s/MCKine.root",dirSimu));
+  TTree* mcTree=(TTree*)fk->Get("mckine");
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+
+  TFile* fh=new TFile(Form("%s/HitsVerTel.root",dirSimu));
+  TTree* th=(TTree*)fh->Get("hitsVerTel");
+  std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
+  th->SetBranchAddress("VerTel", &vtHitsPtr);
+
+  TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
+  printf("Open cluster file: %s\n",fc->GetName());
+  TTree* tc=(TTree*)fc->Get("clustersVerTel");
+  std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
+  tc->SetBranchAddress("VerTel", &vtClusPtr);
+  int nEv=tc->GetEntries();
+  if(lastEv>nEv || lastEv<0) lastEv=nEv;
+  if(firstEv<0) firstEv=0;
+  TVector3 primVert(0,0,0);
+
+  int nIterationsCA = tracker->getNIterations();
+
+  for(int jEv=firstEv;jEv<lastEv; jEv++){
+    mcTree->GetEvent(jEv);
+    th->GetEvent(jEv);
+    int nPart=mcArr->size();
+    double zvert = 0;
+    // get primary vertex position from the Kine Tree
+    for(int jp=0; jp<nPart; jp++){
+      auto curPart=mcArr->at(jp);
+      if(curPart.IsPrimary()){
+	zvert =  curPart.Vz();
+	break;
+      }
+    }
+    primVert.SetZ(zvert);
+    uint nHits=vtHits.size();
+    for(int jp=0; jp<nPart; jp++){
+      auto curPart=mcArr->at(jp);
+      int maskHits = 0;
+      for (size_t jHit = 0; jHit < nHits; ++jHit) {
+	const auto& hit = vtHits.at(jHit);
+	int idPart=hit.getTrackID();
+	if(idPart==jp){
+	  int nLay=hit.getDetectorID()/4;
+	  maskHits += (1<<nLay);
+	}
+      }
+      if(maskHits == (1<<nLayers)-1){
+	double pxPart=curPart.Px();
+	double pyPart=curPart.Py();
+	double pzPart=curPart.Pz();
+	double momPart=curPart.P();
+	double phiPart=curPart.Phi();
+	double thetaPart=std::acos(pzPart/momPart);
+	double etaPart=-std::log(std::tan(thetaPart/2.));
+	hMomGen->Fill(momPart);
+	hEtaGen->Fill(etaPart);
+      }
+    }
+    tc->GetEvent(jEv);
+    tracker->findTracks(vtClus,primVert);
+    std::vector<NA6PTrack> trks = tracker->getTracks();
+    int nTrks = trks.size();
+    for(int jT =0; jT < nTrks; jT++){
+      NA6PTrack tr = trks[jT];
+      int idPartTrack = tr.getParticleID();
+      int jIteration = tr.getCAIteration();
+      if (tr.getNHits() == 5) {
+	auto curPart=mcArr->at(std::abs(idPartTrack));
+	double pxPart=curPart.Px();
+	double pyPart=curPart.Py();
+	double pzPart=curPart.Pz();
+	double momPart=curPart.P();
+	double phiPart=curPart.Phi();
+	double thetaPart=std::acos(pzPart/momPart);
+	double etaPart=-std::log(std::tan(thetaPart/2.));
+	hMomReco->Fill(momPart);
+	hEtaReco->Fill(etaPart);
+	if(jIteration >=0 && jIteration<maxIterationsCA){
+	  hMomRecoIterCA[jIteration]->Fill(momPart);
+	  hEtaRecoIterCA[jIteration]->Fill(etaPart);
+	}
+	if(idPartTrack>0){
+	  hMomGoodReco->Fill(momPart);
+	  hEtaGoodReco->Fill(etaPart);
+	}
+      }
+    }
+  }
+
+  TH1F* hPurityMom = (TH1F*)hMomGoodReco->Clone("hPurityMom");
+  hPurityMom->GetYaxis()->SetTitle("purity");
+  for(int iBin=1; iBin <=hMomGoodReco->GetNbinsX(); iBin++){
+    double cg = hMomGoodReco->GetBinContent(iBin);
+    double ct = hMomReco->GetBinContent(iBin);
+    if(ct == 0){
+      hPurityMom->SetBinContent(iBin,0.);
+      hPurityMom->SetBinError(iBin,0.);
+    }else{
+      double p = cg/ct;
+      double ep = std::sqrt(p * (1-p) / ct);
+      hPurityMom->SetBinContent(iBin,p);
+      hPurityMom->SetBinError(iBin,ep);
+    }
+  }
+  TH1F* hPurityEta = (TH1F*)hEtaGoodReco->Clone("hPurityEta");
+  hPurityEta->GetYaxis()->SetTitle("purity");
+  for(int iBin=1; iBin <=hEtaGoodReco->GetNbinsX(); iBin++){
+    double cg = hEtaGoodReco->GetBinContent(iBin);
+    double ct = hEtaReco->GetBinContent(iBin);
+    if(ct == 0){
+      hPurityEta->SetBinContent(iBin,0.);
+      hPurityEta->SetBinError(iBin,0.);
+    }else{
+      double p = cg/ct;
+      double ep = std::sqrt(p * (1-p) / ct);
+      hPurityEta->SetBinContent(iBin,p);
+      hPurityEta->SetBinError(iBin,ep);
+    }
+  }
+
+  
+  TCanvas* cef = new TCanvas("cef","",1400,800);
+  cef->Divide(2,2);
+  cef->cd(1);
+  hMomGen->SetLineColor(kGray+1);
+  hMomGen->SetLineWidth(3);
+  hMomGen->Draw();
+  hMomReco->SetLineWidth(2);
+  hMomReco->Draw("same");
+  TLegend* leg = new TLegend(0.5,0.6,0.89,0.8);
+  leg->AddEntry(hMomGen,"Generated, 5 hits in VT");
+  for (int jIteration = 0; jIteration < nIterationsCA; ++jIteration){
+    if(hMomRecoIterCA[jIteration]->GetEntries() > 0) {
+      hMomRecoIterCA[jIteration]->SetLineColor(colors[jIteration]);
+      hMomRecoIterCA[jIteration]->SetLineWidth(2);
+      hMomRecoIterCA[jIteration]->Draw("same");
+      leg->AddEntry(hMomRecoIterCA[jIteration],Form("Reconstructed Interation %d, 5 hits in VT",jIteration));
+    }
+  }
+  leg->Draw();
+  cef->cd(2);
+  TH1F* hEffMom = (TH1F*)hMomReco->Clone("hEffMom");
+  hEffMom->Divide(hMomReco,hMomGen,1.,1.,"B");
+  hEffMom->GetYaxis()->SetTitle("Efficiency");
+  hEffMom->SetStats(0);
+  hEffMom->Draw();
+  cef->cd(3);
+  hEtaGen->SetLineColor(kGray+1);
+  hEtaGen->SetLineWidth(3);
+  hEtaGen->Draw();
+  hEtaReco->SetLineWidth(2);
+  hEtaReco->Draw("same");
+  for (int jIteration = 0; jIteration < nIterationsCA; ++jIteration){
+    if(hEtaRecoIterCA[jIteration]->GetEntries() > 0) {
+      hEtaRecoIterCA[jIteration]->SetLineColor(colors[jIteration]);
+      hEtaRecoIterCA[jIteration]->SetLineWidth(2);
+      hEtaRecoIterCA[jIteration]->Draw("same");
+    }
+  }
+  cef->cd(4);
+  TH1F* hEffEta = (TH1F*)hEtaReco->Clone("hEffEta");
+  hEffEta->Divide(hEtaReco,hEtaGen,1.,1.,"B");
+  hEffEta->GetYaxis()->SetTitle("Efficiency");
+  hEffEta->SetStats(0);
+  hEffEta->Draw();
+
+  TCanvas* cpu = new TCanvas("cpu","",1400,800);
+  cpu->Divide(2,2);
+  cpu->cd(1);
+  hMomReco->Draw();
+  hMomGoodReco->SetLineColor(kGreen+1);;
+  hMomGoodReco->Draw("same");
+  cpu->cd(2);
+  hPurityMom->GetYaxis()->SetTitle("Purity");
+  hPurityMom->SetMinimum(0.8);
+  hPurityMom->SetStats(0);
+  hPurityMom->Draw();
+  cpu->cd(3);
+  hEtaReco->Draw();
+  hEtaGoodReco->SetLineColor(kGreen+1);;
+  hEtaGoodReco->Draw("same");
+  cpu->cd(4);
+  hPurityEta->GetYaxis()->SetTitle("Purity");
+  hPurityEta->SetMinimum(0.8);
+  hPurityEta->SetStats(0);
+  hPurityEta->Draw();
+  
+}
+    

--- a/test/runVTTracking.C
+++ b/test/runVTTracking.C
@@ -1,0 +1,59 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <TTree.h>
+#include <TFile.h>
+#include <TParticle.h>
+#include <TStopwatch.h>
+#include "NA6PBaseCluster.h"
+#include "NA6PVerTelReconstruction.h"
+#endif
+
+void runVTTracking(int firstEv = 0,
+		   int lastEv = 99999,
+		   const char *dirSimu = "Angantyr")
+{
+  
+  // kine file needed to get the primary vertex position (temporary)
+  TFile* fk=new TFile(Form("%s/MCKine.root",dirSimu));
+  TTree* mcTree=(TTree*)fk->Get("mckine");
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+
+  TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
+  printf("Open cluster file: %s\n",fc->GetName());
+  TTree* tc=(TTree*)fc->Get("clustersVerTel");
+  std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
+  tc->SetBranchAddress("VerTel", &vtClusPtr);
+
+  NA6PVerTelReconstruction* vtrec = new NA6PVerTelReconstruction();
+  vtrec->init(Form("%s/geometry.root",dirSimu));
+
+  int nEv=tc->GetEntries();
+  if(lastEv>nEv || lastEv<0) lastEv=nEv;
+  if(firstEv<0) firstEv=0;
+
+  TStopwatch timer;
+  timer.Start();
+
+  for(int jEv=firstEv; jEv<lastEv; jEv++){
+    mcTree->GetEvent(jEv);
+    int nPart=mcArr->size();
+    double zvert = 0;
+    // get primary vertex position from the Kine Tree
+    for(int jp=0; jp<nPart; jp++){
+      auto curPart=mcArr->at(jp);
+      if(curPart.IsPrimary()){
+	zvert =  curPart.Vz();
+	break;
+      }
+    }
+    tc->GetEvent(jEv);
+    vtrec->setPrimaryVertexPosition(0.,0.,zvert);
+    vtrec->setClusters(vtClus);
+    vtrec->runTracking();
+  }
+  vtrec->closeTracksOutput();
+  
+  timer.Stop();
+  timer.Print();
+}
+    


### PR DESCRIPTION
This adds essentially the class NA6PTrackerCA, which implements a Cellular Automaton algorithm extracted from the one of ITS2 in AliceO2.
This require some small adaptations of the NA6PTrack and NA6PFastTrackFitter classes.
In addition, I added an interface method in NA6PVerTelReconstruction, which runs the cellular automaton tracker on the clusters and stores the track in a root file. Note that at this stage, the primary vertex position should be provided from the outside since a vertexing algorithm is not yet implemented.
Two simple example macros to run the tracking via the NA6PVerTelReconstruction interfaces (produces a root file with a TTree of tracks) or via a direct usage of NA6PTrackerCA are also provided.
