### PR TITLE
First implementation of tracklet vertex finder

### DIFF
--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -26,6 +26,7 @@ set(DICTIONARY_HEADERS
   NA6PRecoParam.h
   NA6PReconstruction.h
   NA6PVerTelReconstruction.h
+  NA6PVertexerTracklets.h
   NA6PTrackerCA.h
   NA6PFastTrackFitter.h
   ) # Add all class headers requiring dictionary

--- a/rec/include/NA6PReconstruction.h
+++ b/rec/include/NA6PReconstruction.h
@@ -18,24 +18,28 @@
 #include <string>
 #include <Rtypes.h>
 
-// Class to steer the reconstruction 
+// Class to steer the reconstruction
 
 class NA6PReconstruction
 {
  public:
-
-  NA6PReconstruction(const std::string &name) : mName(name) {}
+  NA6PReconstruction(const std::string& name) : mName(name) {}
   virtual ~NA6PReconstruction() {}
 
   const std::string& getName() const { return mName; }
 
   virtual bool init(const char* filename, const char* geoname = "NA6P");
-  
+
   // methods to steer cluster reconstruction
   virtual void createClustersOutput();
   virtual void clearClusters();
   virtual void writeClusters();
   virtual void closeClustersOutput();
+  // methods to steer vertexing
+  virtual void createVerticesOutput();
+  virtual void clearVertices();
+  virtual void writeVertices();
+  virtual void closeVerticesOutput();
   // methods to steer tracking
   virtual void createTracksOutput();
   virtual void clearTracks();
@@ -43,8 +47,8 @@ class NA6PReconstruction
   virtual void closeTracksOutput();
 
  protected:
-  std::string mName{"MothClass"};                // detector name
-  bool        mIsInitialized = false;            // flag for initialization
+  std::string mName{"MothClass"}; // detector name
+  bool mIsInitialized = false;    // flag for initialization
   ClassDefNV(NA6PReconstruction, 1);
 };
 

--- a/rec/include/NA6PVerTelReconstruction.h
+++ b/rec/include/NA6PVerTelReconstruction.h
@@ -23,18 +23,19 @@
 
 #include "NA6PBaseCluster.h"
 #include "NA6PTrack.h"
+#include "NA6PVertex.h"
 #include "NA6PReconstruction.h"
 
 class TFile;
 class TTree;
 class NA6PVerTelHit;
+class NA6PVertexerTracklets;
 class NA6PTrackerCA;
 
 class NA6PVerTelReconstruction : public NA6PReconstruction
 {
  public:
-
-  NA6PVerTelReconstruction() : NA6PReconstruction("VerTel") {}
+  NA6PVerTelReconstruction();
   ~NA6PVerTelReconstruction() override = default;
 
   bool init(const char* filename, const char* geoname = "NA6P") override;
@@ -44,33 +45,46 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   void writeClusters() override;
   void closeClustersOutput() override;
   // fast method to smear the hits bypassing digitization and cluster finder
-  void setClusterSpaceResolution( double clures ) {mCluRes = clures;}
+  void setClusterSpaceResolution(double clures) { mCluRes = clures; }
   void hitsToRecPoints(const std::vector<NA6PVerTelHit>& vtHits);
 
-  void setPrimaryVertexPosition(double x, double y, double z){
+  void setPrimaryVertexPosition(double x, double y, double z)
+  {
     mPrimaryVertex.SetXYZ(x, y, z);
   }
   // methods to steer tracking
-  void setClusters(const std::vector<NA6PBaseCluster>& clusters) {
+  void setClusters(const std::vector<NA6PBaseCluster>& clusters)
+  {
     mClusters = clusters;
     hClusPtr = &mClusters;
   }
+  void createVerticesOutput() override;
+  void clearVertices() override { mVertices.clear(); }
+  void writeVertices() override;
+  void closeVerticesOutput() override;
+  void runVertexerTracklets();
+  const std::vector<NA6PVertex>& getVertices() const { return mVertices; }
+
   void createTracksOutput() override;
-  void clearTracks() override{ mTracks.clear(); }
+  void clearTracks() override { mTracks.clear(); }
   void writeTracks() override;
   void closeTracksOutput() override;
   void runTracking();
-  
+
  private:
-  std::vector<NA6PBaseCluster> mClusters, *hClusPtr = &mClusters;  // vector of clusters
-  TFile* mClusFile = nullptr;                                      // file with clusters
-  TTree* mClusTree = nullptr;                                      // tree of clusters
-  double mCluRes = 5.e-4;                                          // cluster resolution, cm (for fast simu)
-  TVector3 mPrimaryVertex{0.0,0.0,0.0};                            // primary vertex position
-  std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;           // vector of tracks
-  TFile* mTrackFile = nullptr;                                     // file with tracks
-  TTree* mTrackTree = nullptr;                                     // tree of tracks
-  NA6PTrackerCA *mVTTracker = nullptr;                             // tracker
+  std::vector<NA6PBaseCluster> mClusters, *hClusPtr = &mClusters; // vector of clusters
+  TFile* mClusFile = nullptr;                                     // file with clusters
+  TTree* mClusTree = nullptr;                                     // tree of clusters
+  double mCluRes = 5.e-4;                                         // cluster resolution, cm (for fast simu)
+  std::vector<NA6PVertex> mVertices, *hVerticesPtr = &mVertices;  // vector of vertices
+  TFile* mVertexFile = nullptr;                                   // file with vertices
+  TTree* mVertexTree = nullptr;                                   // tree of vertices
+  NA6PVertexerTracklets* mVTTrackletVertexer = nullptr;           // vertexer
+  TVector3 mPrimaryVertex{0.0, 0.0, 0.0};                         // primary vertex position
+  std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;          // vector of tracks
+  TFile* mTrackFile = nullptr;                                    // file with tracks
+  TTree* mTrackTree = nullptr;                                    // tree of tracks
+  NA6PTrackerCA* mVTTracker = nullptr;                            // tracker
 
   ClassDefNV(NA6PVerTelReconstruction, 1);
 };

--- a/rec/include/NA6PVertex.h
+++ b/rec/include/NA6PVertex.h
@@ -106,7 +106,7 @@ class NA6PVertex
   int   mNContributors = 0; 
   short mVertexType = kBaseVertex;
   
-  ClassDefNV(NA6PVertex,1)
+  ClassDefNV(NA6PVertex,1);
 };
 
 #endif

--- a/rec/include/NA6PVertexerTracklets.h
+++ b/rec/include/NA6PVertexerTracklets.h
@@ -1,0 +1,194 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_VERTEXER_TRACKLETS_H
+#define NA6P_VERTEXER_TRACKLETS_H
+
+#include <Rtypes.h>
+
+class NA6PVertex;
+
+// Vertex reconstruction from tracklets in the telescope
+
+// structures for temporary objects used in track finding
+
+struct TrackletForVertex {
+  int startingLayer;
+  int firstClusterIndex;
+  int secondClusterIndex;
+  double tanL;
+  double phi;
+  double pxpz;
+  double pypz;
+  bool isSignal;
+};
+
+struct TracklIntersection {
+  double zeta;
+  double sigmazeta;
+  double tanl;
+  int firstClusterIndex;
+  int secondClusterIndex;
+};
+
+class NA6PVertexerTracklets
+{
+ public:
+  enum { kYZ,
+         kRZ,
+         k3D,
+         kXZ };
+  enum { kNoWeight,
+         kTanL,
+         kSigma };
+  enum { kMaxPileupVertices = 5,
+         kMaxBinsForPeakFind = 1000 };
+  enum { kKDE,
+         kHistoPeak };
+  enum { kStandardKDE,
+         kAdaptiveKDE };
+
+  NA6PVertexerTracklets();
+  ~NA6PVertexerTracklets() = default;
+
+  void configurePeakFinding(double zmin = -20.0, double zmax = 5., int nbins = 250)
+  {
+    mZMin = zmin;
+    mZMax = zmax;
+    mNBinsForPeakFind = nbins;
+    mBinWidth = (mZMax - mZMin) / mNBinsForPeakFind;
+    mHistIntersec.assign(nbins, 0);
+  }
+  void configureKDE(double width, int nbins = 500)
+  {
+    mNGridKDE = nbins;
+    mKDEWidth = width;
+  }
+
+  // Settters
+  void setNLayersVT(int n) { mNLayersVT = n; }
+  void setLayerToStart(int lay) { mLayerToStart = lay; }
+  void setBeamX(double x) { mBeamX = x; }
+  void setBeamY(double y) { mBeamY = y; }
+  void setRecoInYZPlane() { mRecoType = kYZ; }
+  void setRecoInXZPlane() { mRecoType = kXZ; }
+  void setRecoInRZPlane() { mRecoType = kRZ; }
+  void setRecoIn3D() { mRecoType = k3D; }
+  void setMaxDCAxy(double v) { mMaxDCAxy = v; }
+  void setMaxDeltaThetaTracklet(double v) { mMaxDeltaThetaTracklet = v; }
+  void setMaxDeltaPhiTracklet(double v) { mMaxDeltaPhiTracklet = v; }
+  void setMaxDeltaTanLamInOut(double v) { mMaxDeltaTanLamInOut = v; }
+  void setMaxDeltaPhiInOut(double v) { mMaxDeltaPhiInOut = v; }
+  void setMaxDeltaPxPzInOut(double v) { mMaxDeltaPxPzInOut = v; }
+  void setMaxDeltaPyPzInOut(double v) { mMaxDeltaPyPzInOut = v; }
+  void setUseHistoForPeakFinding() { mMethod = kHistoPeak; }
+  void setUseKDEForPeakFinding() { mMethod = kKDE; }
+  void setUseNoWeight() { mWeightedMeanOption = kNoWeight; }
+  void setUseTanLWeight() { mWeightedMeanOption = kTanL; }
+  void setUseSigmaWeight() { mWeightedMeanOption = kSigma; }
+  void setZRange(double zmin, double zmax)
+  {
+    mZMin = zmin;
+    mZMax = zmax;
+    if (mNBinsForPeakFind > 0)
+      configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
+  }
+  void setNBinsForPeakFind(int nbins)
+  {
+    mNBinsForPeakFind = nbins;
+    configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
+  }
+  void setPeakWidthBins(int bins) { mPeakWidthBins = bins; }
+  void setMinCountsInPeak(int counts) { mMinCountsInPeak = counts; }
+  void setUseStandardKDE() { mKDEOption = kStandardKDE; }
+  void setUseAdaptiveKDE() { mKDEOption = kAdaptiveKDE; }
+  void setVerbosity(bool opt = true) { mVerbose = opt; }
+
+  // methods for vertex calculation
+  void findVertices(std::vector<NA6PBaseCluster>& cluArr,
+                    std::vector<NA6PVertex>& vertices);
+
+  void sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,
+                                 std::vector<int>& firstIndex,
+                                 std::vector<int>& lastIndex);
+  void sortTrackletsByLayerAndIndex(std::vector<TrackletForVertex>& tracklets,
+                                    std::vector<int>& firstIndex,
+                                    std::vector<int>& lastIndex);
+  void computeLayerTracklets(const std::vector<NA6PBaseCluster>& cluArr,
+                             const std::vector<int>& firstIndex,
+                             const std::vector<int>& lastIndex,
+                             std::vector<TrackletForVertex>& tracklets);
+  void selectTracklets(const std::vector<TrackletForVertex>& tracklets,
+                       const std::vector<int>& firstIndex,
+                       const std::vector<int>& lastIndex,
+                       const std::vector<NA6PBaseCluster>& cluArr,
+                       std::vector<TrackletForVertex>& selTracklets);
+  void filterOutUsedTracklets(const std::vector<TrackletForVertex>& tracklets,
+                              std::vector<TrackletForVertex>& usableTracklets);
+  void computeIntersections(const std::vector<TrackletForVertex>& selTracklets,
+                            const std::vector<NA6PBaseCluster>& cluArr,
+                            std::vector<TracklIntersection>& zIntersec);
+  bool findVertexHistoPeak(std::vector<TracklIntersection>& zIntersec,
+                           std::vector<NA6PVertex>& vertices);
+
+  double gaussKernel(double u)
+  {
+    return std::exp(-0.5 * u * u) / std::sqrt(2.0 * M_PI);
+  }
+  void resetClusters(int nClus)
+  {
+    mIsClusterUsed.resize(nClus);
+    for (int jClu = 0; jClu < nClus; jClu++)
+      mIsClusterUsed[jClu] = false;
+  }
+  bool findVertexKDE(const std::vector<TracklIntersection>& zIntersec,
+                     std::vector<NA6PVertex>& vertices);
+  void printStats(const std::vector<TrackletForVertex>& candidates,
+                  const std::vector<NA6PBaseCluster>& cluArr,
+                  const std::string& label);
+  short getMethodForPeakFinding() const { return mMethod; }
+
+ private:
+  int mNLayersVT = 5;                    // number of layers in the VT
+  int mLayerToStart = 0;                 // innermost layer used in tracklets
+  std::vector<bool> mIsClusterUsed = {}; // flag for used clusters
+  double mBeamX = 0.;                    // beam transverse coordindates
+  double mBeamY = 0.;                    // beam transverse coordindates
+  double mMaxDeltaThetaTracklet = 0.6;   // selections for tracklet building
+  double mMaxDeltaPhiTracklet = 0.05;    // selections for tracklet building
+  double mMaxDeltaTanLamInOut = 1.;      // selections for tracklet validation
+  double mMaxDeltaPhiInOut = 0.2;        // selections for tracklet validation
+  double mMaxDeltaPxPzInOut = 99.;       // selections for tracklet validation
+  double mMaxDeltaPyPzInOut = 0.005;     // selections for tracklet validation
+  short mRecoType = kYZ;                 // method to compute tracklet intersections with beam axis
+  double mMaxDCAxy = 0.25;               // selection for tracklet intersection, cm
+  short mMethod = kKDE;                  // method for peak finding (KDE vs histo)
+  int mWeightedMeanOption = kNoWeight;   // option for weigthed mean
+  double mZMin = -20.0;                  // z range, min, cm
+  double mZMax = 5.;                     // z range, max, cm
+  double mZWindowWidth = 1.25;           // window around peak, cm
+  int mNBinsForPeakFind = 250;           // 0.1 cm per bin
+  double mBinWidth = 0.1;                // default value
+  std::vector<int> mHistIntersec;        // histogram for the peak finding method
+  int mPeakWidthBins = 3;
+  int mMinCountsInPeak = 3;
+  int mKDEOption = kAdaptiveKDE;
+  int mNGridKDE = 500;
+  double mKDEWidth = 0.5; // smoothing parameter, cm
+  bool mVerbose = false;
+
+  ClassDefNV(NA6PVertexerTracklets, 1);
+};
+
+#endif

--- a/rec/src/NA6PReconstruction.cxx
+++ b/rec/src/NA6PReconstruction.cxx
@@ -62,6 +62,26 @@ void NA6PReconstruction::closeClustersOutput()
   LOGP(warning, "closeClustersOutput called for {}, this should not happen", getName());
 }
 
+void NA6PReconstruction::createVerticesOutput()
+{
+  LOGP(warning, "createVerticesOutput called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::clearVertices()
+{
+  LOGP(warning, "clearVertices called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::writeVertices()
+{
+  LOGP(warning, "writeVertices called for {}, this should not happen", getName());
+}
+
+void NA6PReconstruction::closeVerticesOutput()
+{
+  LOGP(warning, "closeVerticesOutput called for {}, this should not happen", getName());
+}
+
 void NA6PReconstruction::createTracksOutput()
 {
   LOGP(warning, "createTracksOutput called for {}, this should not happen", getName());
@@ -81,4 +101,3 @@ void NA6PReconstruction::closeTracksOutput()
 {
   LOGP(warning, "closeTracksOutput called for {}, this should not happen", getName());
 }
-

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -6,9 +6,16 @@
 #include <fairlogger/Logger.h>
 #include "NA6PVerTelHit.h"
 #include "NA6PTrackerCA.h"
+#include "NA6PVertexerTracklets.h"
 #include "NA6PVerTelReconstruction.h"
 
 ClassImp(NA6PVerTelReconstruction)
+
+  NA6PVerTelReconstruction::NA6PVerTelReconstruction() : NA6PReconstruction("VerTel")
+{
+  mVTTrackletVertexer = new NA6PVertexerTracklets();
+  createVerticesOutput();
+}
 
 bool NA6PVerTelReconstruction::init(const char* filename, const char* geoname)
 {
@@ -33,7 +40,7 @@ void NA6PVerTelReconstruction::writeClusters()
   if (mClusTree) {
     mClusTree->Fill();
   }
-  LOGP(info, "Saved {} clusters in tree with {} entries", mClusters.size(),mClusTree->GetEntries());
+  LOGP(info, "Saved {} clusters in tree with {} entries", mClusters.size(), mClusTree->GetEntries());
 }
 
 void NA6PVerTelReconstruction::closeClustersOutput()
@@ -52,7 +59,7 @@ void NA6PVerTelReconstruction::closeClustersOutput()
 void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>& vtHits)
 {
   int nHits = vtHits.size();
-  for(int jHit = 0; jHit < nHits; ++jHit) {
+  for (int jHit = 0; jHit < nHits; ++jHit) {
     const auto& hit = vtHits[jHit];
     double x = hit.getX();
     double y = hit.getY();
@@ -60,26 +67,68 @@ void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>&
     double ex2clu = 5.e-4;
     double ey2clu = 5.e-4;
     if (mCluRes > 0) {
-      x = gRandom->Gaus(hit.getX(),mCluRes);
-      y = gRandom->Gaus(hit.getY(),mCluRes);
-      ex2clu = mCluRes*mCluRes;
-      ey2clu = mCluRes*mCluRes;
+      x = gRandom->Gaus(hit.getX(), mCluRes);
+      y = gRandom->Gaus(hit.getY(), mCluRes);
+      ex2clu = mCluRes * mCluRes;
+      ey2clu = mCluRes * mCluRes;
     }
     double eloss = hit.getHitValue();
     // very rough cluster size settings
     int clusiz = 2;
-    if (eloss > 2.e-5 && eloss < 5.e-5) clusiz = 3;
-    else if (eloss > 5.e-5) clusiz = 4;
-    int nDet=hit.getDetectorID();
-    int idPart=hit.getTrackID();    
+    if (eloss > 2.e-5 && eloss < 5.e-5)
+      clusiz = 3;
+    else if (eloss > 5.e-5)
+      clusiz = 4;
+    int nDet = hit.getDetectorID();
+    int idPart = hit.getTrackID();
     mClusters.emplace_back(x, y, z, clusiz);
     auto& clu = mClusters.back();
-    clu.setErr(ex2clu,0.,ey2clu);
+    clu.setErr(ex2clu, 0., ey2clu);
     clu.setDetectorID(nDet);
     clu.setParticleID(idPart);
-    clu.setHitID(jHit);    
+    clu.setHitID(jHit);
   }
 }
+
+//____________________________________________________________________________________
+
+void NA6PVerTelReconstruction::createVerticesOutput()
+{
+  auto nm = fmt::format("Vertices{}.root", getName());
+  mVertexFile = TFile::Open(nm.c_str(), "recreate");
+  mVertexTree = new TTree(fmt::format("vertices{}", getName()).c_str(), fmt::format("{} Vertices", getName()).c_str());
+  mVertexTree->Branch(getName().c_str(), &hVerticesPtr);
+  LOGP(info, "Will store {} vertices in {}", getName(), nm);
+}
+
+void NA6PVerTelReconstruction::writeVertices()
+{
+  if (mVertexTree) {
+    mVertexTree->Fill();
+  }
+  LOGP(info, "Saved {} vertices in tree with {} entries", mVertices.size(), mVertexTree->GetEntries());
+}
+
+void NA6PVerTelReconstruction::closeVerticesOutput()
+{
+  if (mVertexTree && mVertexFile) {
+    mVertexFile->cd();
+    mVertexTree->Write();
+    delete mVertexTree;
+    mVertexTree = nullptr;
+    mVertexFile->Close();
+    delete mVertexFile;
+    mVertexFile = nullptr;
+  }
+}
+
+void NA6PVerTelReconstruction::runVertexerTracklets()
+{
+  clearVertices();
+  mVTTrackletVertexer->findVertices(mClusters, mVertices);
+  writeVertices();
+}
+//____________________________________________________________________________________
 
 void NA6PVerTelReconstruction::createTracksOutput()
 {
@@ -95,7 +144,7 @@ void NA6PVerTelReconstruction::writeTracks()
   if (mTrackTree) {
     mTrackTree->Fill();
   }
-  LOGP(info, "Saved {} tracks in tree with {} entries", mTracks.size(),mTrackTree->GetEntries());
+  LOGP(info, "Saved {} tracks in tree with {} entries", mTracks.size(), mTrackTree->GetEntries());
 }
 
 void NA6PVerTelReconstruction::closeTracksOutput()
@@ -113,12 +162,12 @@ void NA6PVerTelReconstruction::closeTracksOutput()
 
 void NA6PVerTelReconstruction::runTracking()
 {
-  if (!mIsInitialized){
-    LOGP(error,"Magnetic field and geometry not initialized");
+  if (!mIsInitialized) {
+    LOGP(error, "Magnetic field and geometry not initialized");
     return;
   }
   clearTracks();
-  mVTTracker->findTracks(mClusters,mPrimaryVertex);
+  mVTTracker->findTracks(mClusters, mPrimaryVertex);
   mTracks = mVTTracker->getTracks();
   writeTracks();
 }

--- a/rec/src/NA6PVertexerTracklets.cxx
+++ b/rec/src/NA6PVertexerTracklets.cxx
@@ -1,0 +1,700 @@
+// NA6PCCopyright
+
+#include <fmt/format.h>
+#include <fairlogger/Logger.h>
+#include "NA6PBaseCluster.h"
+#include "NA6PVertex.h"
+#include "NA6PVertexerTracklets.h"
+
+ClassImp(NA6PVertexerTracklets)
+
+  NA6PVertexerTracklets::NA6PVertexerTracklets()
+{
+  configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
+}
+
+//______________________________________________________________________
+
+void NA6PVertexerTracklets::sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,
+                                                      std::vector<int>& firstIndex,
+                                                      std::vector<int>& lastIndex)
+{
+  // count hits per layer
+  std::vector<int> count(mNLayersVT, 0);
+  for (const auto& clu : cluArr) {
+    int jDet = clu.getDetectorID();
+    int jLay = jDet / 4;
+    if (jLay >= 0 && jLay < mNLayersVT) {
+      count[jLay]++;
+    }
+  }
+  // starting offset for each layer
+  firstIndex.resize(mNLayersVT);
+  lastIndex.resize(mNLayersVT);
+  firstIndex[0] = 0;
+  lastIndex[0] = count[0];
+  for (int jLay = 1; jLay < mNLayersVT; jLay++) {
+    firstIndex[jLay] = firstIndex[jLay - 1] + count[jLay - 1];
+    lastIndex[jLay] = firstIndex[jLay] + count[jLay];
+  }
+  // Create a reordered vector based on layer grouping
+  std::vector<int> countReord = firstIndex;
+  std::vector<NA6PBaseCluster> reordered(cluArr.size());
+  for (const auto& clu : cluArr) {
+    int jLay = clu.getDetectorID() / 4;
+    if (jLay >= 0 && jLay < mNLayersVT)
+      reordered[countReord[jLay]++] = clu;
+  }
+  cluArr = std::move(reordered);
+  // sort by theta within each layer (use z^2/r^2 as a proxy of theta to avoid sqrt and atan)
+  for (int jLay = 0; jLay < mNLayersVT; jLay++) {
+    auto first = cluArr.begin() + firstIndex[jLay];
+    auto last = cluArr.begin() + lastIndex[jLay];
+    std::sort(first, last, [](const NA6PBaseCluster& a, const NA6PBaseCluster& b) {
+      double xa = a.getX();
+      double ya = a.getY();
+      double za = a.getZ();
+      double xb = b.getX();
+      double yb = b.getY();
+      double zb = b.getZ();
+      double r2a = xa * xa + ya * ya;
+      double r2b = xb * xb + yb * yb;
+      return za * za * r2b < zb * zb * r2a;
+    });
+  }
+}
+
+//______________________________________________________________________
+
+void NA6PVertexerTracklets::sortTrackletsByLayerAndIndex(std::vector<TrackletForVertex>& tracklets,
+                                                         std::vector<int>& firstIndex,
+                                                         std::vector<int>& lastIndex)
+{
+  // count clusters per layer
+  std::vector<int> count(mNLayersVT - 1, 0);
+  for (const auto& trkl : tracklets) {
+    int jLay = trkl.startingLayer;
+    if (jLay >= 0 && jLay < mNLayersVT - 1) {
+      count[jLay]++;
+    }
+  }
+  // starting offset for each layer
+  firstIndex.resize(mNLayersVT - 1);
+  lastIndex.resize(mNLayersVT - 1);
+  firstIndex[0] = 0;
+  lastIndex[0] = count[0];
+  for (int jLay = 1; jLay < mNLayersVT - 1; jLay++) {
+    firstIndex[jLay] = firstIndex[jLay - 1] + count[jLay - 1];
+    lastIndex[jLay] = firstIndex[jLay] + count[jLay];
+  }
+  // Create a reordered vector based on layer grouping
+  std::vector<int> countReord = firstIndex;
+  std::vector<TrackletForVertex> reordered(tracklets.size());
+  for (const auto& trkl : tracklets) {
+    int jLay = trkl.startingLayer;
+    if (jLay >= 0 && jLay < mNLayersVT - 1)
+      reordered[countReord[jLay]++] = trkl;
+  }
+  tracklets = std::move(reordered);
+  // sort by cluster index within each layer
+  for (int jLay = 0; jLay < mNLayersVT - 1; jLay++) {
+    auto first = tracklets.begin() + firstIndex[jLay];
+    auto last = tracklets.begin() + lastIndex[jLay];
+    std::sort(first, last, [](const TrackletForVertex& a, const TrackletForVertex& b) {
+      return a.firstClusterIndex < b.firstClusterIndex || (a.firstClusterIndex == b.firstClusterIndex && a.secondClusterIndex < b.secondClusterIndex);
+    });
+  }
+}
+
+//______________________________________________________________________
+
+void NA6PVertexerTracklets::computeLayerTracklets(const std::vector<NA6PBaseCluster>& cluArr,
+                                                  const std::vector<int>& firstIndex,
+                                                  const std::vector<int>& lastIndex,
+                                                  std::vector<TrackletForVertex>& tracklets)
+{
+
+  tracklets.clear();
+
+  for (int iLayer = mLayerToStart; iLayer < mLayerToStart + 2; ++iLayer) {
+    auto layerBegin = cluArr.begin() + firstIndex[iLayer + 1];
+    auto layerEnd = cluArr.begin() + lastIndex[iLayer + 1];
+    for (int jClu1 = firstIndex[iLayer]; jClu1 < lastIndex[iLayer]; ++jClu1) {
+      const NA6PBaseCluster& clu1 = cluArr[jClu1];
+      double x1 = clu1.getX();
+      double y1 = clu1.getY();
+      double z1 = clu1.getZ();
+      double r1 = std::sqrt(x1 * x1 + y1 * y1);
+      double theta1 = std::atan2(z1, r1);
+      double phi1 = std::atan2(y1, x1);
+      double tanth2Min = std::max(0., std::tan(theta1 - 1.2 * mMaxDeltaThetaTracklet)); // 1.2 is a safety margin
+      double tanth2Max = std::tan(std::min(M_PI / 2.001, theta1 + 1.2 * mMaxDeltaThetaTracklet));
+      auto lower = std::partition_point(layerBegin, layerEnd,
+                                        [&](const NA6PBaseCluster& clu) {
+                                          double x = clu.getX();
+                                          double y = clu.getY();
+                                          double z = clu.getZ();
+                                          double r2 = x * x + y * y;
+                                          double tan2 = z * z / r2;
+                                          return tan2 < tanth2Min * tanth2Min;
+                                        });
+
+      auto upper = std::partition_point(layerBegin, layerEnd,
+                                        [&](const NA6PBaseCluster& clu) {
+                                          double x = clu.getX();
+                                          double y = clu.getY();
+                                          double z = clu.getZ();
+                                          double r2 = x * x + y * y;
+                                          double tan2 = z * z / r2;
+                                          return tan2 <= tanth2Max * tanth2Max;
+                                        });
+      int lowerIdx = std::distance(cluArr.begin(), lower);
+      int upperIdx = std::distance(cluArr.begin(), upper);
+      for (int jClu2 = lowerIdx; jClu2 < upperIdx; ++jClu2) {
+        const NA6PBaseCluster& clu2 = cluArr[jClu2];
+        double x2 = clu2.getX();
+        double y2 = clu2.getY();
+        double z2 = clu2.getZ();
+        double r2 = std::sqrt(x2 * x2 + y2 * y2);
+        double theta2 = std::atan2(z2, r2);
+        double phi2 = std::atan2(y2, x2);
+        double dphi = phi2 - phi1;
+        if (dphi > M_PI)
+          dphi -= 2 * M_PI;
+        else if (dphi < -M_PI)
+          dphi += 2 * M_PI;
+        if (std::abs(theta2 - theta1) < mMaxDeltaThetaTracklet && std::abs(dphi) < mMaxDeltaPhiTracklet) {
+          double phi = std::atan2(y2 - y1, x2 - x1);
+          double tanL = (z2 - z1) / (r2 - r1);
+          double pxpz = (x2 - x1) / (z2 - z1);
+          double pypz = (y2 - y1) / (z2 - z1);
+          bool signal = false;
+          if (clu1.getParticleID() == clu2.getParticleID())
+            signal = true;
+          tracklets.emplace_back(iLayer, jClu1, jClu2, tanL, phi, pxpz, pypz, signal);
+        }
+      }
+    }
+  }
+}
+
+//______________________________________________________________________
+
+void NA6PVertexerTracklets::selectTracklets(const std::vector<TrackletForVertex>& tracklets,
+                                            const std::vector<int>& firstIndex,
+                                            const std::vector<int>& lastIndex,
+                                            const std::vector<NA6PBaseCluster>& cluArr,
+                                            std::vector<TrackletForVertex>& selTracklets)
+{
+
+  selTracklets.clear();
+  int iLayer = mLayerToStart;
+  auto layer1Begin = tracklets.begin() + firstIndex[iLayer + 1];
+  auto layer1End = tracklets.begin() + lastIndex[iLayer + 1];
+  std::vector<bool> isTrackletSelected;
+  isTrackletSelected.reserve(lastIndex[iLayer] - firstIndex[iLayer]);
+  for (int jTrkl0 = firstIndex[iLayer]; jTrkl0 < lastIndex[iLayer]; ++jTrkl0) {
+    isTrackletSelected[jTrkl0] = false;
+    const TrackletForVertex& trkl01 = tracklets[jTrkl0];
+    const int nextLayerClusterIndex = trkl01.secondClusterIndex;
+    auto lower = std::partition_point(layer1Begin, layer1End,
+                                      [&](const TrackletForVertex& trkl) {
+                                        return trkl.firstClusterIndex < nextLayerClusterIndex;
+                                      });
+    auto upper = std::partition_point(layer1Begin, layer1End,
+                                      [&](const TrackletForVertex& trkl) {
+                                        return trkl.firstClusterIndex <= nextLayerClusterIndex;
+                                      });
+    for (auto it = lower; it != upper; ++it) {
+      const TrackletForVertex& trkl12 = *it;
+      if (trkl12.firstClusterIndex != nextLayerClusterIndex)
+        continue;
+      const double deltaTanLambda = std::abs(trkl12.tanL - trkl01.tanL);
+      double dphi = trkl12.phi - trkl01.phi;
+      if (dphi > M_PI)
+        dphi -= 2 * M_PI;
+      else if (dphi < -M_PI)
+        dphi += 2 * M_PI;
+      double deltapxpz = std::abs(trkl12.pxpz - trkl01.pxpz);
+      double deltapypz = std::abs(trkl12.pypz - trkl01.pypz);
+      if (deltapypz < mMaxDeltaPyPzInOut && deltapxpz < mMaxDeltaPxPzInOut && deltaTanLambda < mMaxDeltaTanLamInOut && std::abs(dphi) < mMaxDeltaPhiInOut) {
+        // if(trkl01.isSignal) isTrackletSelected[jTrkl0] = true;
+        isTrackletSelected[jTrkl0] = true;
+      }
+    }
+    if (isTrackletSelected[jTrkl0])
+      selTracklets.push_back(std::move(trkl01));
+  }
+}
+
+//______________________________________________________________________
+
+void NA6PVertexerTracklets::filterOutUsedTracklets(const std::vector<TrackletForVertex>& tracklets,
+                                                   std::vector<TrackletForVertex>& usableTracklets)
+{
+  usableTracklets.clear();
+  for (auto trkl : tracklets) {
+    if (mIsClusterUsed[trkl.firstClusterIndex] || mIsClusterUsed[trkl.secondClusterIndex])
+      continue;
+    usableTracklets.push_back(std::move(trkl));
+  }
+}
+
+//______________________________________________________________________
+
+void NA6PVertexerTracklets::computeIntersections(const std::vector<TrackletForVertex>& selTracklets,
+                                                 const std::vector<NA6PBaseCluster>& cluArr,
+                                                 std::vector<TracklIntersection>& zIntersec)
+{
+  zIntersec.clear();
+  for (auto& trkl : selTracklets) {
+    auto clu0 = cluArr[trkl.firstClusterIndex];
+    auto clu1 = cluArr[trkl.secondClusterIndex];
+    double x0 = clu0.getX();
+    double y0 = clu0.getY();
+    double z0 = clu0.getZ();
+    double x1 = clu1.getX();
+    double y1 = clu1.getY();
+    double z1 = clu1.getZ();
+    double sigmayClu0 = std::sqrt(clu0.getSigYY());
+    double sigmayClu1 = std::sqrt(clu1.getSigYY());
+    double dx = x1 - x0;
+    double dy = y1 - y0;
+    double dz = z1 - z0;
+    double zi = -99999.;
+    double sigmazi = 0.1;
+    switch (mRecoType) {
+      case kYZ: {
+        // work in the yz plane (non bending) to use straight line approximation of traks
+        // slo = dy/dz  y = slo*z + q --> q = y0-slo*z0 --> zv = -q/slo = z0 - y0/slo
+        double slo = dy / dz;
+        zi = z0 - y0 / slo;
+        double sigmaSlo = std::sqrt(sigmayClu0 * sigmayClu0 + sigmayClu1 * sigmayClu1) / std::abs(dz);
+        double invSlo = 1.0 / slo;
+        double term1 = (sigmayClu0 * invSlo) * (sigmayClu0 * invSlo);
+        double term2 = (y0 * sigmaSlo / (slo * slo)) * (y0 * sigmaSlo / (slo * slo));
+        sigmazi = std::sqrt(term1 + term2);
+        break;
+      }
+      case kXZ: {
+        // work in the xz plane (bending) just for debug purposes
+        double slo = dx / dz;
+        zi = z0 - x0 / slo;
+        break;
+      }
+      case kRZ: {
+        // solution in the r/z plane (as in AliRoot)
+        double r0 = std::sqrt(x0 * x0 + y0 * y0);
+        double r1 = std::sqrt(x1 * x1 + y1 * y1);
+        double slo = (r1 - r0) / (z1 - z0);
+        // r = slo * z + q --> q = r0 - slo * z0 --> slo * zv + q = = --> zv = -q/slo = -(r0 - slo*z0)/slo = z0 - r0/slo
+        zi = z0 - r0 / slo;
+        break;
+      }
+      case k3D: {
+        // 3D solution for DCA between lines
+        double denomXY = dx * dx + dy * dy;
+        if (denomXY < 1e-8)
+          continue;
+        double tBeam = -((x0 - mBeamX) * dx + (y0 - mBeamY) * dy) / denomXY;
+        double xi = x0 + tBeam * dx;
+        double yi = y0 + tBeam * dy;
+        double ri2 = xi * xi + yi * yi;
+        if (ri2 > mMaxDCAxy * mMaxDCAxy)
+          continue;
+        zi = z0 + tBeam * dz;
+        double sigmaDCA = sigmayClu0 * std::sqrt(2.0) * (1.0 + std::abs(tBeam));
+        sigmazi = sigmaDCA * std::abs(dz) / std::sqrt(denomXY);
+        break;
+      }
+      default:
+        LOGP(error, "wrong option for vertex reco");
+        continue;
+    }
+
+    if (zi >= mZMin && zi < mZMax)
+      zIntersec.emplace_back(zi, sigmazi, trkl.tanL, trkl.firstClusterIndex, trkl.secondClusterIndex);
+  }
+}
+
+//______________________________________________________________________
+
+bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>& zIntersec,
+                                                std::vector<NA6PVertex>& vertices)
+{
+  std::fill(mHistIntersec.begin(), mHistIntersec.end(), 0.0);
+  for (const auto& zInt : zIntersec) {
+    double zi = zInt.zeta;
+    if (zi >= mZMin && zi < mZMax) {
+      int bin = int((zi - mZMin) / mBinWidth);
+      mHistIntersec[bin]++;
+    }
+  }
+  // find peak (case of multiple peaks with same height is treated)
+  int maxHeight = 0;
+  for (int jBin = 0; jBin < mNBinsForPeakFind; ++jBin) {
+    if (mHistIntersec[jBin] > maxHeight)
+      maxHeight = mHistIntersec[jBin];
+  }
+  if (maxHeight == 0 || maxHeight < mMinCountsInPeak)
+    return false;
+
+  std::vector<std::pair<int, int>> peaks;
+  for (int jBin = 0; jBin < mNBinsForPeakFind; ++jBin) {
+    if (mHistIntersec[jBin] == maxHeight) {
+      int lowBin = std::max(jBin - mPeakWidthBins, 0);
+      int highBin = std::min(jBin + mPeakWidthBins, mNBinsForPeakFind - 1);
+      double integral = 0;
+      for (int jPeak = lowBin; jPeak <= highBin; ++jPeak)
+        integral += mHistIntersec[jPeak];
+      peaks.push_back(std::make_pair(jBin, integral));
+    }
+  }
+  int nPeaks = peaks.size();
+  if (nPeaks == 0)
+    return false;
+  std::sort(peaks.begin(), peaks.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
+  int nPeaksSameIntegral = 0;
+  int jMainPeak = -1;
+  if (nPeaks > 1) {
+    // check integrals around peak to define the "main" peak
+    int integralMainPeak = 0;
+    for (int jp = 0; jp < nPeaks; ++jp) {
+      if (peaks[jp].second > integralMainPeak) {
+        integralMainPeak = peaks[jp].second;
+        jMainPeak = jp;
+      }
+    }
+    for (int jp = 0; jp < nPeaks; ++jp) {
+      if (peaks[jp].second == integralMainPeak)
+        ++nPeaksSameIntegral;
+    }
+  } else if (nPeaks == 1) {
+    jMainPeak = 0;
+    nPeaksSameIntegral = 1;
+  }
+  double zPeak, zWinMin, zWinMax;
+  bool peakFound = false;
+  if (jMainPeak >= 0 && (nPeaks == 1 || (nPeaks > 1 && nPeaksSameIntegral == 1))) {
+    // compute the z position for the peak
+    zPeak = mZMin + (peaks[jMainPeak].first + 0.5) * mBinWidth;
+    zWinMin = zPeak - mZWindowWidth;
+    zWinMax = zPeak + mZWindowWidth;
+    peakFound = true;
+  } else {
+    //  merge adjacent peaks
+    struct Cluster {
+      int integral = 0;
+      int firstBin = -1;
+      int lastBin = -1;
+    };
+    std::vector<Cluster> clusters;
+    Cluster cur;
+    cur.integral = peaks[0].second;
+    cur.firstBin = peaks[0].first;
+    cur.lastBin = peaks[0].first;
+    for (int jPk = 1; jPk < nPeaks; ++jPk) {
+      int prev = peaks[jPk - 1].first;
+      int curr = peaks[jPk].first;
+      if (std::abs(curr - prev) < mPeakWidthBins) {
+        cur.integral += peaks[jPk].second;
+        cur.lastBin = curr;
+      } else {
+        clusters.push_back(cur);
+        cur.integral = peaks[jPk].second;
+        cur.firstBin = peaks[jPk].first;
+        cur.lastBin = peaks[jPk].first;
+      }
+    }
+    clusters.push_back(cur);
+    int jLargestClu = 0;
+    int maxIntegral = clusters[0].integral;
+    bool ambiguous = false;
+    for (int jClu = 1; jClu < (int)clusters.size(); ++jClu) {
+      if (clusters[jClu].integral > maxIntegral) {
+        maxIntegral = clusters[jClu].integral;
+        jLargestClu = jClu;
+        ambiguous = false;
+      } else if (clusters[jClu].integral == maxIntegral) {
+        ambiguous = true;
+      }
+    }
+    if (!ambiguous) {
+      double zFirst = mZMin + (clusters[jLargestClu].firstBin + 0.5) * mBinWidth;
+      double zLast = mZMin + (clusters[jLargestClu].lastBin + 0.5) * mBinWidth;
+      zPeak = 0.5 * (zFirst + zLast);
+      zWinMin = zFirst - mZWindowWidth;
+      zWinMax = zLast + mZWindowWidth;
+      peakFound = true;
+    }
+  }
+  if (!peakFound) {
+    // resort to use the lowest z peak
+    zPeak = mZMin + (peaks[0].first + 0.5) * mBinWidth;
+    zWinMin = zPeak - mZWindowWidth;
+    zWinMax = zPeak + mZWindowWidth;
+  }
+  std::sort(zIntersec.begin(), zIntersec.end(),
+            [](const TracklIntersection& a, const TracklIntersection& b) {
+              return a.zeta < b.zeta;
+            });
+  // std::sort(zIntersec.begin(),zIntersec.end());
+  auto lower = std::lower_bound(zIntersec.begin(), zIntersec.end(), zWinMin,
+                                [](const TracklIntersection& a, double value) {
+                                  return a.zeta < value;
+                                });
+
+  auto upper = std::upper_bound(zIntersec.begin(), zIntersec.end(), zWinMax,
+                                [](double value, const TracklIntersection& a) {
+                                  return value < a.zeta;
+                                });
+  int nContrib = 0;
+  double sumZ = 0.;
+  double sumZW = 0.;
+  double sumW = 0.;
+  for (auto it = lower; it != upper; ++it) {
+    double zp = it->zeta;
+    double w = 1.0 / (1.0 + it->tanl * it->tanl);
+    if (mWeightedMeanOption == kSigma)
+      w = 1.0 / (it->sigmazeta * it->sigmazeta);
+    sumZ += zp;
+    sumZW += zp * w;
+    sumW += w;
+    ++nContrib;
+  }
+  double zMean;
+  if (mWeightedMeanOption == kNoWeight) {
+    zMean = (nContrib > 0) ? sumZ / (double)nContrib : 0.0;
+  } else {
+    zMean = (sumW > 0) ? sumZW / sumW : 0.0;
+  }
+  // second average with better centered window
+  zWinMin = zMean - mZWindowWidth;
+  zWinMax = zMean + mZWindowWidth;
+  lower = std::lower_bound(zIntersec.begin(), zIntersec.end(), zWinMin,
+                           [](const TracklIntersection& a, double value) {
+                             return a.zeta < value;
+                           });
+
+  upper = std::upper_bound(zIntersec.begin(), zIntersec.end(), zWinMax,
+                           [](double value, const TracklIntersection& a) {
+                             return value < a.zeta;
+                           });
+  nContrib = 0;
+  sumZ = 0.;
+  sumZW = 0.;
+  sumW = 0.;
+  for (auto it = lower; it != upper; ++it) {
+    double zp = it->zeta;
+    double w = 1.0 / (1.0 + it->tanl * it->tanl);
+    if (mWeightedMeanOption == kSigma)
+      w = 1.0 / (it->sigmazeta * it->sigmazeta);
+    sumZ += zp;
+    sumZW += zp * w;
+    sumW += w;
+    // assign the clusters as used (needed for pileup searches)
+    mIsClusterUsed[it->firstClusterIndex] = true;
+    mIsClusterUsed[it->secondClusterIndex] = true;
+    ++nContrib;
+  }
+  if (mWeightedMeanOption == kNoWeight) {
+    zMean = (nContrib > 0) ? sumZ / (double)nContrib : 0.0;
+  } else {
+    zMean = (sumW > 0) ? sumZW / sumW : 0.0;
+  }
+  double pos[3] = {mBeamX, mBeamY, zMean};
+  NA6PVertex vert(pos, nContrib);
+  vert.setVertexType(NA6PVertex::kTrackletPrimaryVertex);
+  vertices.push_back(vert);
+  return true;
+}
+
+//______________________________________________________________________
+
+bool NA6PVertexerTracklets::findVertexKDE(const std::vector<TracklIntersection>& zIntersec,
+                                          std::vector<NA6PVertex>& vertices)
+{
+  // KDE-based vertex finder
+  if (zIntersec.empty())
+    return false;
+
+  // Prepare grid
+  std::vector<double> gridZ(mNGridKDE);
+  double dz = (mZMax - mZMin) / (mNGridKDE - 1);
+  for (int jg = 0; jg < mNGridKDE; ++jg)
+    gridZ[jg] = mZMin + jg * dz;
+  // Evaluate KDE at each grid point
+  std::vector<double> fkde(mNGridKDE, 0.0);
+  for (int jg = 0; jg < mNGridKDE; ++jg) {
+    double z = gridZ[jg];
+    double sum = 0.0;
+    double sumW = 0.0;
+    double sumGW = 0.0;
+    for (const auto& zInt : zIntersec) {
+      double zi = zInt.zeta;
+      double sigma = mKDEWidth;
+      if (mKDEOption == kAdaptiveKDE)
+        sigma = std::sqrt(mKDEWidth * mKDEWidth + zInt.sigmazeta * zInt.sigmazeta);
+      double u = (z - zi) / sigma;
+      double g = gaussKernel(u);
+      double w = 1.0 / (1.0 + zInt.tanl * zInt.tanl);
+      if (mKDEOption == kStandardKDE && mWeightedMeanOption == kSigma)
+        w = 1.0 / (zInt.sigmazeta * zInt.sigmazeta);
+      sum += g;
+      sumGW += w * g;
+      sumW += w;
+    }
+    if (mKDEOption == kAdaptiveKDE || mWeightedMeanOption == kNoWeight) {
+      fkde[jg] = sum;
+    } else {
+      fkde[jg] = (sumW > 0 ? sumGW / sumW : 0.0);
+    }
+  }
+  // Find global maximum on the grid
+  double fMax = -1.0;
+  int jMax = -1;
+  for (int jg = 0; jg < mNGridKDE; ++jg) {
+    if (fkde[jg] > fMax) {
+      fMax = fkde[jg];
+      jMax = jg;
+    }
+  }
+  if (jMax < 0)
+    return false;
+  // Quadratic interpolation for sub-grid precision
+  double zPeak = gridZ[jMax];
+  if (jMax > 0 && jMax < mNGridKDE - 1) {
+    double f0 = fkde[jMax - 1];
+    double f1 = fkde[jMax];
+    double f2 = fkde[jMax + 1];
+    double denom = 2. * (f0 - 2. * f1 + f2);
+    if (std::abs(denom) > 1e-12) {
+      double delta = (f0 - f2) / denom;
+      zPeak += delta * dz;
+    }
+  }
+  // check peak height in small bin
+  int nInPeak = 0;
+  for (const auto& zInt : zIntersec) {
+    double zi = zInt.zeta;
+    if (zi > zPeak - 0.5 * mBinWidth && zi < zPeak + 0.5 * mBinWidth)
+      ++nInPeak;
+  }
+  if (nInPeak < mMinCountsInPeak)
+    return false;
+
+  // count contributors and mark used hits
+  double zWinMin = zPeak - mZWindowWidth;
+  double zWinMax = zPeak + mZWindowWidth;
+  int nContrib = 0;
+  for (const auto& zInt : zIntersec) {
+    double zi = zInt.zeta;
+    if (zi > zWinMin && zi < zWinMax) {
+      ++nContrib;
+      mIsClusterUsed[zInt.firstClusterIndex] = true;
+      mIsClusterUsed[zInt.secondClusterIndex] = true;
+    }
+  }
+  double pos[3] = {mBeamX, mBeamY, zPeak};
+  NA6PVertex vert(pos, nContrib);
+  vert.setVertexType(NA6PVertex::kTrackletPrimaryVertex);
+  vertices.push_back(vert);
+  return true;
+}
+
+//______________________________________________________________________
+
+void NA6PVertexerTracklets::findVertices(std::vector<NA6PBaseCluster>& cluArr,
+                                         std::vector<NA6PVertex>& vertices)
+{
+
+  uint nClus = cluArr.size();
+  LOGP(info, "Process event with nClusters {}", nClus);
+  resetClusters(nClus);
+  std::vector<TracklIntersection> zIntersec;
+  std::vector<int> firstCluPerLay;
+  std::vector<int> lastCluPerLay;
+  sortClustersByLayerAndEta(cluArr, firstCluPerLay, lastCluPerLay);
+  std::vector<TrackletForVertex> allTracklets;
+  std::vector<TrackletForVertex> selTracklets;
+  computeLayerTracklets(cluArr, firstCluPerLay, lastCluPerLay, allTracklets);
+  std::vector<int> firstTrklPerLay;
+  std::vector<int> lastTrklPerLay;
+  sortTrackletsByLayerAndIndex(allTracklets, firstTrklPerLay, lastTrklPerLay);
+  if (mVerbose)
+    printStats(allTracklets, cluArr, "tracklets");
+  selectTracklets(allTracklets, firstTrklPerLay, lastTrklPerLay, cluArr, selTracklets);
+  if (mVerbose)
+    printStats(selTracklets, cluArr, "selected tracklets");
+  computeIntersections(selTracklets, cluArr, zIntersec);
+  bool retCode;
+  if (mMethod == kKDE)
+    retCode = findVertexKDE(zIntersec, vertices);
+  else
+    retCode = findVertexHistoPeak(zIntersec, vertices);
+
+  // pileup detection
+  std::vector<TrackletForVertex> remainingTracklets;
+  for (int jPil = 0; jPil < kMaxPileupVertices; jPil++) {
+    filterOutUsedTracklets(selTracklets, remainingTracklets);
+    if (mVerbose)
+      printStats(remainingTracklets, cluArr, "remaining tracklets");
+    computeIntersections(remainingTracklets, cluArr, zIntersec);
+    if (mMethod == kKDE)
+      retCode = findVertexKDE(zIntersec, vertices);
+    else
+      retCode = findVertexHistoPeak(zIntersec, vertices);
+    if (!retCode)
+      break;
+    selTracklets.swap(remainingTracklets);
+  }
+  if (mVerbose) {
+    int nVertices = vertices.size();
+    LOGP(info, "Number of reconstructed vertices = {}", nVertices);
+    int jv = 0;
+    for (auto vert : vertices)
+      LOGP(info, "Vertex %d, z = %f nContrib = %d\n", jv++, vert.getZ(), vert.getNContributors());
+  }
+}
+
+//______________________________________________________________________
+void NA6PVertexerTracklets::printStats(const std::vector<TrackletForVertex>& candidates,
+                                       const std::vector<NA6PBaseCluster>& cluArr,
+                                       const std::string& label)
+{
+
+  int nFound = candidates.size();
+  LOGP(info, "Number of {} = {}", label.c_str(), nFound);
+  int nGood = 0;
+  int nSelected = 0;
+  for (int j = 0; j < nFound; ++j) {
+    const auto& tr = candidates[j];
+    int nClus = 2;
+    int idClus[2] = {tr.firstClusterIndex, tr.secondClusterIndex};
+    int startLay = tr.startingLayer;
+    int idPartTrack = -9999999;
+    int nTrueClus = 0;
+    for (int jClu = 0; jClu < nClus; jClu++) {
+      int cluID = idClus[jClu];
+      if (cluID >= 0) {
+        ++nTrueClus;
+        const auto& clu = cluArr[cluID];
+        int jLay = clu.getDetectorID() / 4;
+        if (jClu == 0 && jLay != startLay)
+          LOGP(error, "mismatch in {} layers: {} {}", label.c_str(), jLay, startLay);
+        int idPartClu = clu.getParticleID();
+        if (jClu == 0)
+          idPartTrack = idPartClu;
+        else if (idPartClu != idPartTrack && idPartTrack > 0)
+          idPartTrack *= (-1);
+      }
+    }
+    nSelected++;
+    if (idPartTrack > 0)
+      nGood++;
+  }
+  if (nFound > 0)
+    LOGP(info, "Fraction of good {} = {} / {} = {}",
+         label.c_str(), nGood, nFound, (double)nGood / (double)nFound);
+}

--- a/rec/src/recLinkDef.h
+++ b/rec/src/recLinkDef.h
@@ -16,6 +16,7 @@
 #pragma link C++ class NA6PReconstruction + ;
 #pragma link C++ class NA6PVerTelReconstruction + ;
 #pragma link C++ class ExtTrackPar + ;
+#pragma link C++ class NA6PVertexerTracklets + ;
 #pragma link C++ class NA6PTrackerCA + ;
 #pragma link C++ class NA6PFastTrackFitter + ;
 

--- a/test/inspectVertexerTracklets.C
+++ b/test/inspectVertexerTracklets.C
@@ -1,0 +1,146 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <Riostream.h>
+#include <TString.h>
+#include <TMath.h>
+#include <TTree.h>
+#include <TLegend.h>
+#include <TLegendEntry.h>
+#include <TH1F.h>
+#include <TF1.h>
+#include <TH2F.h>
+#include <TFile.h>
+#include <TCanvas.h>
+#include <TPad.h>
+#include <TPaveStats.h>
+#include <TParticle.h>
+#include <TParticlePDG.h>
+#include <TVectorD.h>
+#include <TRandom3.h>
+#include <TStopwatch.h>
+#include "NA6PBaseCluster.h"
+#include "NA6PVertex.h"
+#include "NA6PVertexerTracklets.h"
+#endif
+
+void inspectVertexerTracklets(int firstEv = 0,
+                              int lastEv = 999999,
+                              const char *dirSimu = "../testN6Proot/pions/latesttag")
+//			const char *dirSimu = "Angantyr") 
+{
+  TFile* fk=new TFile(Form("%s/MCKine.root",dirSimu));
+  TTree* mcTree=(TTree*)fk->Get("mckine");
+  int nEv=mcTree->GetEntries();
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+
+  TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
+  printf("Open cluster file: %s\n",fc->GetName());
+  TTree* tc=(TTree*)fc->Get("clustersVerTel");
+  std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
+  tc->SetBranchAddress("VerTel", &vtClusPtr);
+
+  if(lastEv>nEv || lastEv<0) lastEv=nEv;
+  if(firstEv<0) firstEv=0;
+
+  TH1F* hdz = new TH1F("hdz","",100,-0.5,0.5);
+  TH1F* hncontr = new TH1F("hncontr","",100,-0.5,999.5);
+  TH1F* hnvert = new TH1F("hnvert","",11,-0.5,10.5);
+  TH1D* histocheck = new TH1D("histocheck","",250,-20.,5.);
+  int kMaxPileupVertices = NA6PVertexerTracklets::kMaxPileupVertices;  
+  TH1D* histocheck2[kMaxPileupVertices];
+  for (int jPil = 0; jPil < kMaxPileupVertices; jPil++) {
+    histocheck2[jPil] = new TH1D(Form("histocheckPil%d",jPil+1),"",250,-20.,5.);
+  }
+  TH1F* hSigmaZ = new TH1F("hSigmaZ","",100,0.,10.);
+
+
+  NA6PVertexerTracklets* vertxr = new NA6PVertexerTracklets();
+  
+  for(int jEv=firstEv;jEv<lastEv; jEv++){
+    mcTree->GetEvent(jEv);
+    tc->GetEvent(jEv);
+    int nPart=mcArr->size();
+    double zVertGen = 0;
+    // get primary vertex position from the Kine Tree
+    for(int jp=0; jp<nPart; jp++){
+      auto curPart=mcArr->at(jp);
+      if(curPart.IsPrimary()){
+        zVertGen =  curPart.Vz();
+        break;
+      }
+    }
+    std::vector<TracklIntersection> zIntersec;
+    int nClus=vtClus.size();
+    vertxr->resetClusters(nClus);
+    std::vector<int> firstCluPerLay;
+    std::vector<int> lastCluPerLay;
+    vertxr->sortClustersByLayerAndEta(vtClus,firstCluPerLay,lastCluPerLay);
+    std::vector<TrackletForVertex> allTracklets;
+    std::vector<TrackletForVertex> selTracklets;
+    vertxr->computeLayerTracklets(vtClus,firstCluPerLay,lastCluPerLay,allTracklets);
+    std::vector<int> firstTrklPerLay;
+    std::vector<int> lastTrklPerLay;
+    vertxr->sortTrackletsByLayerAndIndex(allTracklets,firstTrklPerLay,lastTrklPerLay);
+    vertxr->printStats(allTracklets,vtClus,"tracklets");
+    vertxr->selectTracklets(allTracklets,firstTrklPerLay,lastTrklPerLay,vtClus,selTracklets);
+    vertxr->printStats(selTracklets,vtClus,"selected tracklets");
+    vertxr->computeIntersections(selTracklets,vtClus,zIntersec);
+    std::vector<NA6PVertex> zVertices;
+    bool retCode;
+    if(vertxr->getMethodForPeakFinding() == NA6PVertexerTracklets::kKDE) retCode = vertxr->findVertexKDE(zIntersec,zVertices);
+    else retCode = vertxr->findVertexHistoPeak(zIntersec,zVertices);
+    histocheck->Reset("MICE");
+    for (auto zi : zIntersec){
+      histocheck->Fill(zi.zeta);
+      hSigmaZ->Fill(zi.sigmazeta);
+    }
+    int nVertices = zVertices.size();
+    int jv=0;
+    for (auto vert : zVertices) {
+      double zRec = vert.getZ();
+      printf("Vertex %d, z = %f contrib = %d\n",jv++,zRec,vert.getNContributors());
+      hdz->Fill(zRec-zVertGen);
+      hncontr->Fill(vert.getNContributors());
+    }
+    // pileup detection
+    std::vector<TrackletForVertex> remainingTracklets;      
+    for (int jPil = 0; jPil < kMaxPileupVertices; jPil++) {
+      vertxr->filterOutUsedTracklets(selTracklets,remainingTracklets);
+      vertxr->printStats(remainingTracklets,vtClus,"remaining tracklets");
+      vertxr->computeIntersections(remainingTracklets,vtClus,zIntersec);
+      if(vertxr->getMethodForPeakFinding() == NA6PVertexerTracklets::kKDE) retCode = vertxr->findVertexKDE(zIntersec,zVertices);
+      else retCode = vertxr->findVertexHistoPeak(zIntersec,zVertices);
+      histocheck2[jPil]->Reset("MICES");
+      for (auto zi : zIntersec) histocheck2[jPil]->Fill(zi.zeta);
+      if (!retCode) break;
+      selTracklets.swap(remainingTracklets);
+    }
+    nVertices = zVertices.size();
+    hnvert->Fill(nVertices);
+    printf("After pileup search: nVertices = %d\n",nVertices);
+    jv=0;
+    for (auto vert : zVertices) {
+      double zRec = vert.getZ();
+      printf("Vertex %d, z = %f nContrib = %d\n",jv++,zRec,vert.getNContributors());
+    }
+  }
+
+  TCanvas* coutp= new TCanvas("coutp","",1200,800);
+  coutp->Divide(3,2);
+  coutp->cd(1);
+  histocheck->Draw();
+  for (int jPil = 0; jPil < kMaxPileupVertices; jPil++) {
+    if(histocheck2[jPil]->GetEntries() > 0){
+      histocheck2[jPil]->SetLineColor(jPil+2);
+      histocheck2[jPil]->Draw("sames");
+    }
+  }
+  coutp->cd(2);
+  hnvert->Draw();
+  coutp->cd(3);
+  hdz->Draw();
+  coutp->cd(4);
+  hncontr->Draw();
+  coutp->cd(5);
+  hSigmaZ->Draw();
+}

--- a/test/runVTTracking.C
+++ b/test/runVTTracking.C
@@ -42,8 +42,8 @@ void runVTTracking(int firstEv = 0,
     for(int jp=0; jp<nPart; jp++){
       auto curPart=mcArr->at(jp);
       if(curPart.IsPrimary()){
-	zvert =  curPart.Vz();
-	break;
+        zvert =  curPart.Vz();
+        break;
       }
     }
     tc->GetEvent(jEv);

--- a/test/runVertexerTracklets.C
+++ b/test/runVertexerTracklets.C
@@ -1,0 +1,89 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <Riostream.h>
+#include <TString.h>
+#include <TMath.h>
+#include <TTree.h>
+#include <TLegend.h>
+#include <TLegendEntry.h>
+#include <TH1F.h>
+#include <TF1.h>
+#include <TH2F.h>
+#include <TFile.h>
+#include <TCanvas.h>
+#include <TPad.h>
+#include <TPaveStats.h>
+#include <TParticle.h>
+#include <TParticlePDG.h>
+#include <TVectorD.h>
+#include <TRandom3.h>
+#include <TStopwatch.h>
+#include "NA6PBaseCluster.h"
+#include "NA6PVertex.h"
+#include "NA6PVerTelReconstruction.h"
+#endif
+
+void runVertexerTracklets(int firstEv = 0,
+                          int lastEv = 999999,
+                          const char *dirSimu = "../testN6Proot/pions/latesttag")
+//			const char *dirSimu = "Angantyr") 
+{
+  TFile* fk=new TFile(Form("%s/MCKine.root",dirSimu));
+  TTree* mcTree=(TTree*)fk->Get("mckine");
+  int nEv=mcTree->GetEntries();
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+
+  TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
+  printf("Open cluster file: %s\n",fc->GetName());
+  TTree* tc=(TTree*)fc->Get("clustersVerTel");
+  std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
+  tc->SetBranchAddress("VerTel", &vtClusPtr);
+
+  if(lastEv>nEv || lastEv<0) lastEv=nEv;
+  if(firstEv<0) firstEv=0;
+
+  TH1F* hdz = new TH1F("hdz","",100,-0.5,0.5);
+  TH1F* hncontr = new TH1F("hncontr","",100,-0.5,999.5);
+  TH1F* hnvert = new TH1F("hnvert","",11,-0.5,10.5);
+
+  NA6PVerTelReconstruction* vtrec = new NA6PVerTelReconstruction();
+
+  for(int jEv=firstEv;jEv<lastEv; jEv++){
+    mcTree->GetEvent(jEv);
+    tc->GetEvent(jEv);
+    int nPart=mcArr->size();
+    double zVertGen = 0;
+    // get primary vertex position from the Kine Tree
+    for(int jp=0; jp<nPart; jp++){
+      auto curPart=mcArr->at(jp);
+      if(curPart.IsPrimary()){
+        zVertGen =  curPart.Vz();
+        break;
+      }
+    }
+    vtrec->setClusters(vtClus);
+    vtrec->runVertexerTracklets();
+    std::vector<NA6PVertex> zVertices = vtrec->getVertices();
+    int nVertices = zVertices.size();
+    hnvert->Fill(nVertices);
+    int jv=0;
+    for (auto vert : zVertices) {
+      double zRec = vert.getZ();
+      if(jv == 0){
+				hdz->Fill(zRec-zVertGen);
+				hncontr->Fill(vert.getNContributors());
+			}
+      printf("Vertex %d, z = %f contrib = %d\n",jv++,zRec,vert.getNContributors());
+		}
+  }
+  vtrec->closeVerticesOutput();
+
+  TCanvas* coutp= new TCanvas("coutp","",1200,600);
+  coutp->Divide(3,1);
+  coutp->cd(1);
+  hnvert->Draw();
+  coutp->cd(2);
+  hdz->Draw();
+  coutp->cd(3);
+  hncontr->Draw();
+}


### PR DESCRIPTION
This commit contains a first implementation of a vertex finder based on tracklets, to be run before the VT tracking in order to have a seeding vertex.
The current implementation is essentially the algorithm of AliITSVertexerZ of AliRoot, complemented with a KDE-based peak finding as an alternative to the histo-based peak finding.
I plan to add in the future another alternative method taken from the O2 ITS Vertexer, which does clusters of tracklet intersection points instead of peak finding.
Note: still missing the configuration of the vertexer parameters in the RecoParam class (will add it in the next days).