### PR TITLE
Add muon spectrometer reconstruction

### DIFF
--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -20,12 +20,15 @@ add_library(${LIB_NAME} SHARED ${THIS_SOURCES} ${THIS_HEADERS} )
 
 set(DICTIONARY_HEADERS
   NA6PBaseCluster.h
+  NA6PMuonSpecCluster.h
+  NA6PVerTelCluster.h
   ExtTrackPar.h
   NA6PTrack.h
   NA6PVertex.h
   NA6PRecoParam.h
   NA6PReconstruction.h
   NA6PVerTelReconstruction.h
+  NA6PMuonSpecReconstruction.h
   NA6PVertexerTracklets.h
   NA6PTrackerCA.h
   NA6PFastTrackFitter.h

--- a/rec/include/NA6PBaseCluster.h
+++ b/rec/include/NA6PBaseCluster.h
@@ -73,9 +73,9 @@ class NA6PBaseCluster
   float mSigYZ = 0.f;          // covariance matrix elements
   float mSigZZ = 0.f;          // covariance matrix elements
   int   mCluSiz = 0;           // cluster size
-  short mDetectorID = 0;       // the detector/sensor id
   int   mParticleID = 0;       // particle ID in Kine tree (MC truth)
   int   mHitID = -1;           // hit ID (for test of hitsToRecPoints)
+  short mDetectorID = 0;       // the detector/sensor id
   int8_t mLayer = -1;
 
   ClassDefNV(NA6PBaseCluster, 1);

--- a/rec/include/NA6PBaseCluster.h
+++ b/rec/include/NA6PBaseCluster.h
@@ -30,7 +30,8 @@ class NA6PBaseCluster
   NA6PBaseCluster& operator=(const NA6PBaseCluster&) = default;
   virtual ~NA6PBaseCluster() {}
 
-  virtual int getLayer() const { return -1; } // to be overridden in derived classes
+  int getLayer() const { return mLayer; }
+  int   getClusterSize() const { return mCluSiz; }
   // Lab frame coordinates
   auto getXLab()       const {return mPos[0];}
   auto getYLab()       const {return mPos[1];}
@@ -75,6 +76,7 @@ class NA6PBaseCluster
   short mDetectorID = 0;       // the detector/sensor id
   int   mParticleID = 0;       // particle ID in Kine tree (MC truth)
   int   mHitID = -1;           // hit ID (for test of hitsToRecPoints)
+  int8_t mLayer = -1;
 
   ClassDefNV(NA6PBaseCluster, 1);
 };

--- a/rec/include/NA6PBaseCluster.h
+++ b/rec/include/NA6PBaseCluster.h
@@ -30,6 +30,7 @@ class NA6PBaseCluster
   NA6PBaseCluster& operator=(const NA6PBaseCluster&) = default;
   virtual ~NA6PBaseCluster() {}
 
+  virtual int getLayer() const { return -1; } // to be overridden in derived classes
   // Lab frame coordinates
   auto getXLab()       const {return mPos[0];}
   auto getYLab()       const {return mPos[1];}
@@ -64,7 +65,6 @@ class NA6PBaseCluster
 
   virtual void print() const;
   std::string asString() const;
-
   
  protected:
   float mPos[3] = {};          // cartesian position of cluster in lab frame

--- a/rec/include/NA6PBaseCluster.h
+++ b/rec/include/NA6PBaseCluster.h
@@ -25,7 +25,7 @@ class NA6PBaseCluster
  public:
 
   NA6PBaseCluster() = default;
-  NA6PBaseCluster(float x, float y, float z, int clusiz);
+  NA6PBaseCluster(float x, float y, float z, int clusiz, int layer);
   NA6PBaseCluster(const NA6PBaseCluster&) = default;
   NA6PBaseCluster& operator=(const NA6PBaseCluster&) = default;
   virtual ~NA6PBaseCluster() {}

--- a/rec/include/NA6PFastTrackFitter.h
+++ b/rec/include/NA6PFastTrackFitter.h
@@ -17,12 +17,12 @@
 
 #include <string>
 #include <Rtypes.h>
+#include "NA6PBaseCluster.h"
 
 // Fast track fit based on Kalman filter
 
 class TGeoManager;
 class NA6PTrack;
-class NA6PBaseCluster;
 
 class NA6PFastTrackFitter
 {
@@ -35,7 +35,7 @@ class NA6PFastTrackFitter
 
   // setters for configurable parameters
   void   setMaxChi2Cl(double v=10)  {mMaxChi2Cl = v;}
-  void   setNLayersVT(int n) {
+  void   setNLayers(int n) {
     mNLayersVT = n; mClusters.clear(); mClusters.resize(n);
   }
   void   setParticleHypothesis(int pdg);
@@ -53,7 +53,8 @@ class NA6PFastTrackFitter
   void   computeSeed();
   void   printSeed() const;
   
-  void   addClusterVT(int jLay, NA6PBaseCluster* cl);
+  template <typename ClusterType>
+  void   addCluster(int jLay, ClusterType* cl);
   void   resetClusters() {
     // deletes the owned cluster and sets pointer to nullptr
     for (auto& clPtr : mClusters) clPtr.reset();
@@ -65,8 +66,9 @@ class NA6PFastTrackFitter
 
   bool   loadGeometry(const char* filename = "geometry.root", const char* geoname = "NA6P");
   
-  NA6PTrack*  fitTrackPointsVT();
-  bool   updateTrack(NA6PTrack* trc, NA6PBaseCluster* cl) const;
+  NA6PTrack*  fitTrackPoints();
+  template <typename ClusterType>
+  bool   updateTrack(NA6PTrack* trc, ClusterType* cl) const;
   int    propagateToZ(NA6PTrack* trc, double zFrom, double zTo, int dir) const;
   int    propagateToZ(NA6PTrack* trc, double zTo) const;
   void   getMeanMaterialBudgetFromGeom(double* start, double* end, double *mparam) const;

--- a/rec/include/NA6PFastTrackFitter.h
+++ b/rec/include/NA6PFastTrackFitter.h
@@ -36,7 +36,9 @@ class NA6PFastTrackFitter
   // setters for configurable parameters
   void   setMaxChi2Cl(double v=10)  {mMaxChi2Cl = v;}
   void   setNLayers(int n) {
-    mNLayers = n; mClusters.clear(); mClusters.resize(n);
+    mNLayers = n;
+    mClusters.clear();
+    mClusters.resize(n);
   }
   void   setParticleHypothesis(int pdg);
   void   enableMaterialCorrections() {mCorrectForMaterial = true;}
@@ -53,8 +55,7 @@ class NA6PFastTrackFitter
   void   computeSeed();
   void   printSeed() const;
   
-  template <typename ClusterType>
-  void   addCluster(int jLay, ClusterType* cl);
+  void   addCluster(int jLay, NA6PBaseCluster* cl);
   void   resetClusters() {
     // deletes the owned cluster and sets pointer to nullptr
     for (auto& clPtr : mClusters) clPtr.reset();
@@ -67,8 +68,7 @@ class NA6PFastTrackFitter
   bool   loadGeometry(const char* filename = "geometry.root", const char* geoname = "NA6P");
   
   NA6PTrack*  fitTrackPoints();
-  template <typename ClusterType>
-  bool   updateTrack(NA6PTrack* trc, ClusterType* cl) const;
+  bool   updateTrack(NA6PTrack* trc, NA6PBaseCluster* cl) const;
   int    propagateToZ(NA6PTrack* trc, double zFrom, double zTo, int dir) const;
   int    propagateToZ(NA6PTrack* trc, double zTo) const;
   void   getMeanMaterialBudgetFromGeom(double* start, double* end, double *mparam) const;

--- a/rec/include/NA6PFastTrackFitter.h
+++ b/rec/include/NA6PFastTrackFitter.h
@@ -36,7 +36,7 @@ class NA6PFastTrackFitter
   // setters for configurable parameters
   void   setMaxChi2Cl(double v=10)  {mMaxChi2Cl = v;}
   void   setNLayers(int n) {
-    mNLayersVT = n; mClusters.clear(); mClusters.resize(n);
+    mNLayers = n; mClusters.clear(); mClusters.resize(n);
   }
   void   setParticleHypothesis(int pdg);
   void   enableMaterialCorrections() {mCorrectForMaterial = true;}
@@ -81,9 +81,7 @@ class NA6PFastTrackFitter
   static const Double_t kAlmostZero;
 
  protected:
-  int  mNLayersVT = 5;                   // number of active VT layers in the model
-  int  mNLayersMS = 4;                   // number of active MS layers in the model
-  int  mNLayersTR = 2;                   // number of active Trigger layers in the model
+  int  mNLayers = 5;                   // number of active 
   double mMaxChi2Cl = 10.;               // max cluster-track chi2
   bool   mIsSeedSet = false;             // flag for set seed
   int    mSeedOption = kThreePointSeed;  // seed option (see enum)
@@ -102,7 +100,7 @@ class NA6PFastTrackFitter
   
   int getNumberOfClusters() const{
     int nClus = 0;
-    for (int jLay = 0; jLay < mNLayersVT; ++jLay) if(mClusters[jLay]) nClus++;
+    for (int jLay = 0; jLay < mNLayers; ++jLay) if(mClusters[jLay]) nClus++;
     return nClus;
   }
 

--- a/rec/include/NA6PMuonSpecCluster.h
+++ b/rec/include/NA6PMuonSpecCluster.h
@@ -24,13 +24,11 @@ class NA6PMuonSpecCluster : public NA6PBaseCluster
  public:
 
   NA6PMuonSpecCluster() = default;
-  NA6PMuonSpecCluster(float x, float y, float z, int clusiz) : NA6PBaseCluster(x, y, z, clusiz) {}
+  NA6PMuonSpecCluster(float x, float y, float z, int clusiz);
   NA6PMuonSpecCluster(const NA6PMuonSpecCluster&) = default;
   NA6PMuonSpecCluster& operator=(const NA6PMuonSpecCluster&) = default;
   virtual ~NA6PMuonSpecCluster() {}
-
-  int getLayer() const override;
-
+  
   ClassDefNV(NA6PMuonSpecCluster, 1);
 };
 

--- a/rec/include/NA6PMuonSpecCluster.h
+++ b/rec/include/NA6PMuonSpecCluster.h
@@ -1,0 +1,37 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_MUONSPEC_CLUSTER_H
+#define NA6P_MUONSPEC_CLUSTER_H
+
+#include "NA6PBaseCluster.h"
+
+// Muon Spectrometer cluster class
+
+class NA6PMuonSpecCluster : public NA6PBaseCluster
+{
+ public:
+
+  NA6PMuonSpecCluster() = default;
+  NA6PMuonSpecCluster(float x, float y, float z, int clusiz) : NA6PBaseCluster(x, y, z, clusiz) {}
+  NA6PMuonSpecCluster(const NA6PMuonSpecCluster&) = default;
+  NA6PMuonSpecCluster& operator=(const NA6PMuonSpecCluster&) = default;
+  virtual ~NA6PMuonSpecCluster() {}
+
+  int getLayer() const override;
+
+  ClassDefNV(NA6PMuonSpecCluster, 1);
+};
+
+#endif

--- a/rec/include/NA6PMuonSpecCluster.h
+++ b/rec/include/NA6PMuonSpecCluster.h
@@ -24,10 +24,9 @@ class NA6PMuonSpecCluster : public NA6PBaseCluster
  public:
 
   NA6PMuonSpecCluster() = default;
-  NA6PMuonSpecCluster(float x, float y, float z, int clusiz);
+  NA6PMuonSpecCluster(float x, float y, float z, int clusiz, int nDet);
   NA6PMuonSpecCluster(const NA6PMuonSpecCluster&) = default;
   NA6PMuonSpecCluster& operator=(const NA6PMuonSpecCluster&) = default;
-  virtual ~NA6PMuonSpecCluster() {}
   
   ClassDefNV(NA6PMuonSpecCluster, 1);
 };

--- a/rec/include/NA6PMuonSpecCluster.h
+++ b/rec/include/NA6PMuonSpecCluster.h
@@ -24,7 +24,7 @@ class NA6PMuonSpecCluster : public NA6PBaseCluster
  public:
 
   NA6PMuonSpecCluster() = default;
-  NA6PMuonSpecCluster(float x, float y, float z, int clusiz, int nDet);
+  NA6PMuonSpecCluster(float x, float y, float z, int clusiz, int layer);
   NA6PMuonSpecCluster(const NA6PMuonSpecCluster&) = default;
   NA6PMuonSpecCluster& operator=(const NA6PMuonSpecCluster&) = default;
   

--- a/rec/include/NA6PMuonSpecReconstruction.h
+++ b/rec/include/NA6PMuonSpecReconstruction.h
@@ -49,6 +49,7 @@ class NA6PMuonSpecReconstruction : public NA6PReconstruction
   void setClusterSpaceResolutionX(double clures) { mCluResX = clures; }
   void setClusterSpaceResolutionY(double clures) { mCluResY = clures; }
   void hitsToRecPoints(const std::vector<NA6PMuonSpecModularHit>& hits);
+  NA6PTrackerCA* getTracker() const { return mMSTracker; }
 
   void setPrimaryVertexPosition(double x, double y, double z)
   {

--- a/rec/include/NA6PMuonSpecReconstruction.h
+++ b/rec/include/NA6PMuonSpecReconstruction.h
@@ -12,8 +12,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef NA6P_VERTEL_RECONSTRUCTION_H
-#define NA6P_VERTEL_RECONSTRUCTION_H
+#ifndef NA6P_MUONSPEC_RECONSTRUCTION_H
+#define NA6P_MUONSPEC_RECONSTRUCTION_H
 
 #include <string>
 #include <Rtypes.h>
@@ -21,22 +21,23 @@
 
 // Class to steer the VT reconstruction
 
-#include "NA6PVerTelCluster.h"
+#include "NA6PMuonSpecCluster.h"
 #include "NA6PTrack.h"
 #include "NA6PVertex.h"
 #include "NA6PReconstruction.h"
 
 class TFile;
 class TTree;
-class NA6PVerTelHit;
-class NA6PVertexerTracklets;
+class NA6PMuonSpecHit;
+class NA6PMuonSpecModularHit;
+class NA6PMuonSpecVertexerTracklets;
 class NA6PTrackerCA;
 
-class NA6PVerTelReconstruction : public NA6PReconstruction
+class NA6PMuonSpecReconstruction : public NA6PReconstruction
 {
  public:
-  NA6PVerTelReconstruction();
-  ~NA6PVerTelReconstruction() override = default;
+  NA6PMuonSpecReconstruction();
+  ~NA6PMuonSpecReconstruction() override = default;
 
   bool init(const char* filename, const char* geoname = "NA6P") override;
   // methods to steer cluster reconstruction
@@ -45,25 +46,20 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   void writeClusters() override;
   void closeClustersOutput() override;
   // fast method to smear the hits bypassing digitization and cluster finder
-  void setClusterSpaceResolution(double clures) { mCluRes = clures; }
-  void hitsToRecPoints(const std::vector<NA6PVerTelHit>& hits);
+  void setClusterSpaceResolutionX(double clures) { mCluResX = clures; }
+  void setClusterSpaceResolutionY(double clures) { mCluResY = clures; }
+  void hitsToRecPoints(const std::vector<NA6PMuonSpecModularHit>& hits);
 
   void setPrimaryVertexPosition(double x, double y, double z)
   {
     mPrimaryVertex.SetXYZ(x, y, z);
   }
   // methods to steer tracking
-  void setClusters(const std::vector<NA6PVerTelCluster>& clusters)
+  void setClusters(const std::vector<NA6PMuonSpecCluster>& clusters)
   {
     mClusters = clusters;
     hClusPtr = &mClusters;
   }
-  void createVerticesOutput() override;
-  void clearVertices() override { mVertices.clear(); }
-  void writeVertices() override;
-  void closeVerticesOutput() override;
-  void runVertexerTracklets();
-  const std::vector<NA6PVertex>& getVertices() const { return mVertices; }
 
   void createTracksOutput() override;
   void clearTracks() override { mTracks.clear(); }
@@ -72,21 +68,18 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   void runTracking();
 
  private:
-  std::vector<NA6PVerTelCluster> mClusters, *hClusPtr = &mClusters; // vector of clusters
+  std::vector<NA6PMuonSpecCluster> mClusters, *hClusPtr = &mClusters; // vector of clusters
   TFile* mClusFile = nullptr;                                     // file with clusters
   TTree* mClusTree = nullptr;                                     // tree of clusters
-  double mCluRes = 5.e-4;                                         // cluster resolution, cm (for fast simu)
-  std::vector<NA6PVertex> mVertices, *hVerticesPtr = &mVertices;  // vector of vertices
-  TFile* mVertexFile = nullptr;                                   // file with vertices
-  TTree* mVertexTree = nullptr;                                   // tree of vertices
-  NA6PVertexerTracklets* mVTTrackletVertexer = nullptr;           // vertexer
+  double mCluResX = 100.e-4;                                      // cluster resolution, cm (for fast simu)
+  double mCluResY = 500.e-4;                                      // cluster resolution, cm (for fast simu)
   TVector3 mPrimaryVertex{0.0, 0.0, 0.0};                         // primary vertex position
   std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;          // vector of tracks
   TFile* mTrackFile = nullptr;                                    // file with tracks
   TTree* mTrackTree = nullptr;                                    // tree of tracks
-  NA6PTrackerCA* mVTTracker = nullptr;                            // tracker
+  NA6PTrackerCA* mMSTracker = nullptr;                            // tracker
 
-  ClassDefNV(NA6PVerTelReconstruction, 1);
+  ClassDefNV(NA6PMuonSpecReconstruction, 1);
 };
 
 #endif

--- a/rec/include/NA6PRecoParam.h
+++ b/rec/include/NA6PRecoParam.h
@@ -11,7 +11,7 @@ struct NA6PRecoParam : public na6p::conf::ConfigurableParamHelper<NA6PRecoParam>
   static constexpr int MaxIterationsTrackerCA = 10;
 
   // VerTel reconstruction parameters
-  int    nVerTelLayers = 5;
+  int    nLayers = 5;
   int    nIterationsTrackerCA = 2;
   float maxDeltaThetaTrackletsCA[MaxIterationsTrackerCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   float maxDeltaPhiTrackletsCA[MaxIterationsTrackerCA]   = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};

--- a/rec/include/NA6PTrack.h
+++ b/rec/include/NA6PTrack.h
@@ -43,9 +43,8 @@ class NA6PTrack
   void    resetCovariance(float err=-1.);
 
   double        getMass()                  const {return mMass;}
-  int           getNVTLayers()             const {return mNVTLayers;}
+  int           getNLayers()             const {return mNLayers;}
   double        getChi2()                  const {return mChi2;}
-  double        getChi2VT()                const {return mChi2VT;}
   const ExtTrackPar& getTrackExtParam()    const {return mExtTrack; }
   const double* getCovariance()            const {return mExtTrack.getCovariance(); }
   int          getNVTHits()                const {return mNClustersVT;}
@@ -53,8 +52,8 @@ class NA6PTrack
   int          getNTRHits()                const {return mNClustersTR;}
   int          getNHits()                  const {return mNClusters;}
   uint32_t     getClusterMap()             const {return mClusterMap;}
-  bool         hasClusterOnVTLayer(int lr) const {return (lr<mNVTLayers) ?  mClusterMap&(1<<lr) : false;}
-  int          getVTClusterIndex(int lr)   const {return lr < kMaxVTLr ? mClusterIndices[lr] : -1; }
+  bool         hasClusterOnLayer(int lr) const {return (lr<mNLayers) ?  mClusterMap&(1<<lr) : false;}
+  int          getClusterIndex(int lr)   const {return lr < kMaxVTLr ? mClusterIndices[lr] : -1; }
   int          getParticleLabel(int lr)    const {return lr < kMaxVTLr ? mClusterPartID[lr] : -2; }
   int          getParticleID()             const {return mParticleID;}
   int          getCAIteration()            const {return mCAIteration;}
@@ -80,13 +79,11 @@ class NA6PTrack
   double       getSigmaPY2()               const;
   double       getSigmaPZ2()               const;
   double       getNormChi2()               const {return mNClusters<3 ? 0 :  mChi2 / ( (mNClusters<<1)-kNDOF);}
-  double       getNormChi2VT()             const {return mNClustersVT<3 ? 0 :  mChi2VT / ( (mNClustersVT<<1)-kNDOF);}
   double       getPredictedChi2(double* p, double* cov) const {return mExtTrack.getPredictedChi2(p,cov);}
   
   void   setMass(double m)         {mMass = m;}
-  void   setNVTLayers(int n)       {mNVTLayers = n;}
+  void   setNLayers(int n)       {mNLayers = n;}
   void   setChi2(double chi2)      {mChi2 = chi2;}
-  void   setChi2VT(double chi2)    {mChi2VT = chi2;}
   void   setParticleLabel(int idx, int lr)  { if (lr < kMaxVTLr) mClusterPartID[lr] = idx;}
   void   setVTClusterIndex(int idx, int lr) { if (lr < kMaxVTLr) mClusterIndices[lr] = idx;}
   void   setParticleID(int idx)    {mParticleID = idx;}
@@ -111,8 +108,7 @@ class NA6PTrack
  protected:
   double   mMass = 0.140;                        // particle mass
   double   mChi2 = 0.f;                          // total chi2
-  double   mChi2VT = 0.f;                        // total chi2 VT
-  int      mNVTLayers = 5;                       // number of vT laters
+  int      mNLayers = 6;                       // number of layers
   uint32_t mClusterMap = 0;                      // pattern of clusters per layer
   int      mNClusters = 0;                       // total hits
   int      mNClustersVT = 0;                     // total VT hits

--- a/rec/include/NA6PTrack.h
+++ b/rec/include/NA6PTrack.h
@@ -27,7 +27,7 @@ class NA6PTrack
 {
  public:
   
-  enum {kNDOF=5, kMaxVTLr=16};
+  enum {kNDOF=5, kMaxLr=16};
   enum {kY2=0,kZ2=2,kSnp2=5,kTgl2=9,kPtI2=14};
   enum {kY,kZ,kSnp,kTgl,kPtI};
 
@@ -43,8 +43,9 @@ class NA6PTrack
   void    resetCovariance(float err=-1.);
 
   double        getMass()                  const {return mMass;}
-  int           getNLayers()             const {return mNLayers;}
   double        getChi2()                  const {return mChi2;}
+  double        getChi2VT()                const { return mChi2VT; }
+  double        getChi2MS()                const { return mChi2MS; }
   const ExtTrackPar& getTrackExtParam()    const {return mExtTrack; }
   const double* getCovariance()            const {return mExtTrack.getCovariance(); }
   int          getNVTHits()                const {return mNClustersVT;}
@@ -52,9 +53,8 @@ class NA6PTrack
   int          getNTRHits()                const {return mNClustersTR;}
   int          getNHits()                  const {return mNClusters;}
   uint32_t     getClusterMap()             const {return mClusterMap;}
-  bool         hasClusterOnLayer(int lr) const {return (lr<mNLayers) ?  mClusterMap&(1<<lr) : false;}
-  int          getClusterIndex(int lr)   const {return lr < kMaxVTLr ? mClusterIndices[lr] : -1; }
-  int          getParticleLabel(int lr)    const {return lr < kMaxVTLr ? mClusterPartID[lr] : -2; }
+  int          getClusterIndex(int lr)   const {return lr < kMaxLr ? mClusterIndices[lr] : -1; }
+  int          getParticleLabel(int lr)    const {return lr < kMaxLr ? mClusterPartID[lr] : -2; }
   int          getParticleID()             const {return mParticleID;}
   int          getCAIteration()            const {return mCAIteration;}
   
@@ -82,17 +82,19 @@ class NA6PTrack
   double       getPredictedChi2(double* p, double* cov) const {return mExtTrack.getPredictedChi2(p,cov);}
   
   void   setMass(double m)         {mMass = m;}
-  void   setNLayers(int n)       {mNLayers = n;}
   void   setChi2(double chi2)      {mChi2 = chi2;}
-  void   setParticleLabel(int idx, int lr)  { if (lr < kMaxVTLr) mClusterPartID[lr] = idx;}
-  void   setVTClusterIndex(int idx, int lr) { if (lr < kMaxVTLr) mClusterIndices[lr] = idx;}
+  void   setChi2VT(double chi2)    {mChi2VT = chi2;}
+  void   setChi2MS(double chi2)    {mChi2MS = chi2;}
+  void   setParticleLabel(int idx, int lr)  { if (lr < kMaxLr) mClusterPartID[lr] = idx;}
+  void   setClusterIndex(int idx, int lr) { if (lr < kMaxLr) mClusterIndices[lr] = idx;}
   void   setParticleID(int idx)    {mParticleID = idx;}
   void   setCAIteration(int iter)  {mCAIteration = iter;}
 
   static void lab2trk(const double *vLab, double *vTrk); 
   static void trk2lab(const double *vTrk, double *vLab); 
 
-  void   addCluster(const NA6PBaseCluster* clu, int cluIndex, double chi2);
+  template <typename ClusterType>
+  void   addCluster(const ClusterType* clu, int cluIndex, double chi2);
   bool   correctForMeanMaterial(double xOverX0, double xTimesRho, bool anglecorr = false){
     return mExtTrack.correctForMeanMaterial(xOverX0, xTimesRho, mMass, anglecorr);
   }
@@ -108,14 +110,15 @@ class NA6PTrack
  protected:
   double   mMass = 0.140;                        // particle mass
   double   mChi2 = 0.f;                          // total chi2
-  int      mNLayers = 6;                       // number of layers
+  double   mChi2VT = 0.f;                        // total chi2 VT
+  double   mChi2MS = 0.f;                        // total chi2 MS
   uint32_t mClusterMap = 0;                      // pattern of clusters per layer
   int      mNClusters = 0;                       // total hits
   int      mNClustersVT = 0;                     // total VT hits
   int      mNClustersMS = 0;                     // total MS hits
   int      mNClustersTR = 0;                     // total TR hits
-  std::array<int, kMaxVTLr> mClusterIndices{};   // cluster indices
-  std::array<int, kMaxVTLr> mClusterPartID{};    // particle ID (per cluster)
+  std::array<int, kMaxLr> mClusterIndices{};   // cluster indices
+  std::array<int, kMaxLr> mClusterPartID{};    // particle ID (per cluster)
   int      mParticleID = -1;                     // particle ID (MC truth)
   int      mCAIteration = -1;                    //! CA iteration (for debug)
   ExtTrackPar mExtTrack;                         // track params

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -73,7 +73,7 @@ public:
   ~NA6PTrackerCA();
 
   // setters for configurable parameters
-  void setNLayers(int n) {mNLayers = n;}
+  void setNLayers(int n);
   void setMaxNumberOfSharedClusters(int n) {mMaxSharedClusters = n;}
   void setNumberOfIterations(int nIter);
   void setIterationParams(int iter,
@@ -93,13 +93,17 @@ public:
   void printConfiguration() const;
   int  getNIterations() const {return mNIterationsCA;}
   bool loadGeometry(const char* filename, const char* geoname = "NA6P");
-  void findTracks(std::vector<NA6PBaseCluster>& cluArr, TVector3 primVert);
+  
+  template<typename ClusterType>
+  void findTracks(std::vector<ClusterType>& cluArr, TVector3 primVert);
+  
   std::vector<NA6PTrack> getTracks();
 
   
 protected:
   // methods used in tracking
-  void sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,
+  template<typename ClusterType>
+  void sortClustersByLayerAndEta(std::vector<ClusterType>& cluArr,
 				 std::vector<int>& firstIndex,
 				 std::vector<int>& lastIndex);
   void sortTrackletsByLayerAndIndex(std::vector<TrackletCandidate>& tracklets,
@@ -108,16 +112,18 @@ protected:
   void sortCellsByLayerAndIndex(std::vector<CellCandidate>& cells,
 				std::vector<int>& firstIndex,
 				std::vector<int>& lastIndex);
-  void computeLayerTracklets(const std::vector<NA6PBaseCluster>& cluArr,
+  template<typename ClusterType>
+  void computeLayerTracklets(const std::vector<ClusterType>& cluArr,
 			     const std::vector<int>& firstIndex,
 			     const std::vector<int>& lastIndex,
 			     std::vector<TrackletCandidate>& tracklets,
 			     double deltaThetaMax,
 			     double deltaPhiMax);
+  template<typename ClusterType>
   void computeLayerCells(const std::vector<TrackletCandidate>& tracklets,
 			 const std::vector<int>& firstIndex,
 			 const std::vector<int>& lastIndex,
-			 const std::vector<NA6PBaseCluster>& cluArr,
+			 const std::vector<ClusterType>& cluArr,
 			 std::vector<CellCandidate>& cells,
 			 double deltaTanLMax,
 			 double deltaPhiMax,
@@ -125,43 +131,49 @@ protected:
 			 double deltaPyPzMax,
 			 double maxChi2TrClu,
 			 double maxChi2NDF);
+  template<typename ClusterType>
   double computeTrackToClusterChi2(const NA6PTrack& track,
-				   const NA6PBaseCluster& clu);
+				   const ClusterType& clu);
+  template<typename ClusterType>
   bool fitTrackPointsFast(const std::vector<int>& cluIDs,
-			  const std::vector<NA6PBaseCluster>& cluArr,
+			  const std::vector<ClusterType>& cluArr,
 			  NA6PTrack& fitTrack,
 			  double maxChi2TrClu,
 			  double maxChi2NDF);
+  template<typename ClusterType>
   void findCellsNeighbours(const std::vector<CellCandidate>& cells,
 			   const std::vector<int>& firstIndex,
 			   const std::vector<int>& lastIndex,
 			   std::vector<std::pair<int,int>>& cneigh,
-			   const std::vector<NA6PBaseCluster>& cluArr,
+			   const std::vector<ClusterType>& cluArr,
 			   double maxChi2TrClu);
+  template<typename ClusterType>
   std::vector<TrackCandidate> prolongSeed(const TrackCandidate& seed,
 					  const std::vector<CellCandidate>& cells,
 					  const std::vector<int>& firstIndex,
 					  const std::vector<int>& lastIndex,
-					  const std::vector<NA6PBaseCluster>& cluArr,
+					  const std::vector<ClusterType>& cluArr,
 					  double maxChi2TrClu,
 					  ExtendDirection dir);
+  template<typename ClusterType>
   void findRoads(const std::vector<std::pair<int,int>>& cneigh,
 		 const std::vector<CellCandidate>& cells,
 		 const std::vector<int>& firstIndex,
 		 const std::vector<int>& lastIndex,
 		 const std::vector<TrackletCandidate>& tracklets,
-		 const std::vector<NA6PBaseCluster>& cluArr,
+		 const std::vector<ClusterType>& cluArr,
 		 std::vector<TrackCandidate>& trackCands,
 		 double maxChi2TrClu);
+  template<typename ClusterType>
   void fitAndSelectTracks(const std::vector<TrackCandidate>& trackCands,
-			  const std::vector<NA6PBaseCluster>& cluArr,
+			  const std::vector<ClusterType>& cluArr,
 			  std::vector<TrackFitted>& tracks,
 			  double maxChi2TrClu,
 			  int minNClu,
 			  double maxChi2NDF);
-  template<typename T>
+  template<typename T, typename ClusterType>
   void printStats(const std::vector<T>& candidates,
-		  const std::vector<NA6PBaseCluster>& cluArr,
+		  const std::vector<ClusterType>& cluArr,
 		  const std::vector<CellCandidate>& cells,
 		  const std::string& label,
 		  int requiredClus = -1);
@@ -189,11 +201,6 @@ private:
   double mMaxChi2ndfCellsCA[kMaxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   double mMaxChi2ndfTracksCA[kMaxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   int    mMinNClusTracksCA[kMaxIterationsCA] = {5, 3, 0, 0, 0, 0, 0, 0, 0, 0};
-
-
-
- 
-  
 
   ClassDefNV(NA6PTrackerCA, 1);
 };

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -75,6 +75,7 @@ public:
   // setters for configurable parameters
   void setNLayers(int n);
   void setMaxNumberOfSharedClusters(int n) {mMaxSharedClusters = n;}
+  void setStartLayer(int start) {mLayerStart = start;}
   void setNumberOfIterations(int nIter);
   void setIterationParams(int iter,
 			  double maxDeltaThetaTracklets,
@@ -182,8 +183,8 @@ protected:
 
 
 private:
-  
-  int    mNLayers = 5;
+  int  mLayerStart = 0;
+  int  mNLayers = 5;
   double mPrimVertPos[3] = {};
   NA6PFastTrackFitter* mTrackFitter = nullptr;
   std::vector<bool> mIsClusterUsed = {};

--- a/rec/include/NA6PVerTelCluster.h
+++ b/rec/include/NA6PVerTelCluster.h
@@ -27,7 +27,6 @@ class NA6PVerTelCluster : public NA6PBaseCluster
   NA6PVerTelCluster(float x, float y, float z, int clusiz, int nDet);
   NA6PVerTelCluster(const NA6PVerTelCluster&) = default;
   NA6PVerTelCluster& operator=(const NA6PVerTelCluster&) = default;
-  virtual ~NA6PVerTelCluster() {}
 
   ClassDefNV(NA6PVerTelCluster, 1);
 };

--- a/rec/include/NA6PVerTelCluster.h
+++ b/rec/include/NA6PVerTelCluster.h
@@ -24,7 +24,7 @@ class NA6PVerTelCluster : public NA6PBaseCluster
  public:
 
   NA6PVerTelCluster() = default;
-  NA6PVerTelCluster(float x, float y, float z, int clusiz, int nDet);
+  NA6PVerTelCluster(float x, float y, float z, int clusiz, int layer);
   NA6PVerTelCluster(const NA6PVerTelCluster&) = default;
   NA6PVerTelCluster& operator=(const NA6PVerTelCluster&) = default;
 

--- a/rec/include/NA6PVerTelCluster.h
+++ b/rec/include/NA6PVerTelCluster.h
@@ -1,0 +1,37 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_VERTEL_CLUSTER_H
+#define NA6P_VERTEL_CLUSTER_H
+
+#include "NA6PBaseCluster.h"
+
+// Vertex Telescope cluster class
+
+class NA6PVerTelCluster : public NA6PBaseCluster
+{
+ public:
+
+  NA6PVerTelCluster() = default;
+  NA6PVerTelCluster(float x, float y, float z, int clusiz) : NA6PBaseCluster(x, y, z, clusiz) {}
+  NA6PVerTelCluster(const NA6PVerTelCluster&) = default;
+  NA6PVerTelCluster& operator=(const NA6PVerTelCluster&) = default;
+  virtual ~NA6PVerTelCluster() {}
+
+  int getLayer() const override;
+
+  ClassDefNV(NA6PVerTelCluster, 1);
+};
+
+#endif

--- a/rec/include/NA6PVerTelCluster.h
+++ b/rec/include/NA6PVerTelCluster.h
@@ -24,12 +24,10 @@ class NA6PVerTelCluster : public NA6PBaseCluster
  public:
 
   NA6PVerTelCluster() = default;
-  NA6PVerTelCluster(float x, float y, float z, int clusiz) : NA6PBaseCluster(x, y, z, clusiz) {}
+  NA6PVerTelCluster(float x, float y, float z, int clusiz, int nDet);
   NA6PVerTelCluster(const NA6PVerTelCluster&) = default;
   NA6PVerTelCluster& operator=(const NA6PVerTelCluster&) = default;
   virtual ~NA6PVerTelCluster() {}
-
-  int getLayer() const override;
 
   ClassDefNV(NA6PVerTelCluster, 1);
 };

--- a/rec/include/NA6PVerTelReconstruction.h
+++ b/rec/include/NA6PVerTelReconstruction.h
@@ -47,6 +47,7 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   // fast method to smear the hits bypassing digitization and cluster finder
   void setClusterSpaceResolution(double clures) { mCluRes = clures; }
   void hitsToRecPoints(const std::vector<NA6PVerTelHit>& hits);
+  NA6PTrackerCA* getTracker() const { return mVTTracker; }
 
   void setPrimaryVertexPosition(double x, double y, double z)
   {

--- a/rec/include/NA6PVertexerTracklets.h
+++ b/rec/include/NA6PVertexerTracklets.h
@@ -18,6 +18,7 @@
 #include <Rtypes.h>
 
 class NA6PVertex;
+class NA6PVerTelCluster;
 
 // Vertex reconstruction from tracklets in the telescope
 
@@ -116,28 +117,28 @@ class NA6PVertexerTracklets
   void setVerbosity(bool opt = true) { mVerbose = opt; }
 
   // methods for vertex calculation
-  void findVertices(std::vector<NA6PBaseCluster>& cluArr,
+  void findVertices(std::vector<NA6PVerTelCluster>& cluArr,
                     std::vector<NA6PVertex>& vertices);
 
-  void sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,
+  void sortClustersByLayerAndEta(std::vector<NA6PVerTelCluster>& cluArr,
                                  std::vector<int>& firstIndex,
                                  std::vector<int>& lastIndex);
   void sortTrackletsByLayerAndIndex(std::vector<TrackletForVertex>& tracklets,
                                     std::vector<int>& firstIndex,
                                     std::vector<int>& lastIndex);
-  void computeLayerTracklets(const std::vector<NA6PBaseCluster>& cluArr,
+  void computeLayerTracklets(const std::vector<NA6PVerTelCluster>& cluArr,
                              const std::vector<int>& firstIndex,
                              const std::vector<int>& lastIndex,
                              std::vector<TrackletForVertex>& tracklets);
   void selectTracklets(const std::vector<TrackletForVertex>& tracklets,
                        const std::vector<int>& firstIndex,
                        const std::vector<int>& lastIndex,
-                       const std::vector<NA6PBaseCluster>& cluArr,
+                       const std::vector<NA6PVerTelCluster>& cluArr,
                        std::vector<TrackletForVertex>& selTracklets);
   void filterOutUsedTracklets(const std::vector<TrackletForVertex>& tracklets,
                               std::vector<TrackletForVertex>& usableTracklets);
   void computeIntersections(const std::vector<TrackletForVertex>& selTracklets,
-                            const std::vector<NA6PBaseCluster>& cluArr,
+                            const std::vector<NA6PVerTelCluster>& cluArr,
                             std::vector<TracklIntersection>& zIntersec);
   bool findVertexHistoPeak(std::vector<TracklIntersection>& zIntersec,
                            std::vector<NA6PVertex>& vertices);
@@ -155,7 +156,7 @@ class NA6PVertexerTracklets
   bool findVertexKDE(const std::vector<TracklIntersection>& zIntersec,
                      std::vector<NA6PVertex>& vertices);
   void printStats(const std::vector<TrackletForVertex>& candidates,
-                  const std::vector<NA6PBaseCluster>& cluArr,
+                  const std::vector<NA6PVerTelCluster>& cluArr,
                   const std::string& label);
   short getMethodForPeakFinding() const { return mMethod; }
 

--- a/rec/src/NA6PBaseCluster.cxx
+++ b/rec/src/NA6PBaseCluster.cxx
@@ -4,8 +4,10 @@
 #include <fmt/format.h>
 #include <fairlogger/Logger.h>
 
-NA6PBaseCluster::NA6PBaseCluster(float x, float y, float z, int clusiz) : mPos{x, y, z}, mSigYY(0.),mSigYZ(0.),mSigZZ(0.),mCluSiz(clusiz),mDetectorID(0),mParticleID(0)
-{}
+NA6PBaseCluster::NA6PBaseCluster(float x, float y, float z, int clusiz, int layer)
+  : mPos{x, y, z}, mCluSiz(clusiz), mLayer(layer)
+{
+}
 
 std::string NA6PBaseCluster::asString() const
 {

--- a/rec/src/NA6PFastTrackFitter.cxx
+++ b/rec/src/NA6PFastTrackFitter.cxx
@@ -45,13 +45,12 @@ NA6PFastTrackFitter::NA6PFastTrackFitter() :
   mSeedMom[0] = mSeedMom[1] = mSeedMom[2] = 1.; // 1 GeV for default momentum seed
 }
 
-template <typename ClusterType>
-void NA6PFastTrackFitter::addCluster(int jLay, ClusterType* cl) {
+void NA6PFastTrackFitter::addCluster(int jLay, NA6PBaseCluster* cl) {
   if (jLay < 0 || jLay >= mNLayers) {
     LOGP(error,"Invalid layer index {}",jLay);
     return;
   }
-  mClusters[jLay] = std::unique_ptr<ClusterType>(cl);
+  mClusters[jLay] = std::unique_ptr<NA6PBaseCluster>(cl);
 }
 
 void NA6PFastTrackFitter::setSeed(const double* pos, const double* mom, int charge){
@@ -227,8 +226,7 @@ int NA6PFastTrackFitter::propagateToZ(NA6PTrack* trc, double zFrom, double zTo, 
   return 1;
 }
 
-template <typename ClusterType>
-bool NA6PFastTrackFitter::updateTrack(NA6PTrack* trc, ClusterType* cl) const
+bool NA6PFastTrackFitter::updateTrack(NA6PTrack* trc, NA6PBaseCluster* cl) const
 {
   // update track with measured cluster
   // propagate to cluster
@@ -246,15 +244,6 @@ bool NA6PFastTrackFitter::updateTrack(NA6PTrack* trc, ClusterType* cl) const
   //
   return true;
 }
-
-// Explicit instantiations to ensure symbols are emitted in the library
-template void NA6PFastTrackFitter::addCluster<NA6PMuonSpecCluster>(int, NA6PMuonSpecCluster*);
-template void NA6PFastTrackFitter::addCluster<NA6PVerTelCluster>(int, NA6PVerTelCluster*);
-template void NA6PFastTrackFitter::addCluster<NA6PBaseCluster>(int, NA6PBaseCluster*);
-template bool NA6PFastTrackFitter::updateTrack<NA6PMuonSpecCluster>(NA6PTrack*, NA6PMuonSpecCluster*) const;
-template bool NA6PFastTrackFitter::updateTrack<NA6PVerTelCluster>(NA6PTrack*, NA6PVerTelCluster*) const;
-template bool NA6PFastTrackFitter::updateTrack<NA6PBaseCluster>(NA6PTrack*, NA6PBaseCluster*) const;
-
 
 void NA6PFastTrackFitter::computeSeed(){
   // compute track seed from the 3 (or 2) outermost clusters

--- a/rec/src/NA6PFastTrackFitter.cxx
+++ b/rec/src/NA6PFastTrackFitter.cxx
@@ -22,9 +22,7 @@ const Double_t NA6PFastTrackFitter::kAlmostZero = 1.e-12;
 // const Double_t NA6PFastTrackFitter::fgkFldEps = 1.e-4;
 
 NA6PFastTrackFitter::NA6PFastTrackFitter() : 
-  mNLayersVT{5},
-  mNLayersMS{0},
-  mNLayersTR{0},
+  mNLayers{5},
   mMaxChi2Cl{10.},
   mIsSeedSet{false},
   mSeedOption{kThreePointSeed},
@@ -49,7 +47,7 @@ NA6PFastTrackFitter::NA6PFastTrackFitter() :
 
 template <typename ClusterType>
 void NA6PFastTrackFitter::addCluster(int jLay, ClusterType* cl) {
-  if (jLay < 0 || jLay >= mNLayersVT) {
+  if (jLay < 0 || jLay >= mNLayers) {
     LOGP(error,"Invalid layer index {}",jLay);
     return;
   }
@@ -270,7 +268,7 @@ void NA6PFastTrackFitter::computeSeed(){
     LOGP(error,"Cannot compute seed with the 3-cluster option and only {} clusters -> resort to 2-point seed",nClus);
   }
 
-  for (int jLay = mNLayersVT-1; jLay>=0; --jLay){
+  for (int jLay = mNLayers-1; jLay>=0; --jLay){
     if(mClusters[jLay]){
       mSeedPos[0] = mClusters[jLay]->getXLab();
       mSeedPos[1] = mClusters[jLay]->getYLab();
@@ -376,12 +374,12 @@ NA6PTrack* NA6PFastTrackFitter::fitTrackPoints(){
   bool propToNext = true;
   // construct bit mask
   uint clusterMask = 0;
-  for (Int_t jLay = 0; jLay < mNLayersVT; ++jLay) {
+  for (Int_t jLay = 0; jLay < mNLayers; ++jLay) {
     if (mClusters[jLay]) clusterMask |= (1 << jLay);
   }
   
   // track fit starts from the outer layer
-  for (Int_t jLay = mNLayersVT - 1; jLay >= 0; jLay --) {
+  for (Int_t jLay = mNLayers - 1; jLay >= 0; jLay --) {
     // update track with point in current layer
     if (mClusters[jLay]){
       if (!updateTrack(currTr, mClusters[jLay].get())){

--- a/rec/src/NA6PMuonSpecCluster.cxx
+++ b/rec/src/NA6PMuonSpecCluster.cxx
@@ -1,0 +1,19 @@
+// NA6PCCopyright
+
+#include "NA6PMuonSpecCluster.h"
+#include "NA6PLayoutParam.h"
+#include <cmath>
+
+int NA6PMuonSpecCluster::getLayer() const {
+	float z = getZLab();
+	const auto& layout = NA6PLayoutParam::Instance();
+	const float dzWindow = 20.f; // half-width window around plane Z
+	for (int i = 0; i < layout.nMSPlanes; ++i) {
+		float zPlane = layout.posMSPlaneZ[i];
+		if (z > (zPlane - dzWindow) && z < (zPlane + dzWindow)) {
+			return i;
+		}
+	}
+	return -1;
+}
+

--- a/rec/src/NA6PMuonSpecCluster.cxx
+++ b/rec/src/NA6PMuonSpecCluster.cxx
@@ -4,16 +4,18 @@
 #include "NA6PLayoutParam.h"
 #include <cmath>
 
-int NA6PMuonSpecCluster::getLayer() const {
-	float z = getZLab();
-	const auto& layout = NA6PLayoutParam::Instance();
-	const float dzWindow = 20.f; // half-width window around plane Z
-	for (int i = 0; i < layout.nMSPlanes; ++i) {
-		float zPlane = layout.posMSPlaneZ[i];
-		if (z > (zPlane - dzWindow) && z < (zPlane + dzWindow)) {
-			return i;
-		}
-	}
-	return -1;
+NA6PMuonSpecCluster::NA6PMuonSpecCluster(float x, float y, float z, int clusiz)
+  : NA6PBaseCluster(x, y, z, clusiz)
+{
+  // Set layer based on Z position and layout parameters
+  float zCluster = getZLab();
+  const auto& layout = NA6PLayoutParam::Instance();
+  const float dzWindow = 20.f; // half-width window around plane Z
+  for (int i = 0; i < layout.nMSPlanes; ++i) {
+    float zPlane = layout.posMSPlaneZ[i];
+    if (zCluster > (zPlane - dzWindow) && zCluster < (zPlane + dzWindow)) {
+      mLayer = i + layout.nVerTelPlanes;
+      return;
+    }
+  }
 }
-

--- a/rec/src/NA6PMuonSpecCluster.cxx
+++ b/rec/src/NA6PMuonSpecCluster.cxx
@@ -1,22 +1,8 @@
 // NA6PCCopyright
 
 #include "NA6PMuonSpecCluster.h"
-#include "NA6PLayoutParam.h"
-#include <cmath>
 
-NA6PMuonSpecCluster::NA6PMuonSpecCluster(float x, float y, float z, int clusiz, int nDet)
-  : NA6PBaseCluster(x, y, z, clusiz)
+NA6PMuonSpecCluster::NA6PMuonSpecCluster(float x, float y, float z, int clusiz, int layer)
+  : NA6PBaseCluster(x, y, z, clusiz, layer)
 {
-  mDetectorID = nDet;
-  // Set layer based on Z position and layout parameters
-  float zCluster = getZLab();
-  const auto& layout = NA6PLayoutParam::Instance();
-  const float dzWindow = 20.f; // half-width window around plane Z
-  for (int i = 0; i < layout.nMSPlanes; ++i) {
-    float zPlane = layout.posMSPlaneZ[i];
-    if (zCluster > (zPlane - dzWindow) && zCluster < (zPlane + dzWindow)) {
-      mLayer = i + layout.nVerTelPlanes;
-      return;
-    }
-  }
 }

--- a/rec/src/NA6PMuonSpecCluster.cxx
+++ b/rec/src/NA6PMuonSpecCluster.cxx
@@ -4,9 +4,10 @@
 #include "NA6PLayoutParam.h"
 #include <cmath>
 
-NA6PMuonSpecCluster::NA6PMuonSpecCluster(float x, float y, float z, int clusiz)
+NA6PMuonSpecCluster::NA6PMuonSpecCluster(float x, float y, float z, int clusiz, int nDet)
   : NA6PBaseCluster(x, y, z, clusiz)
 {
+  mDetectorID = nDet;
   // Set layer based on Z position and layout parameters
   float zCluster = getZLab();
   const auto& layout = NA6PLayoutParam::Instance();

--- a/rec/src/NA6PMuonSpecReconstruction.cxx
+++ b/rec/src/NA6PMuonSpecReconstruction.cxx
@@ -79,10 +79,9 @@ void NA6PMuonSpecReconstruction::hitsToRecPoints(const std::vector<NA6PMuonSpecM
     int clusiz = 1;
     int nDet = hit.getDetectorID();
     int idPart = hit.getTrackID();
-    mClusters.emplace_back(x, y, z, clusiz);
+    mClusters.emplace_back(x, y, z, clusiz, nDet);
     auto& clu = mClusters.back();
     clu.setErr(ex2clu, 0., ey2clu);
-    clu.setDetectorID(nDet);
     clu.setParticleID(idPart);
     clu.setHitID(jHit);
   }

--- a/rec/src/NA6PMuonSpecReconstruction.cxx
+++ b/rec/src/NA6PMuonSpecReconstruction.cxx
@@ -21,6 +21,7 @@ bool NA6PMuonSpecReconstruction::init(const char* filename, const char* geoname)
   mMSTracker = new NA6PTrackerCA();
   mMSTracker->configureFromRecoParam();
   mMSTracker->setNLayers(6); 
+  mMSTracker->setStartLayer(5);
   createTracksOutput();
   return true;
 }

--- a/rec/src/NA6PTrack.cxx
+++ b/rec/src/NA6PTrack.cxx
@@ -12,8 +12,7 @@ ClassImp(NA6PTrack)
 NA6PTrack::NA6PTrack() :
   mMass{0.140},
   mChi2{0.0},
-  mChi2VT{0.0},
-  mNVTLayers{5},
+  mNLayers{6},
   mClusterMap{0},
   mNClusters{0},
   mNClustersVT{0},
@@ -32,8 +31,7 @@ NA6PTrack::NA6PTrack() :
 NA6PTrack::NA6PTrack(const double* xyz, const double* pxyz, int sign, double errLoose) :
   mMass{0.140},
   mChi2{0.0},
-  mChi2VT{0.0},
-  mNVTLayers{5},
+  mNLayers{6},
   mClusterMap{0},
   mNClusters{0},
   mNClustersVT{0},
@@ -56,14 +54,13 @@ void NA6PTrack::reset()
 {
   mMass = 0.14; 
   mChi2 = 0; 
-  mChi2VT = 0;
   mClusterMap = 0;
   mExtTrack.Reset();
   resetCovariance();
   mParticleID = -2;
   mClusterIndices.fill(-1);
   mClusterPartID.fill(-2);
-  mNClusters = mNClustersVT = mNClustersMS = mNClustersTR = 0;
+  mNClusters = mNClusters = mNClustersMS = mNClustersTR = 0;
 }
   
 //_______________________________________________________________________
@@ -229,7 +226,7 @@ std::string NA6PTrack::asString() const
   double pxyz[3];
   getPXYZ(pxyz);
   return fmt::format("Track: Nclusters:{} NVTclusters:{}  chi2:{} pos:{:.4f},{:.4f},{:.4f} mom:{:.3f},{:.3f},{:.3f}",
-                     mNClusters,mNClustersVT,mChi2,getXLab(),getYLab(),getZLab(),pxyz[0],pxyz[1],pxyz[2]);
+                     mNClusters,mNClusters,mChi2,getXLab(),getYLab(),getZLab(),pxyz[0],pxyz[1],pxyz[2]);
 }
 
 //_______________________________________________________________________
@@ -243,18 +240,18 @@ void NA6PTrack::addCluster(const NA6PBaseCluster* clu, int cluIndex, double chi2
 
   mNClusters++;
   mChi2 += chi2;
-  int nDet = clu->getDetectorID();
+  // int nDet = clu->getDetectorID();
   int trackID = clu->getParticleID();
-  if (nDet < mNVTLayers * 4) {
-    int nLay = nDet / 4;
-    mChi2VT += chi2;
-    mNClustersVT++;
-    mClusterPartID[nLay] = trackID;
-    mClusterIndices[nLay] = cluIndex;
-    mClusterMap |= (1<<nLay);
-  }
-  else if (nDet >= 20 && nDet < 24) mNClustersMS++;
-  else if (nDet >= 24) mNClustersTR++;
+  
+  int nLay = clu->getLayer();
+  mClusterPartID[nLay] = trackID;
+  mClusterIndices[nLay] = cluIndex;
+  mClusterMap |= (1<<nLay);
+
+  // if (nDet < mNLayers * 4) {
+  // }
+  // else if (nDet >= 20 && nDet < 24) mNClustersMS++;
+  // else if (nDet >= 24) mNClustersTR++;
 }
 
 //____________________________________________

--- a/rec/src/NA6PVerTelCluster.cxx
+++ b/rec/src/NA6PVerTelCluster.cxx
@@ -1,12 +1,12 @@
 // NA6PCCopyright
 
 #include "NA6PVerTelCluster.h"
-#include "NA6PLayoutParam.h"
 
+// NA6PCCopyright
 
-NA6PVerTelCluster::NA6PVerTelCluster(float x, float y, float z, int clusiz, int nDet)
-  : NA6PBaseCluster(x, y, z, clusiz)
+#include "NA6PVerTelCluster.h"
+
+NA6PVerTelCluster::NA6PVerTelCluster(float x, float y, float z, int clusiz, int layer)
+  : NA6PBaseCluster(x, y, z, clusiz, layer)
 {
-	mDetectorID = nDet;
-	mLayer = nDet / 4;
 }

--- a/rec/src/NA6PVerTelCluster.cxx
+++ b/rec/src/NA6PVerTelCluster.cxx
@@ -1,0 +1,20 @@
+// NA6PCCopyright
+
+#include "NA6PVerTelCluster.h"
+#include "NA6PLayoutParam.h"
+
+int NA6PVerTelCluster::getLayer() const {
+	float z = getZLab();
+	const auto& layout = NA6PLayoutParam::Instance();
+	const float dzWindow = 2.5f; // tighter window for VT planes
+	for (int i = 0; i < layout.nVerTelPlanes; ++i) {
+		float zPlane = layout.posVerTelPlaneZ[i];
+		if (z > (zPlane - dzWindow) && z < (zPlane + dzWindow)) {
+			return i;
+		}
+	}
+	return -1;
+}
+// NA6PCCopyright
+
+#include "NA6PVerTelCluster.h"

--- a/rec/src/NA6PVerTelCluster.cxx
+++ b/rec/src/NA6PVerTelCluster.cxx
@@ -3,18 +3,10 @@
 #include "NA6PVerTelCluster.h"
 #include "NA6PLayoutParam.h"
 
-int NA6PVerTelCluster::getLayer() const {
-	float z = getZLab();
-	const auto& layout = NA6PLayoutParam::Instance();
-	const float dzWindow = 2.5f; // tighter window for VT planes
-	for (int i = 0; i < layout.nVerTelPlanes; ++i) {
-		float zPlane = layout.posVerTelPlaneZ[i];
-		if (z > (zPlane - dzWindow) && z < (zPlane + dzWindow)) {
-			return i;
-		}
-	}
-	return -1;
-}
-// NA6PCCopyright
 
-#include "NA6PVerTelCluster.h"
+NA6PVerTelCluster::NA6PVerTelCluster(float x, float y, float z, int clusiz, int nDet)
+  : NA6PBaseCluster(x, y, z, clusiz)
+{
+	mDetectorID = nDet;
+	mLayer = nDet / 4;
+}

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -84,9 +84,11 @@ void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>&
       clusiz = 4;
     int nDet = hit.getDetectorID();
     int idPart = hit.getTrackID();
-    mClusters.emplace_back(x, y, z, clusiz, nDet);
+    int layer = nDet / 4;
+    mClusters.emplace_back(x, y, z, clusiz, layer);
     auto& clu = mClusters.back();
     clu.setErr(ex2clu, 0., ey2clu);
+    clu.setDetectorID(nDet);
     clu.setParticleID(idPart);
     clu.setHitID(jHit);
   }

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -21,6 +21,8 @@ bool NA6PVerTelReconstruction::init(const char* filename, const char* geoname)
 {
   NA6PReconstruction::init(filename, geoname);
   mVTTracker = new NA6PTrackerCA();
+  mVTTracker->setNLayers(5);
+  mVTTracker->setStartLayer(0);
   mVTTracker->configureFromRecoParam();
   createTracksOutput();
   return true;
@@ -81,10 +83,9 @@ void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>&
       clusiz = 4;
     int nDet = hit.getDetectorID();
     int idPart = hit.getTrackID();
-    mClusters.emplace_back(x, y, z, clusiz);
+    mClusters.emplace_back(x, y, z, clusiz, nDet);
     auto& clu = mClusters.back();
     clu.setErr(ex2clu, 0., ey2clu);
-    clu.setDetectorID(nDet);
     clu.setParticleID(idPart);
     clu.setHitID(jHit);
   }

--- a/rec/src/NA6PVertexerTracklets.cxx
+++ b/rec/src/NA6PVertexerTracklets.cxx
@@ -2,7 +2,7 @@
 
 #include <fmt/format.h>
 #include <fairlogger/Logger.h>
-#include "NA6PBaseCluster.h"
+#include "NA6PVerTelCluster.h"
 #include "NA6PVertex.h"
 #include "NA6PVertexerTracklets.h"
 
@@ -15,15 +15,14 @@ ClassImp(NA6PVertexerTracklets)
 
 //______________________________________________________________________
 
-void NA6PVertexerTracklets::sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,
+void NA6PVertexerTracklets::sortClustersByLayerAndEta(std::vector<NA6PVerTelCluster>& cluArr,
                                                       std::vector<int>& firstIndex,
                                                       std::vector<int>& lastIndex)
 {
   // count hits per layer
   std::vector<int> count(mNLayersVT, 0);
   for (const auto& clu : cluArr) {
-    int jDet = clu.getDetectorID();
-    int jLay = jDet / 4;
+    int jLay = clu.getLayer();
     if (jLay >= 0 && jLay < mNLayersVT) {
       count[jLay]++;
     }
@@ -39,9 +38,9 @@ void NA6PVertexerTracklets::sortClustersByLayerAndEta(std::vector<NA6PBaseCluste
   }
   // Create a reordered vector based on layer grouping
   std::vector<int> countReord = firstIndex;
-  std::vector<NA6PBaseCluster> reordered(cluArr.size());
+  std::vector<NA6PVerTelCluster> reordered(cluArr.size());
   for (const auto& clu : cluArr) {
-    int jLay = clu.getDetectorID() / 4;
+    int jLay = clu.getLayer();
     if (jLay >= 0 && jLay < mNLayersVT)
       reordered[countReord[jLay]++] = clu;
   }
@@ -50,7 +49,7 @@ void NA6PVertexerTracklets::sortClustersByLayerAndEta(std::vector<NA6PBaseCluste
   for (int jLay = 0; jLay < mNLayersVT; jLay++) {
     auto first = cluArr.begin() + firstIndex[jLay];
     auto last = cluArr.begin() + lastIndex[jLay];
-    std::sort(first, last, [](const NA6PBaseCluster& a, const NA6PBaseCluster& b) {
+    std::sort(first, last, [](const NA6PVerTelCluster& a, const NA6PVerTelCluster& b) {
       double xa = a.getX();
       double ya = a.getY();
       double za = a.getZ();
@@ -108,7 +107,7 @@ void NA6PVertexerTracklets::sortTrackletsByLayerAndIndex(std::vector<TrackletFor
 
 //______________________________________________________________________
 
-void NA6PVertexerTracklets::computeLayerTracklets(const std::vector<NA6PBaseCluster>& cluArr,
+void NA6PVertexerTracklets::computeLayerTracklets(const std::vector<NA6PVerTelCluster>& cluArr,
                                                   const std::vector<int>& firstIndex,
                                                   const std::vector<int>& lastIndex,
                                                   std::vector<TrackletForVertex>& tracklets)
@@ -120,7 +119,7 @@ void NA6PVertexerTracklets::computeLayerTracklets(const std::vector<NA6PBaseClus
     auto layerBegin = cluArr.begin() + firstIndex[iLayer + 1];
     auto layerEnd = cluArr.begin() + lastIndex[iLayer + 1];
     for (int jClu1 = firstIndex[iLayer]; jClu1 < lastIndex[iLayer]; ++jClu1) {
-      const NA6PBaseCluster& clu1 = cluArr[jClu1];
+      const NA6PVerTelCluster& clu1 = cluArr[jClu1];
       double x1 = clu1.getX();
       double y1 = clu1.getY();
       double z1 = clu1.getZ();
@@ -130,7 +129,7 @@ void NA6PVertexerTracklets::computeLayerTracklets(const std::vector<NA6PBaseClus
       double tanth2Min = std::max(0., std::tan(theta1 - 1.2 * mMaxDeltaThetaTracklet)); // 1.2 is a safety margin
       double tanth2Max = std::tan(std::min(M_PI / 2.001, theta1 + 1.2 * mMaxDeltaThetaTracklet));
       auto lower = std::partition_point(layerBegin, layerEnd,
-                                        [&](const NA6PBaseCluster& clu) {
+                                        [&](const NA6PVerTelCluster& clu) {
                                           double x = clu.getX();
                                           double y = clu.getY();
                                           double z = clu.getZ();
@@ -140,7 +139,7 @@ void NA6PVertexerTracklets::computeLayerTracklets(const std::vector<NA6PBaseClus
                                         });
 
       auto upper = std::partition_point(layerBegin, layerEnd,
-                                        [&](const NA6PBaseCluster& clu) {
+                                        [&](const NA6PVerTelCluster& clu) {
                                           double x = clu.getX();
                                           double y = clu.getY();
                                           double z = clu.getZ();
@@ -151,7 +150,7 @@ void NA6PVertexerTracklets::computeLayerTracklets(const std::vector<NA6PBaseClus
       int lowerIdx = std::distance(cluArr.begin(), lower);
       int upperIdx = std::distance(cluArr.begin(), upper);
       for (int jClu2 = lowerIdx; jClu2 < upperIdx; ++jClu2) {
-        const NA6PBaseCluster& clu2 = cluArr[jClu2];
+        const NA6PVerTelCluster& clu2 = cluArr[jClu2];
         double x2 = clu2.getX();
         double y2 = clu2.getY();
         double z2 = clu2.getZ();
@@ -183,7 +182,7 @@ void NA6PVertexerTracklets::computeLayerTracklets(const std::vector<NA6PBaseClus
 void NA6PVertexerTracklets::selectTracklets(const std::vector<TrackletForVertex>& tracklets,
                                             const std::vector<int>& firstIndex,
                                             const std::vector<int>& lastIndex,
-                                            const std::vector<NA6PBaseCluster>& cluArr,
+                                            const std::vector<NA6PVerTelCluster>& cluArr,
                                             std::vector<TrackletForVertex>& selTracklets)
 {
 
@@ -243,7 +242,7 @@ void NA6PVertexerTracklets::filterOutUsedTracklets(const std::vector<TrackletFor
 //______________________________________________________________________
 
 void NA6PVertexerTracklets::computeIntersections(const std::vector<TrackletForVertex>& selTracklets,
-                                                 const std::vector<NA6PBaseCluster>& cluArr,
+                                                 const std::vector<NA6PVerTelCluster>& cluArr,
                                                  std::vector<TracklIntersection>& zIntersec)
 {
   zIntersec.clear();
@@ -605,7 +604,7 @@ bool NA6PVertexerTracklets::findVertexKDE(const std::vector<TracklIntersection>&
 
 //______________________________________________________________________
 
-void NA6PVertexerTracklets::findVertices(std::vector<NA6PBaseCluster>& cluArr,
+void NA6PVertexerTracklets::findVertices(std::vector<NA6PVerTelCluster>& cluArr,
                                          std::vector<NA6PVertex>& vertices)
 {
 
@@ -660,7 +659,7 @@ void NA6PVertexerTracklets::findVertices(std::vector<NA6PBaseCluster>& cluArr,
 
 //______________________________________________________________________
 void NA6PVertexerTracklets::printStats(const std::vector<TrackletForVertex>& candidates,
-                                       const std::vector<NA6PBaseCluster>& cluArr,
+                                       const std::vector<NA6PVerTelCluster>& cluArr,
                                        const std::string& label)
 {
 
@@ -680,7 +679,7 @@ void NA6PVertexerTracklets::printStats(const std::vector<TrackletForVertex>& can
       if (cluID >= 0) {
         ++nTrueClus;
         const auto& clu = cluArr[cluID];
-        int jLay = clu.getDetectorID() / 4;
+        int jLay = clu.getLayer();
         if (jClu == 0 && jLay != startLay)
           LOGP(error, "mismatch in {} layers: {} {}", label.c_str(), jLay, startLay);
         int idPartClu = clu.getParticleID();

--- a/rec/src/NA6PVertexerTracklets.cxx
+++ b/rec/src/NA6PVertexerTracklets.cxx
@@ -149,14 +149,14 @@ void NA6PVertexerTracklets::sortClustersByLayerAndEta(std::vector<NA6PVerTelClus
     auto first = cluArr.begin() + firstIndex[jLay];
     auto last = cluArr.begin() + lastIndex[jLay];
     std::sort(first, last, [](const NA6PVerTelCluster& a, const NA6PVerTelCluster& b) {
-      double xa = a.getX();
-      double ya = a.getY();
-      double za = a.getZ();
-      double xb = b.getX();
-      double yb = b.getY();
-      double zb = b.getZ();
-      double r2a = xa * xa + ya * ya;
-      double r2b = xb * xb + yb * yb;
+      float xa = a.getX();
+      float ya = a.getY();
+      float za = a.getZ();
+      float xb = b.getX();
+      float yb = b.getY();
+      float zb = b.getZ();
+      float r2a = xa * xa + ya * ya;
+      float r2b = xb * xb + yb * yb;
       return za * za * r2b < zb * zb * r2a;
     });
   }

--- a/rec/src/recLinkDef.h
+++ b/rec/src/recLinkDef.h
@@ -8,6 +8,10 @@
 
 #pragma link C++ class NA6PBaseCluster + ;
 #pragma link C++ class std::vector < NA6PBaseCluster> + ;
+#pragma link C++ class NA6PVerTelCluster + ;
+#pragma link C++ class std::vector < NA6PVerTelCluster> + ;
+#pragma link C++ class NA6PMuonSpecCluster + ;
+#pragma link C++ class std::vector < NA6PMuonSpecCluster> + ;
 #pragma link C++ class NA6PTrack + ;
 #pragma link C++ class std::vector < NA6PTrack> + ;
 #pragma link C++ class NA6PVertex + ;
@@ -15,6 +19,7 @@
 
 #pragma link C++ class NA6PReconstruction + ;
 #pragma link C++ class NA6PVerTelReconstruction + ;
+#pragma link C++ class NA6PMuonSpecReconstruction + ;
 #pragma link C++ class ExtTrackPar + ;
 #pragma link C++ class NA6PVertexerTracklets + ;
 #pragma link C++ class NA6PTrackerCA + ;
@@ -22,5 +27,8 @@
 
 #pragma link C++ class NA6PRecoParam + ;
 #pragma link C++ class na6p::conf::ConfigurableParamHelper < NA6PRecoParam> + ;
+#pragma link C++ class NA6PMuonSpecRecoParam + ;
+#pragma link C++ class na6p::conf::ConfigurableParamHelper < NA6PMuonSpecRecoParam> + ;
+
 
 #endif

--- a/rec/src/recLinkDef.h
+++ b/rec/src/recLinkDef.h
@@ -27,8 +27,6 @@
 
 #pragma link C++ class NA6PRecoParam + ;
 #pragma link C++ class na6p::conf::ConfigurableParamHelper < NA6PRecoParam> + ;
-#pragma link C++ class NA6PMuonSpecRecoParam + ;
-#pragma link C++ class na6p::conf::ConfigurableParamHelper < NA6PMuonSpecRecoParam> + ;
 
 
 #endif

--- a/test/convertHitsToRecPoints.C
+++ b/test/convertHitsToRecPoints.C
@@ -7,28 +7,73 @@
 #include <TVector3.h>
 #include <TRandom3.h>
 #include "NA6PVerTelHit.h"
-#include "NA6PBaseCluster.h"
+#include "NA6PMuonSpecHit.h"
 #include "ConfigurableParam.h"
 #include <fairlogger/Logger.h>
 #include "NA6PVerTelReconstruction.h"
+#include "NA6PMuonSpecReconstruction.h"
 #endif
 
 void convertHitsToRecPoints(){
-  TFile* fh=new TFile("HitsVerTel.root");
-  TTree* th=(TTree*)fh->Get("hitsVerTel");
-  std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
-  th->SetBranchAddress("VerTel", &vtHitsPtr);
-  int nEv=th->GetEntriesFast();
+  // Process VerTel hits
+  TFile* fhVT = TFile::Open("HitsVerTel.root");
+  if (!fhVT || fhVT->IsZombie()) {
+    LOGP(error, "Cannot open HitsVerTel.root");
+    if (fhVT) delete fhVT;
+  } else {
+    TTree* thVT = (TTree*)fhVT->Get("hitsVerTel");
+    if (!thVT) {
+      LOGP(error, "Cannot find tree 'hitsVerTel' in HitsVerTel.root");
+    } else {
+      std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
+      thVT->SetBranchAddress("VerTel", &vtHitsPtr);
+      int nEvVT = thVT->GetEntriesFast();
 
-  NA6PVerTelReconstruction* recVT = new NA6PVerTelReconstruction();
-  recVT->createClustersOutput();
-  for(int jEv=0; jEv<nEv; jEv++){
-    th->GetEvent(jEv);
-    int nHits=vtHits.size();
-    printf("Event %d nHits=%d\n",jEv,nHits);
-    recVT->clearClusters();
-    recVT->hitsToRecPoints(vtHits);
-    recVT->writeClusters();
+      NA6PVerTelReconstruction* recVT = new NA6PVerTelReconstruction();
+      recVT->createClustersOutput();
+      for(int jEv=0; jEv<nEvVT; jEv++){
+        thVT->GetEvent(jEv);
+        int nHits = vtHits.size();
+        printf("VerTel Event %d nHits=%d\n", jEv, nHits);
+        recVT->clearClusters();
+        recVT->hitsToRecPoints(vtHits);
+        recVT->writeClusters();
+      }
+      recVT->closeClustersOutput();
+      delete recVT;
+    }
+    fhVT->Close();
+    delete fhVT;
   }
-  recVT->closeClustersOutput();
+
+  // Process MuonSpec hits
+  TFile* fhMS = TFile::Open("HitsMuonSpecModular.root");
+  if (!fhMS || fhMS->IsZombie()) {
+    LOGP(error, "Cannot open HitsMuonSpecModular.root");
+    if (fhMS) delete fhMS;
+  } else {
+    TTree* thMS = (TTree*)fhMS->Get("hitsMuonSpecModular");
+    if (!thMS) {
+      LOGP(error, "Cannot find tree 'hitsMuonSpecModular' in HitsMuonSpecModular.root");
+    } else {
+      std::vector<NA6PMuonSpecModularHit> msHits, *msHitsPtr = &msHits;
+      thMS->SetBranchAddress("MuonSpecModular", &msHitsPtr);
+      int nEvMS = thMS->GetEntriesFast();
+
+      NA6PMuonSpecReconstruction* recMS = new NA6PMuonSpecReconstruction();
+      recMS->createClustersOutput();
+      for(int jEv=0; jEv<nEvMS; jEv++){
+        thMS->GetEvent(jEv);
+        int nHits = msHits.size();
+        printf("MuonSpec Event %d nHits=%d\n", jEv, nHits);
+        recMS->clearClusters();
+        recMS->hitsToRecPoints(msHits);
+        recMS->writeClusters();
+      }
+      recMS->closeClustersOutput();
+      delete recMS;
+    }
+    fhMS->Close();
+    delete fhMS;
+  }
 }

--- a/test/inspectVertexerTracklets.C
+++ b/test/inspectVertexerTracklets.C
@@ -17,7 +17,7 @@
 #include <TVectorD.h>
 #include <TRandom3.h>
 #include <TStopwatch.h>
-#include "NA6PBaseCluster.h"
+#include "NA6PVerTelCluster.h"
 #include "NA6PVertex.h"
 #include "NA6PVertexerTracklets.h"
 #endif
@@ -36,7 +36,7 @@ void inspectVertexerTracklets(int firstEv = 0,
   TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
   printf("Open cluster file: %s\n",fc->GetName());
   TTree* tc=(TTree*)fc->Get("clustersVerTel");
-  std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
+  std::vector<NA6PVerTelCluster> vtClus, *vtClusPtr = &vtClus;
   tc->SetBranchAddress("VerTel", &vtClusPtr);
 
   if(lastEv>nEv || lastEv<0) lastEv=nEv;

--- a/test/runFastFitOnHits.C
+++ b/test/runFastFitOnHits.C
@@ -19,6 +19,7 @@
 #include <TVector3.h>
 #include <TRandom3.h>
 #include "NA6PVerTelHit.h"
+#include "NA6PMuonSpecModularHit.h"
 #include "NA6PTrack.h"
 #include "NA6PBaseCluster.h"
 #include "NA6PFastTrackFitter.h"
@@ -28,47 +29,49 @@
 #include "NA6PLayoutParam.h"
 #endif
 
-
 // simple macro with an example of how to use NA6PFastFitter to fit tracks starting from their hits in the VT
 // uses the MC truth information to group the hits produced by the same particle
 
-void SuperposHistos(TH1* h1, TH1* h2, TH1* h3){
+void SuperposHistos(TH1* h1, TH1* h2, TH1* h3)
+{
   h1->SetLineColor(1);
   h1->SetLineWidth(2);
-  if(h2->GetMaximum()>h1->GetMaximum()) h1->SetMaximum(1.02*h2->GetMaximum());
-  if(h3->GetMaximum()>h1->GetMaximum()) h1->SetMaximum(1.02*h3->GetMaximum());
+  if (h2->GetMaximum() > h1->GetMaximum())
+    h1->SetMaximum(1.02 * h2->GetMaximum());
+  if (h3->GetMaximum() > h1->GetMaximum())
+    h1->SetMaximum(1.02 * h3->GetMaximum());
   h1->SetMinimum(0);
   h1->Draw();
   h2->SetLineColor(2);
   h2->SetLineWidth(2);
   h2->Draw("sames");
-  h3->SetLineColor(kGreen+1);
+  h3->SetLineColor(kGreen + 1);
   h3->SetLineWidth(2);
   h3->Draw("sames");
   gPad->Update();
-  TPaveStats* st1=(TPaveStats*)h1->GetListOfFunctions()->FindObject("stats");
-  if(st1){
+  TPaveStats* st1 = (TPaveStats*)h1->GetListOfFunctions()->FindObject("stats");
+  if (st1) {
     st1->SetY1NDC(0.72);
     st1->SetY2NDC(0.92);
     st1->SetTextColor(1);
   }
-  TPaveStats* st2=(TPaveStats*)h2->GetListOfFunctions()->FindObject("stats");
-  if(st2){
+  TPaveStats* st2 = (TPaveStats*)h2->GetListOfFunctions()->FindObject("stats");
+  if (st2) {
     st2->SetY1NDC(0.51);
     st2->SetY2NDC(0.71);
     st2->SetTextColor(2);
   }
-  TPaveStats* st3=(TPaveStats*)h3->GetListOfFunctions()->FindObject("stats");
-  if(st3){
+  TPaveStats* st3 = (TPaveStats*)h3->GetListOfFunctions()->FindObject("stats");
+  if (st3) {
     st3->SetY1NDC(0.30);
     st3->SetY2NDC(0.50);
-    st3->SetTextColor(kGreen+1);
+    st3->SetTextColor(kGreen + 1);
   }
   gPad->Modified();
 }
 
-
-void FillMeanAndRms(TH2F* hImpParVsP, TH1F* hImpParMean, TH1F* hImpParRms, TH1F* hImpParSig){
+void FillMeanAndRms(TH2F* hImpParVsP, TH1F* hImpParMean, TH1F* hImpParRms, TH1F* hImpParSig)
+{
   if (!hImpParVsP || !hImpParMean || !hImpParRms || !hImpParSig) {
     printf("One of pointers is not set: hImpParVsP=%p hImpParMean=%p hImpParRms=%p hImpParSig=%p\n", hImpParVsP, hImpParMean, hImpParRms, hImpParSig);
     return;
@@ -77,261 +80,311 @@ void FillMeanAndRms(TH2F* hImpParVsP, TH1F* hImpParMean, TH1F* hImpParRms, TH1F*
   hImpParMean->SetStats(0);
   hImpParRms->SetStats(0);
   hImpParSig->SetStats(0);
-  for(int jp = 1; jp <= nMomBins; jp++){
-    TH1D* htmp1 = hImpParVsP->ProjectionY("htmp1",jp,jp);
+  for (int jp = 1; jp <= nMomBins; jp++) {
+    TH1D* htmp1 = hImpParVsP->ProjectionY("htmp1", jp, jp);
     double mean = htmp1->GetMean();
     double emean = htmp1->GetMeanError();
     double rms = htmp1->GetRMS();
     double erms = htmp1->GetRMSError();
-    hImpParMean->SetBinContent(jp,mean);
-    hImpParMean->SetBinError(jp,emean);
-    hImpParRms->SetBinContent(jp,rms);
-    hImpParRms->SetBinError(jp,erms);
+    hImpParMean->SetBinContent(jp, mean);
+    hImpParMean->SetBinError(jp, emean);
+    hImpParRms->SetBinContent(jp, rms);
+    hImpParRms->SetBinError(jp, erms);
     double gw = rms;
     double egw = erms;
-    if(htmp1->GetEntries()>20. && htmp1->Fit("gaus","Q","",-3.*rms,3.*rms)) {
+    if (htmp1->GetEntries() > 20. && htmp1->Fit("gaus", "Q", "", -3. * rms, 3. * rms)) {
       TF1* fg = (TF1*)htmp1->GetListOfFunctions()->FindObject("gaus");
-      if (!fg) continue;
+      if (!fg)
+        continue;
       gw = fg->GetParameter(2);
       egw = fg->GetParError(2);
     }
-    hImpParSig->SetBinContent(jp,gw);
-    hImpParSig->SetBinError(jp,egw);
+    hImpParSig->SetBinContent(jp, gw);
+    hImpParSig->SetBinError(jp, egw);
     delete htmp1;
   }
 }
 
-void runFastFitOnHits(int firstEv = 0,
-		      int lastEv = 99999999,
-		      double clures = 5.e-4,
-		      const char *dirSimu = "../testN6Proot/pions/50evwithtarget",
-		      int minITShits=5) {
-  
+
+// Template function to run fast fit on hits - works with both NA6PVerTelHit and NA6PMuonSpecModularHit
+template <typename HitType>
+void runFastFitOnHitsTemplate(int firstEv = 0,
+                               int lastEv = 99999999,
+                               double cluresx = 5.e-4,
+                               double cluresy = 5.e-4,
+                               const char* dirSimu = "../tst",
+                               const char* hitFileName = "HitsVerTel.root",
+                               const char* hitTreeName = "hitsVerTel",
+                               const char* hitBranchName = "VerTel",
+                               int nLayers = 5,
+                               int minHits = 5,
+                               bool useVT = true)
+{
+
   // na6p::conf::ConfigurableParam::updateFromFile(Form("%s/na6pLayout.ini",dirSimu),"",true);
   // const auto& param = NA6PLayoutParam::Instance();
-  
-  TFile* fk=new TFile(Form("%s/MCKine.root",dirSimu));
-  TTree* mcTree=(TTree*)fk->Get("mckine");
-  int nEv=mcTree->GetEntries();
+
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  int nEv = mcTree->GetEntries();
   std::vector<TParticle>* mcArr = nullptr;
   mcTree->SetBranchAddress("tracks", &mcArr);
 
-  TFile* fh=new TFile(Form("%s/HitsVerTel.root",dirSimu));
-  TTree* th=(TTree*)fh->Get("hitsVerTel");
-  std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
-  th->SetBranchAddress("VerTel", &vtHitsPtr);
+  TFile* fh = new TFile(Form("%s/%s", dirSimu, hitFileName));
+  TTree* th = (TTree*)fh->Get(hitTreeName);
+  std::vector<HitType> hits, *hitsPtr = &hits;
+  th->SetBranchAddress(hitBranchName, &hitsPtr);
 
   int nMomBins = 20;
-  double maxP = 10.;
-  TH1F* hEtaGen = new TH1F("hEtaGen",";#eta;counts",20,0.,5.);
-  TH1F* hEtaReco = new TH1F("hEtaReco",";#eta;counts",20,0.,5.);
-  TH1F* hDeltaPx = new TH1F("hDeltaPx",";p_{x}^{rec}-p_{x}^{gen} (GeV/c);counts",100,-0.2,0.2);
-  TH1F* hDeltaPy = new TH1F("hDeltaPy",";p_{y}^{rec}-p_{y}^{gen} (GeV/c);counts",100,-0.2,0.2);
-  TH1F* hDeltaPz = new TH1F("hDeltaPz",";p_{z}^{rec}-p_{z}^{gen} (GeV/c);counts",100,-0.5,0.5);
-  TH1F* hDeltaP = new TH1F("hDeltaP",";p^{rec}-p^{gen} (GeV/c);counts",100,-0.5,0.5);
-  TH1F* hDeltaPhi = new TH1F("hDeltaPhi",";#varphi^{rec}-#varphi^{gen};counts",100,-M_PI/4.,M_PI/4.);
-  TH1F* hDeltaEta = new TH1F("hDeltaEta",";#eta^{rec}-#eta^{gen};counts",100,-0.5,0.5);
-  TH1F* hImpParX = new TH1F("hImpParX",";Track Imp. Par. X (#mum)};counts",100,-500,500);
-  TH1F* hImpParY = new TH1F("hImpParY",";Track Imp. Par. Y (#mum)};counts",100,-500,500);
-  TH2F* hImpParXVsP = new TH2F("hImpParXVsP",";p (GeV/c);Track Imp. Par. X (#mum)};counts",nMomBins,0.,maxP,100,-500.,500.);
-  TH2F* hImpParYVsP = new TH2F("hImpParYVsP",";p (GeV/c);Track Imp. Par. Y (#mum)};counts",nMomBins,0.,maxP,100,-500.,500.);
-  TH2F* hDeltaPxVsP = new TH2F("hDeltaPxVsP",";p (GeV/c);p_{x}^{rec}-p_{x}^{gen} (GeV/c);counts",nMomBins,0.,maxP,500,-0.5,0.5);
-  TH2F* hDeltaPyVsP = new TH2F("hDeltaPyVsP",";p (GeV/c);p_{y}^{rec}-p_{y}^{gen} (GeV/c);counts",nMomBins,0.,maxP,500,-0.5,0.5);
-  TH2F* hDeltaPzVsP = new TH2F("hDeltaPzVsP",";p (GeV/c);p_{z}^{rec}-p_{z}^{gen} (GeV/c);counts",nMomBins,0.,maxP,500,-0.5,0.5);
-  TH2F* hDeltaPVsP = new TH2F("hDeltaPVsP",";p (GeV/c);p^{rec}-p^{gen} (GeV/c);counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH2F* hRelDeltaPxVsP = new TH2F("hRelDeltaPxVsP",";p (GeV/c);(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen};counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH2F* hRelDeltaPyVsP = new TH2F("hRelDeltaPyVsP",";p (GeV/c);(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen};counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH2F* hRelDeltaPzVsP = new TH2F("hRelDeltaPzVsP",";p (GeV/c);(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen};counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH2F* hRelDeltaPVsP = new TH2F("hRelDeltaPVsP",";p (GeV/c);(p^{rec}-p^{gen})/p_{gen};counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH1F* hIsGood = new TH1F("hIsGood","",2,-0.5,1.5);
-  hIsGood->GetXaxis()->SetBinLabel(1,"bad");
-  hIsGood->GetXaxis()->SetBinLabel(2,"good");
-  TH1F* hNclu = new TH1F("hNclu",";n_{ITSclus};counts",7,-0.5,6.5);
-  TH1F* hChi2NDF = new TH1F("hChi2NDF",";#chi^{2}/nDOF;counts",100,0.,10.);
+  double maxP = 20.;
+  TH1F* hEtaGen = new TH1F("hEtaGen", ";#eta;counts", 20, 0., 5.);
+  TH1F* hEtaReco = new TH1F("hEtaReco", ";#eta;counts", 20, 0., 5.);
+  TH1F* hDeltaPx = new TH1F("hDeltaPx", ";p_{x}^{rec}-p_{x}^{gen} (GeV/c);counts", 100, -0.2, 0.2);
+  TH1F* hDeltaPy = new TH1F("hDeltaPy", ";p_{y}^{rec}-p_{y}^{gen} (GeV/c);counts", 100, -0.2, 0.2);
+  TH1F* hDeltaPz = new TH1F("hDeltaPz", ";p_{z}^{rec}-p_{z}^{gen} (GeV/c);counts", 100, -0.5, 0.5);
+  TH1F* hDeltaP = new TH1F("hDeltaP", ";p^{rec}-p^{gen} (GeV/c);counts", 100, -0.5, 0.5);
+  TH1F* hDeltaPhi = new TH1F("hDeltaPhi", ";#varphi^{rec}-#varphi^{gen};counts", 100, -M_PI / 4., M_PI / 4.);
+  double impMax = 60000.; // in microns
+  double deltaMax = 1; // in GeV/c
+  if(useVT){
+    impMax = 500.; // in microns
+    deltaMax = 0.5; // in GeV/c
+  }
+  TH1F* hDeltaEta = new TH1F("hDeltaEta", ";#eta^{rec}-#eta^{gen};counts", 100, -0.5, 0.5);
+  TH1F* hImpParX = new TH1F("hImpParX", ";Track Imp. Par. X (#mum)};counts", 100, -impMax, impMax);
+  TH1F* hImpParY = new TH1F("hImpParY", ";Track Imp. Par. Y (#mum)};counts", 100, -impMax, impMax);
+  TH2F* hImpParXVsP = new TH2F("hImpParXVsP", ";p (GeV/c);Track Imp. Par. X (#mum)};counts", nMomBins, 0., maxP, 100, -impMax, impMax);
+  TH2F* hImpParYVsP = new TH2F("hImpParYVsP", ";p (GeV/c);Track Imp. Par. Y (#mum)};counts", nMomBins, 0., maxP, 100, -impMax, impMax);
+  TH2F* hDeltaPxVsP = new TH2F("hDeltaPxVsP", ";p (GeV/c);p_{x}^{rec}-p_{x}^{gen} (GeV/c);counts", nMomBins, 0., maxP, 500, -deltaMax, deltaMax);
+  TH2F* hDeltaPyVsP = new TH2F("hDeltaPyVsP", ";p (GeV/c);p_{y}^{rec}-p_{y}^{gen} (GeV/c);counts", nMomBins, 0., maxP, 500, -deltaMax, deltaMax);
+  TH2F* hDeltaPzVsP = new TH2F("hDeltaPzVsP", ";p (GeV/c);p_{z}^{rec}-p_{z}^{gen} (GeV/c);counts", nMomBins, 0., maxP, 500, -deltaMax, deltaMax);
+  TH2F* hDeltaPVsP = new TH2F("hDeltaPVsP", ";p (GeV/c);p^{rec}-p^{gen} (GeV/c);counts", nMomBins, 0., maxP, 100, -deltaMax, deltaMax);
+  TH2F* hRelDeltaPxVsP = new TH2F("hRelDeltaPxVsP", ";p (GeV/c);(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen};counts", nMomBins, 0., maxP, 100, -deltaMax, deltaMax);
+  TH2F* hRelDeltaPyVsP = new TH2F("hRelDeltaPyVsP", ";p (GeV/c);(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen};counts", nMomBins, 0., maxP, 100, -deltaMax, deltaMax);
+  TH2F* hRelDeltaPzVsP = new TH2F("hRelDeltaPzVsP", ";p (GeV/c);(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen};counts", nMomBins, 0., maxP, 100, -deltaMax, deltaMax);
+  TH2F* hRelDeltaPVsP = new TH2F("hRelDeltaPVsP", ";p (GeV/c);(p^{rec}-p^{gen})/p_{gen};counts", nMomBins, 0., maxP, 100, -deltaMax, deltaMax);
+  TH1F* hIsGood = new TH1F("hIsGood", "", 2, -0.5, 1.5);
+  hIsGood->GetXaxis()->SetBinLabel(1, "bad");
+  hIsGood->GetXaxis()->SetBinLabel(2, "good");
+  TH1F* hNclu = new TH1F("hNclu", ";n_{ITSclus};counts", 7, -0.5, 6.5);
+  TH1F* hChi2NDF = new TH1F("hChi2NDF", ";#chi^{2}/nDOF;counts", 100, 0., 10.);
 
-  if(lastEv>nEv || lastEv<0) lastEv=nEv;
-  if(firstEv<0) firstEv=0;
-  
+  if (lastEv > nEv || lastEv < 0)
+    lastEv = nEv;
+  if (firstEv < 0)
+    firstEv = 0;
+
   NA6PTreeStreamRedirector outTr("fitCheck.root");
 
   NA6PFastTrackFitter* fitter = new NA6PFastTrackFitter();
-  fitter->loadGeometry(Form("%s/geometry.root",dirSimu));
-  fitter->setNLayersVT(5);
-  fitter->setMaxChi2Cl(10.);
+  fitter->loadGeometry(Form("%s/geometry.root", dirSimu));
+  fitter->setNLayers(nLayers);
+  fitter->setMaxChi2Cl(10000);
   fitter->setPropagateToPrimaryVertex(true);
   // fitter->setSeedFromTwoOutermostHits();
   // fitter->setCharge(2);
   // fitter->setParticleHypothesis(2212);
   // fitter->disableMaterialCorrections();
-  for(int jEv=firstEv;jEv<lastEv; jEv++){
+  const auto& layout = NA6PLayoutParam::Instance();
+
+  for (int jEv = firstEv; jEv < lastEv; jEv++) {
     mcTree->GetEvent(jEv);
     th->GetEvent(jEv);
-    int nPart=mcArr->size();
-    int nHits=vtHits.size();
+    int nPart = mcArr->size();
+    int nHits = hits.size();
     double zvert = 0;
     // get primary vertex position from the Kine Tree
-    for(int jp=0; jp<nPart; jp++){
-      auto curPart=mcArr->at(jp);
-      if(curPart.IsPrimary()){
-	zvert =  curPart.Vz();
-	break;
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      if (curPart.IsPrimary()) {
+        zvert = curPart.Vz();
+        break;
       }
     }
     fitter->setPrimaryVertexZ(zvert);
-    for(int jp=0; jp<nPart; jp++){
-      const auto& curPart=mcArr->at(jp);
-      double pxPart=curPart.Px();
-      double pyPart=curPart.Py();
-      double pzPart=curPart.Pz();
-      double momPart=curPart.P();
-      double phiPart=curPart.Phi();
-      double thetaPart=std::acos(pzPart/momPart);
-      double etaPart=-std::log(std::tan(thetaPart/2.));
-      std::array<std::unique_ptr<NA6PBaseCluster>, 5> clusters{ nullptr, nullptr, nullptr, nullptr, nullptr };
-      double xclu[5],yclu[5],zclu[5];
-      if(curPart.IsPrimary()){
-	hEtaGen->Fill(etaPart);
-	int maskHits = 0;
-	fitter->cleanupAndStartFit();
-	for(const auto& hit : vtHits) {
-	  int idPart=hit.getTrackID();
-	  if(idPart==jp){
-	    int nDet=hit.getDetectorID();
-	    int nLay=nDet/4;
-	    maskHits += (1<<nLay);
-	    if(clures > 0){
-	      xclu[nLay] = gRandom->Gaus(hit.getX(),clures); 
-	      yclu[nLay] = gRandom->Gaus(hit.getY(),clures); 
-	      zclu[nLay] = hit.getZ(); 
-	    }else{
-	      xclu[nLay] = hit.getX(); 
-	      yclu[nLay] = hit.getY(); 
-	      zclu[nLay] = hit.getZ(); 
-	    }
-	    NA6PBaseCluster* clu = new NA6PBaseCluster(xclu[nLay], yclu[nLay], zclu[nLay], idPart);
-	    clu->setDetectorID(nDet);
-	    if(clures>0)  clu->setErr(clures*clures,0.,clures*clures);
-	    else clu->setErr(1.e-6,0.,1e-6);
-	    fitter->addClusterVT(nLay,clu);
-	  }
-	}
-	// track only particles with 5 hits in the VT
-	if (maskHits != 31) continue;
+    for (int jp = 0; jp < nPart; jp++) {
+      const auto& curPart = mcArr->at(jp);
+      double pxPart = curPart.Px();
+      double pyPart = curPart.Py();
+      double pzPart = curPart.Pz();
+      double momPart = curPart.P();
+      double phiPart = curPart.Phi();
+      double thetaPart = std::acos(pzPart / momPart);
+      double etaPart = -std::log(std::tan(thetaPart / 2.));
+      std::vector<double> xclu(nLayers), yclu(nLayers), zclu(nLayers);        
+      int maskHits = 0;
+      if (curPart.GetPdgCode()==13) {
+        hEtaGen->Fill(etaPart);
+        fitter->cleanupAndStartFit();
+        for (const auto& hit : hits) {
+          int idPart = hit.getTrackID();
+          if (idPart == jp) {
+            int nDet = hit.getDetectorID();
+            int nLay = -1; // initialize to invalid value
+            if (useVT) {
+              nLay = nDet / 4; // Get layer from detector ID for VT
+            } else {
+              // Lookup layer from layout parameters for MS
+              float hitZ = (hit.getZIn() + hit.getZOut()) / 2.f; // use average Z
+              const float dzWindow = 20.f; // half-width window
+              for (int i = 0; i < layout.nMSPlanes; ++i) {
+                float zPlane = layout.posMSPlaneZ[i];
+                if (hitZ > (zPlane - dzWindow) && hitZ < (zPlane + dzWindow)) {
+                  nLay = i;
+                  break;
+                }
+              }
+              if (nLay < 0)
+                continue; // skip hits not in expected z ranges
+            }
+            if (nLay < 0 || nLay >= nLayers) continue; // safety check: skip if layer index out of bounds
+            maskHits |= (1 << nLay); // use bitmask instead of counter
+            if (cluresx > 0 && cluresy > 0) {
+              xclu[nLay] = gRandom->Gaus(hit.getX(), cluresx);
+              yclu[nLay] = gRandom->Gaus(hit.getY(), cluresy);
+              zclu[nLay] = hit.getZ();
+            } else {
+              xclu[nLay] = hit.getX();
+              yclu[nLay] = hit.getY();
+              zclu[nLay] = hit.getZ();
+            }
+            NA6PBaseCluster* clu = new NA6PBaseCluster(xclu[nLay], yclu[nLay], zclu[nLay], idPart);
+            clu->setDetectorID(nLay);
+            if (cluresx > 0 && cluresy > 0)
+              clu->setErr(cluresx * cluresx, 0., cluresy * cluresy);
+            else
+              clu->setErr(1.e-6, 0., 1e-6);
+            std::cout << "Adding cluster at layer " << nLay << " (det " << nDet << ") for track " << jp << "\n";
+            fitter->addCluster(nLay, clu);
+            
+            // else fitter->addClusterMS(nLay, clu); // TODO: add support for MS
+          }
+        }
+        int expectedMask = (1 << nLayers) - 1; // e.g., for 6 layers: 63 = 0b111111
 
-	
-	// Uncomment the next lines to use the MC truth as seed for the track
-	//	double xyz0[3]={xclu[4],yclu[4],zclu[4]};	
-	//	double pxyz0[3]={curPart.Px(),curPart.Py(),curPart.Pz()};
-	//	printf("Initialize seed at %f %f %f p = %f %f %f\n",xyz0[0],xyz0[1],xyz0[2],pxyz0[0],pxyz0[1],pxyz0[2]);
-	//	int sign = curPart.GetPdgCode() > 0 ? 1 : -1;
-	//	fitter->setSeed(xyz0,pxyz0,sign);
+        if (maskHits != expectedMask) {
+          continue;
+        }
 
-	NA6PTrack* currTr = fitter->fitTrackPointsVT();
-	//	fitter->propagateToZ(currTr,zvert); 
-	double chiFit = -1.;
-	if(currTr){
-	  hIsGood->Fill(1);
-	  int nClusters = currTr->getNVTHits();
-	  hNclu->Fill(nClusters);
-	  if(nClusters<5) continue;
-	  chiFit = currTr->getChi2();
-	  //	  printf("chi2 = %f  chi2/ndf = %f\n",chiFit,currTr->GetNormChi2());
-	  double pxyz[3];
-	  currTr->getPXYZ(pxyz);
-	  double pxtr=pxyz[0];
-	  double pytr=pxyz[1];
-	  double pztr=pxyz[2];
-	  double momtr=currTr->getP();
-	  double phitr=std::atan2(pytr,pxtr);
-	  double thetatr=std::acos(pztr/momtr);
-	  double etatr=-std::log(std::tan(thetatr/2.));
-	  double impparX = currTr->getXLab();
-	  double impparY = currTr->getYLab();
-	  hEtaReco->Fill(etatr);
-	  hDeltaPx->Fill(pxtr-pxPart);
-	  hDeltaPy->Fill(pytr-pyPart);
-	  hDeltaPz->Fill(pztr-pzPart);
-	  hDeltaP->Fill(momtr-momPart);
-	  hDeltaPxVsP->Fill(momtr,pxtr-pxPart);
-	  hDeltaPyVsP->Fill(momtr,pytr-pyPart);
-	  hDeltaPzVsP->Fill(momtr,pztr-pzPart);
-	  hDeltaPVsP->Fill(momtr,momtr-momPart);
-	  hRelDeltaPxVsP->Fill(momtr,(pxtr-pxPart)/pxPart);
-	  hRelDeltaPyVsP->Fill(momtr,(pytr-pyPart)/pyPart);
-	  hRelDeltaPzVsP->Fill(momtr,(pztr-pzPart)/pzPart);
-	  hRelDeltaPVsP->Fill(momtr,(momtr-momPart)/momPart);
-	  hDeltaPhi->Fill(phitr-phiPart);
-	  hDeltaEta->Fill(etatr-etaPart);
-	  hImpParX->Fill(impparX*1e4);
-	  hImpParY->Fill(impparY*1e4);
-	  hImpParXVsP->Fill(momtr,impparX*1e4);
-	  hImpParYVsP->Fill(momtr,impparY*1e4);
-	  hChi2NDF->Fill(chiFit);
-	}else{
-	  hIsGood->Fill(0); 
-	}	
-	TParticle trFit;
-	if (currTr) {
-	  double pos[3],mom[3];
-	  currTr->getPXYZ(mom);
-	  TLorentzVector v;
-	  v.SetXYZM(mom[0], mom[1], mom[2], 0.14);
-	  trFit.SetMomentum(v);
-	  trFit.SetProductionVertex(currTr->getXLab(), currTr->getYLab(), currTr->getZLab(), 0);
-	}
-	outTr << "out" << "mcTr=" << curPart << "fitTr=" << trFit << "fitChi2=" << chiFit << "\n";
+        // Uncomment the next lines to use the MC truth as seed for the track
+        //	double xyz0[3]={xclu[nLayers-1],yclu[nLayers-1],zclu[nLayers-1]};
+        //	double pxyz0[3]={curPart.Px(),curPart.Py(),curPart.Pz()};
+        //	printf("Initialize seed at %f %f %f p = %f %f %f\n",xyz0[0],xyz0[1],xyz0[2],pxyz0[0],pxyz0[1],pxyz0[2]);
+        //	int sign = curPart.GetPdgCode() > 0 ? 1 : -1;
+        //	fitter->setSeed(xyz0,pxyz0,sign);
+
+        NA6PTrack* currTr = fitter->fitTrackPoints();
+        std::cout << "Track fit done.\n";
+        //	fitter->propagateToZ(currTr,zvert);
+        double chiFit = -1.;
+        if (currTr) {
+          hIsGood->Fill(1);
+          int nClusters = currTr->getNHits();
+          hNclu->Fill(nClusters);
+          if (nClusters != minHits){
+            std::cout << "Skipping track with only " << nClusters << " hits (minHits=" << minHits << ")\n";
+            continue;
+          }
+          else
+            std::cout << "Fitted track with " << nClusters << " hits\n";
+          chiFit = currTr->getChi2();
+          //	  printf("chi2 = %f  chi2/ndf = %f\n",chiFit,currTr->GetNormChi2());
+          double pxyz[3];
+          currTr->getPXYZ(pxyz);
+          double pxtr = pxyz[0];
+          double pytr = pxyz[1];
+          double pztr = pxyz[2];
+          double momtr = currTr->getP();
+          double phitr = std::atan2(pytr, pxtr);
+          double thetatr = std::acos(pztr / momtr);
+          double etatr = -std::log(std::tan(thetatr / 2.));
+          double impparX = currTr->getXLab();
+          double impparY = currTr->getYLab();
+          hEtaReco->Fill(etatr);
+          hDeltaPx->Fill(pxtr - pxPart);
+          hDeltaPy->Fill(pytr - pyPart);
+          hDeltaPz->Fill(pztr - pzPart);
+          hDeltaP->Fill(momtr - momPart);
+          hDeltaPxVsP->Fill(momtr, pxtr - pxPart);
+          hDeltaPyVsP->Fill(momtr, pytr - pyPart);
+          hDeltaPzVsP->Fill(momtr, pztr - pzPart);
+          hDeltaPVsP->Fill(momtr, momtr - momPart);
+          hRelDeltaPxVsP->Fill(momtr, (pxtr - pxPart) / pxPart);
+          hRelDeltaPyVsP->Fill(momtr, (pytr - pyPart) / pyPart);
+          hRelDeltaPzVsP->Fill(momtr, (pztr - pzPart) / pzPart);
+          hRelDeltaPVsP->Fill(momtr, (momtr - momPart) / momPart);
+          hDeltaPhi->Fill(phitr - phiPart);
+          hDeltaEta->Fill(etatr - etaPart);
+          hImpParX->Fill(impparX * 1e4);
+          hImpParY->Fill(impparY * 1e4);
+          hImpParXVsP->Fill(momtr, impparX * 1e4);
+          hImpParYVsP->Fill(momtr, impparY * 1e4);
+          hChi2NDF->Fill(chiFit);
+        } else {
+          hIsGood->Fill(0);
+        }
+        TParticle trFit;
+        if (currTr) {
+          double pos[3], mom[3];
+          currTr->getPXYZ(mom);
+          TLorentzVector v;
+          v.SetXYZM(mom[0], mom[1], mom[2], 0.14);
+          trFit.SetMomentum(v);
+          trFit.SetProductionVertex(currTr->getXLab(), currTr->getYLab(), currTr->getZLab(), 0);
+        }
+        outTr << "out" << "mcTr=" << curPart << "fitTr=" << trFit << "fitChi2=" << chiFit << "\n";
       }
     }
   }
   outTr.Close();
 
-  TH1F* hImpParXMean = new TH1F("hImpParXMean",";p (GeV/c);<Imp Par X> (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParYMean = new TH1F("hImpParYMean",";p (GeV/c);<Imp Par Y> (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParXRms = new TH1F("hImpParXRms",";p (GeV/c);rms (Imp Par X) (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParYRms = new TH1F("hImpParYRms",";p (GeV/c);rms (Imp Par Y) (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParXSig = new TH1F("hImpParXSig",";p (GeV/c);#sigma(Imp Par X) (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParYSig = new TH1F("hImpParYSig",";p (GeV/c);#sigma(Imp Par Y) (#mum)",nMomBins,0.,maxP);
-  FillMeanAndRms(hImpParXVsP,hImpParXMean,hImpParXRms,hImpParXSig);
-  FillMeanAndRms(hImpParYVsP,hImpParYMean,hImpParYRms,hImpParYSig);
+  TH1F* hImpParXMean = new TH1F("hImpParXMean", ";p (GeV/c);<Imp Par X> (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParYMean = new TH1F("hImpParYMean", ";p (GeV/c);<Imp Par Y> (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParXRms = new TH1F("hImpParXRms", ";p (GeV/c);rms (Imp Par X) (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParYRms = new TH1F("hImpParYRms", ";p (GeV/c);rms (Imp Par Y) (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParXSig = new TH1F("hImpParXSig", ";p (GeV/c);#sigma(Imp Par X) (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParYSig = new TH1F("hImpParYSig", ";p (GeV/c);#sigma(Imp Par Y) (#mum)", nMomBins, 0., maxP);
+  FillMeanAndRms(hImpParXVsP, hImpParXMean, hImpParXRms, hImpParXSig);
+  FillMeanAndRms(hImpParYVsP, hImpParYMean, hImpParYRms, hImpParYSig);
 
-  TH1F* hDeltaPMean = new TH1F("hDeltaPMean",";p (GeV/c);<p_{rec}-p_{gen}> (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPRms = new TH1F("hDeltaPRms",";p (GeV/c);rms (p_{rec}-p_{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPSig = new TH1F("hDeltaPSig",";p (GeV/c);#sigma(p_{rec}-p_{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPMean = new TH1F("hRelDeltaPMean",";p (GeV/c);<(p_{rec}-p_{gen})/p_{gen}>",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPRms = new TH1F("hRelDeltaPRms",";p (GeV/c);rms (p_{rec}-p_{gen})/p_{gen}",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPSig = new TH1F("hRelDeltaPSig",";p (GeV/c);#sigma(p_{rec}-p_{gen})/p_{gen} (GeV/c)",nMomBins,0.,maxP);
-  FillMeanAndRms(hDeltaPVsP,hDeltaPMean,hDeltaPRms,hDeltaPSig);
-  FillMeanAndRms(hRelDeltaPVsP,hRelDeltaPMean,hRelDeltaPRms,hRelDeltaPSig);
-  
-  TH1F* hDeltaPxMean = new TH1F("hDeltaPxMean",";p (GeV/c);<p_{x}^{rec}-p_{x}^{gen}> (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPxRms = new TH1F("hDeltaPxRms",";p (GeV/c);rms (p_{x}^{rec}-p_{x}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPxSig = new TH1F("hDeltaPxSig",";p (GeV/c);#sigma(p_{x}^{rec}-p_{x}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPxMean = new TH1F("hRelDeltaPxMean",";p (GeV/c);<(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen}>",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPxRms = new TH1F("hRelDeltaPxRms",";p (GeV/c);rms (p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen}",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPxSig = new TH1F("hRelDeltaPxSig",";p (GeV/c);#sigma(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen} (GeV/c)",nMomBins,0.,maxP);
-  FillMeanAndRms(hDeltaPxVsP,hDeltaPxMean,hDeltaPxRms,hDeltaPxSig);
-  FillMeanAndRms(hRelDeltaPxVsP,hRelDeltaPxMean,hRelDeltaPxRms,hRelDeltaPxSig);
+  TH1F* hDeltaPMean = new TH1F("hDeltaPMean", ";p (GeV/c);<p_{rec}-p_{gen}> (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPRms = new TH1F("hDeltaPRms", ";p (GeV/c);rms (p_{rec}-p_{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPSig = new TH1F("hDeltaPSig", ";p (GeV/c);#sigma(p_{rec}-p_{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPMean = new TH1F("hRelDeltaPMean", ";p (GeV/c);<(p_{rec}-p_{gen})/p_{gen}>", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPRms = new TH1F("hRelDeltaPRms", ";p (GeV/c);rms (p_{rec}-p_{gen})/p_{gen}", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPSig = new TH1F("hRelDeltaPSig", ";p (GeV/c);#sigma(p_{rec}-p_{gen})/p_{gen} (GeV/c)", nMomBins, 0., maxP);
+  FillMeanAndRms(hDeltaPVsP, hDeltaPMean, hDeltaPRms, hDeltaPSig);
+  FillMeanAndRms(hRelDeltaPVsP, hRelDeltaPMean, hRelDeltaPRms, hRelDeltaPSig);
 
-  TH1F* hDeltaPyMean = new TH1F("hDeltaPyMean",";p (GeV/c);<p_{y}^{rec}-p_{x}^{gen}> (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPyRms = new TH1F("hDeltaPyRms",";p (GeV/c);rms (p_{y}^{rec}-p_{x}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPySig = new TH1F("hDeltaPySig",";p (GeV/c);#sigma(p_{y}^{rec}-p_{x}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-   TH1F* hRelDeltaPyMean = new TH1F("hRelDeltaPyMean",";p (GeV/c);<(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen}>",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPyRms = new TH1F("hRelDeltaPyRms",";p (GeV/c);rms (p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen}",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPySig = new TH1F("hRelDeltaPySig",";p (GeV/c);#sigma(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen} (GeV/c)",nMomBins,0.,maxP);
-  FillMeanAndRms(hDeltaPyVsP,hDeltaPyMean,hDeltaPyRms,hDeltaPySig);
-  FillMeanAndRms(hRelDeltaPyVsP,hRelDeltaPyMean,hRelDeltaPyRms,hRelDeltaPySig);
+  TH1F* hDeltaPxMean = new TH1F("hDeltaPxMean", ";p (GeV/c);<p_{x}^{rec}-p_{x}^{gen}> (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPxRms = new TH1F("hDeltaPxRms", ";p (GeV/c);rms (p_{x}^{rec}-p_{x}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPxSig = new TH1F("hDeltaPxSig", ";p (GeV/c);#sigma(p_{x}^{rec}-p_{x}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPxMean = new TH1F("hRelDeltaPxMean", ";p (GeV/c);<(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen}>", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPxRms = new TH1F("hRelDeltaPxRms", ";p (GeV/c);rms (p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen}", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPxSig = new TH1F("hRelDeltaPxSig", ";p (GeV/c);#sigma(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen} (GeV/c)", nMomBins, 0., maxP);
+  FillMeanAndRms(hDeltaPxVsP, hDeltaPxMean, hDeltaPxRms, hDeltaPxSig);
+  FillMeanAndRms(hRelDeltaPxVsP, hRelDeltaPxMean, hRelDeltaPxRms, hRelDeltaPxSig);
 
-  TH1F* hDeltaPzMean = new TH1F("hDeltaPzMean",";p (GeV/c);<p_{z}^{rec}-p_{z}^{gen}> (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPzRms = new TH1F("hDeltaPzRms",";p (GeV/c);rms (p_{z}^{rec}-p_{z}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPzSig = new TH1F("hDeltaPzSig",";p (GeV/c);#sigma(p_{z}^{rec}-p_{z}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPzMean = new TH1F("hRelDeltaPzMean",";p (GeV/c);<(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen}>",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPzRms = new TH1F("hRelDeltaPzRms",";p (GeV/c);rms (p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen}",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPzSig = new TH1F("hRelDeltaPzSig",";p (GeV/c);#sigma(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen} (GeV/c)",nMomBins,0.,maxP);
-  FillMeanAndRms(hDeltaPzVsP,hDeltaPzMean,hDeltaPzRms,hDeltaPzSig);
-  FillMeanAndRms(hRelDeltaPzVsP,hRelDeltaPzMean,hRelDeltaPzRms,hRelDeltaPzSig);
-  
-  TCanvas* ct = new TCanvas("ct","",1000,800);
-  ct->Divide(2,2);
+  TH1F* hDeltaPyMean = new TH1F("hDeltaPyMean", ";p (GeV/c);<p_{y}^{rec}-p_{x}^{gen}> (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPyRms = new TH1F("hDeltaPyRms", ";p (GeV/c);rms (p_{y}^{rec}-p_{x}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPySig = new TH1F("hDeltaPySig", ";p (GeV/c);#sigma(p_{y}^{rec}-p_{x}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPyMean = new TH1F("hRelDeltaPyMean", ";p (GeV/c);<(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen}>", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPyRms = new TH1F("hRelDeltaPyRms", ";p (GeV/c);rms (p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen}", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPySig = new TH1F("hRelDeltaPySig", ";p (GeV/c);#sigma(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen} (GeV/c)", nMomBins, 0., maxP);
+  FillMeanAndRms(hDeltaPyVsP, hDeltaPyMean, hDeltaPyRms, hDeltaPySig);
+  FillMeanAndRms(hRelDeltaPyVsP, hRelDeltaPyMean, hRelDeltaPyRms, hRelDeltaPySig);
+
+  TH1F* hDeltaPzMean = new TH1F("hDeltaPzMean", ";p (GeV/c);<p_{z}^{rec}-p_{z}^{gen}> (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPzRms = new TH1F("hDeltaPzRms", ";p (GeV/c);rms (p_{z}^{rec}-p_{z}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPzSig = new TH1F("hDeltaPzSig", ";p (GeV/c);#sigma(p_{z}^{rec}-p_{z}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPzMean = new TH1F("hRelDeltaPzMean", ";p (GeV/c);<(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen}>", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPzRms = new TH1F("hRelDeltaPzRms", ";p (GeV/c);rms (p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen}", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPzSig = new TH1F("hRelDeltaPzSig", ";p (GeV/c);#sigma(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen} (GeV/c)", nMomBins, 0., maxP);
+  FillMeanAndRms(hDeltaPzVsP, hDeltaPzMean, hDeltaPzRms, hDeltaPzSig);
+  FillMeanAndRms(hRelDeltaPzVsP, hRelDeltaPzMean, hRelDeltaPzRms, hRelDeltaPzSig);
+
+  TCanvas* ct = new TCanvas("ct", "", 1000, 800);
+  ct->Divide(2, 2);
   ct->cd(1);
   hIsGood->Draw();
   ct->cd(2);
@@ -339,16 +392,19 @@ void runFastFitOnHits(int firstEv = 0,
   ct->cd(3);
   hChi2NDF->Draw();
 
-  TCanvas* cip = new TCanvas("cip","",1200,800);
-  cip->Divide(2,2);
+  float deltaMaxImp = 60000.;
+  if (useVT)
+    deltaMaxImp = 500.;
+  TCanvas* cip = new TCanvas("cip", "", 1200, 800);
+  cip->Divide(2, 2);
   cip->cd(1);
   gPad->SetTickx();
   gPad->SetTicky();
   hImpParXMean->SetMarkerStyle(25);
   hImpParXMean->SetMarkerColor(1);
   hImpParXMean->SetLineColor(1);
-  hImpParXMean->SetMinimum(-20);
-  hImpParXMean->SetMaximum(20);
+  hImpParXMean->SetMinimum(-deltaMaxImp);
+  hImpParXMean->SetMaximum(deltaMaxImp);
   hImpParXMean->Draw("P");
   cip->cd(2);
   gPad->SetTickx();
@@ -357,7 +413,7 @@ void runFastFitOnHits(int firstEv = 0,
   hImpParXSig->SetMarkerColor(1);
   hImpParXSig->SetLineColor(1);
   hImpParXSig->SetMinimum(0);
-  hImpParXSig->SetMaximum(120);
+  hImpParXSig->SetMaximum(deltaMaxImp);
   hImpParXSig->Draw("P");
   cip->cd(3);
   gPad->SetTickx();
@@ -365,8 +421,8 @@ void runFastFitOnHits(int firstEv = 0,
   hImpParYMean->SetMarkerStyle(25);
   hImpParYMean->SetMarkerColor(1);
   hImpParYMean->SetLineColor(1);
-  hImpParYMean->SetMinimum(-20);
-  hImpParYMean->SetMaximum(20);
+  hImpParYMean->SetMinimum(-deltaMaxImp);
+  hImpParYMean->SetMaximum(deltaMaxImp);
   hImpParYMean->Draw("P");
   cip->cd(4);
   gPad->SetTickx();
@@ -375,19 +431,22 @@ void runFastFitOnHits(int firstEv = 0,
   hImpParYSig->SetMarkerColor(1);
   hImpParYSig->SetLineColor(1);
   hImpParYSig->SetMinimum(0);
-  hImpParYSig->SetMaximum(120);
+  hImpParYSig->SetMaximum(deltaMaxImp);
   hImpParYSig->Draw("P");
 
-  TCanvas* cmom = new TCanvas("cmom","",1400,900);
-  cmom->Divide(3,3);
+  float maxDelP = 0.75;
+  if (useVT)
+    maxDelP = 0.05;
+  TCanvas* cmom = new TCanvas("cmom", "", 1400, 900);
+  cmom->Divide(3, 3);
   cmom->cd(1);
   gPad->SetTickx();
   gPad->SetTicky();
   hDeltaPxMean->SetMarkerStyle(25);
   hDeltaPxMean->SetMarkerColor(1);
   hDeltaPxMean->SetLineColor(1);
-  hDeltaPxMean->SetMinimum(-0.05);
-  hDeltaPxMean->SetMaximum(0.05);
+  hDeltaPxMean->SetMinimum(-maxDelP);
+  hDeltaPxMean->SetMaximum(maxDelP);
   hDeltaPxMean->Draw("P");
   cmom->cd(2);
   gPad->SetTickx();
@@ -396,7 +455,7 @@ void runFastFitOnHits(int firstEv = 0,
   hDeltaPxSig->SetMarkerColor(1);
   hDeltaPxSig->SetLineColor(1);
   hDeltaPxSig->SetMinimum(0);
-  hDeltaPxSig->SetMaximum(0.05);
+  hDeltaPxSig->SetMaximum(maxDelP);
   hDeltaPxSig->Draw("P");
   cmom->cd(3);
   gPad->SetTickx();
@@ -405,7 +464,7 @@ void runFastFitOnHits(int firstEv = 0,
   hRelDeltaPxSig->SetMarkerColor(1);
   hRelDeltaPxSig->SetLineColor(1);
   hRelDeltaPxSig->SetMinimum(0);
-  hRelDeltaPxSig->SetMaximum(0.1);
+  hRelDeltaPxSig->SetMaximum(maxDelP);
   hRelDeltaPxSig->Draw("P");
   cmom->cd(4);
   gPad->SetTickx();
@@ -413,8 +472,8 @@ void runFastFitOnHits(int firstEv = 0,
   hDeltaPyMean->SetMarkerStyle(25);
   hDeltaPyMean->SetMarkerColor(1);
   hDeltaPyMean->SetLineColor(1);
-  hDeltaPyMean->SetMinimum(-0.05);
-  hDeltaPyMean->SetMaximum(0.05);
+  hDeltaPyMean->SetMinimum(-maxDelP);
+  hDeltaPyMean->SetMaximum(maxDelP);
   hDeltaPyMean->Draw("P");
   cmom->cd(5);
   gPad->SetTickx();
@@ -423,7 +482,7 @@ void runFastFitOnHits(int firstEv = 0,
   hDeltaPySig->SetMarkerColor(1);
   hDeltaPySig->SetLineColor(1);
   hDeltaPySig->SetMinimum(0);
-  hDeltaPySig->SetMaximum(0.05);
+  hDeltaPySig->SetMaximum(maxDelP);
   hDeltaPySig->Draw("P");
   cmom->cd(6);
   gPad->SetTickx();
@@ -432,7 +491,7 @@ void runFastFitOnHits(int firstEv = 0,
   hRelDeltaPySig->SetMarkerColor(1);
   hRelDeltaPySig->SetLineColor(1);
   hRelDeltaPySig->SetMinimum(0);
-  hRelDeltaPySig->SetMaximum(0.1);
+  hRelDeltaPySig->SetMaximum(maxDelP);
   hRelDeltaPySig->Draw("P");
   cmom->cd(7);
   gPad->SetTickx();
@@ -440,8 +499,8 @@ void runFastFitOnHits(int firstEv = 0,
   hDeltaPzMean->SetMarkerStyle(25);
   hDeltaPzMean->SetMarkerColor(1);
   hDeltaPzMean->SetLineColor(1);
-  hDeltaPzMean->SetMinimum(-0.05);
-  hDeltaPzMean->SetMaximum(0.05);
+  hDeltaPzMean->SetMinimum(-maxDelP);
+  hDeltaPzMean->SetMaximum(maxDelP);
   hDeltaPzMean->Draw("P");
   cmom->cd(8);
   gPad->SetTickx();
@@ -450,32 +509,32 @@ void runFastFitOnHits(int firstEv = 0,
   hDeltaPzSig->SetMarkerColor(1);
   hDeltaPzSig->SetLineColor(1);
   hDeltaPzSig->SetMinimum(0);
-  hDeltaPzSig->SetMaximum(0.2);
+  hDeltaPzSig->SetMaximum(maxDelP);
   hDeltaPzSig->Draw("P");
   cmom->cd(9);
   hRelDeltaPzSig->SetMarkerStyle(25);
   hRelDeltaPzSig->SetMarkerColor(1);
   hRelDeltaPzSig->SetLineColor(1);
   hRelDeltaPzSig->SetMinimum(0);
-  hRelDeltaPzSig->SetMaximum(0.05);
+  hRelDeltaPzSig->SetMaximum(maxDelP);
   hRelDeltaPzSig->Draw("P");
 
-  TCanvas* ce = new TCanvas("ce","",1200,600);
-  ce->Divide(2,1);
+  TCanvas* ce = new TCanvas("ce", "", 1200, 600);
+  ce->Divide(2, 1);
   ce->cd(1);
   hEtaGen->SetLineColor(kGray);
   hEtaGen->SetLineWidth(2);
   hEtaGen->Draw();
-  hEtaReco->SetLineColor(kGreen+1);
+  hEtaReco->SetLineColor(kGreen + 1);
   hEtaReco->SetLineWidth(2);
   hEtaReco->Draw("same");
   ce->cd(2);
   TH1F* hEffRec = (TH1F*)hEtaReco->Clone("hEffRec");
-  hEffRec->Divide(hEtaReco,hEtaGen,1.,1.,"B");
+  hEffRec->Divide(hEtaReco, hEtaGen, 1., 1., "B");
   hEffRec->SetMaximum(1.05);
   hEffRec->Draw("");
 
-  TFile* outFFit = new TFile("TrackingFastFit.root","recreate");
+  TFile* outFFit = new TFile("TrackingFastFit.root", "recreate");
   hImpParXVsP->Write();
   hImpParYVsP->Write();
   hDeltaPxVsP->Write();
@@ -489,5 +548,32 @@ void runFastFitOnHits(int firstEv = 0,
   hEtaGen->Write();
   hEtaReco->Write();
   outFFit->Close();
-
 }
+
+// Wrapper functions for backward compatibility and ease of use
+
+// Original function signature for Vertex Telescope hits
+void runFastFitOnVerTelHits(int firstEv = 0,
+                      int lastEv = 99999999,
+                      double clures = 5.e-4,
+                      const char* dirSimu = "../tst",
+                      int minHits = 5)
+{
+  runFastFitOnHitsTemplate<NA6PVerTelHit>(firstEv, lastEv, clures, clures, dirSimu,
+                                          "HitsVerTel.root", "hitsVerTel", "VerTel",
+                                          5, minHits, true);
+}
+
+// New function for Muon Spectrometer Modular hits
+void runFastFitOnMuonSpecHits(int firstEv = 0,
+                               int lastEv = 99999999,
+                               double cluresx = 500.e-4,
+                               double cluresy = 1000.e-4,
+                               const char* dirSimu = "../tst",
+                               int minHits = 6)
+{
+  runFastFitOnHitsTemplate<NA6PMuonSpecModularHit>(firstEv, lastEv, cluresx, cluresy, dirSimu,
+                                                    "HitsMuonSpecModular.root", "hitsMuonSpecModular", "MuonSpecModular",
+                                                    6, minHits, false);
+}
+

--- a/test/runMSTrackFinderCA.C
+++ b/test/runMSTrackFinderCA.C
@@ -56,6 +56,7 @@ void runMSTrackFinderCA(int firstEv = 0,
 
   NA6PTrackerCA* tracker = new NA6PTrackerCA();
   tracker->setNLayers(6);
+  tracker->setStartLayer(5);
   //tracker->setVerbosity(true);
   if (!tracker->loadGeometry(Form("%s/geometry.root", dirSimu)))
     return;

--- a/test/runMSTrackFinderCA.C
+++ b/test/runMSTrackFinderCA.C
@@ -1,0 +1,260 @@
+/*
+  CA Track Finder Macro
+
+  Usage:
+    root -l
+    root [0] .L setup_macros.C     // Load NA6PRoot libraries and setup paths
+    root [1] .L runMSTrackFinderCA.C+  // Compile the macro with ACLiC
+    root [2] runMSTrackFinderCA()      // Run with default parameters
+
+  Or with custom parameters:
+    root [2] runMSTrackFinderCA(0, 100, "../fullgeo", 5)
+*/
+
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <TTree.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TVector3.h>
+#include <TParticle.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+#include "NA6PMuonSpecCluster.h"
+#include "NA6PTrack.h"
+#include "NA6PTrackerCA.h"
+#include "MagneticField.h"
+#include "NA6PMuonSpecModularHit.h"
+#endif
+
+const int maxIterationsCA = NA6PTrackerCA::kMaxIterationsCA;
+
+void runMSTrackFinderCA(int firstEv = 0,
+                        int lastEv = 9999,
+                        const char* dirSimu = "../tst",
+                        int nLayers = 6)
+{
+
+  auto magField = new MagneticField();
+  magField->loadField();
+  magField->setAsGlobalField();
+
+  int nMomBins = 40;
+  float pMax = 30.0;
+  TH1F* hMomGen = new TH1F("hMomGen", ";p (GeV/c);counts", nMomBins, 0., pMax);
+  TH1F* hEtaGen = new TH1F("hEtaGen", ";#eta;counts", 20, 1., 5.);
+  TH1F* hMomReco = new TH1F("hMomReco", ";p (GeV/c);counts", nMomBins, 0., pMax);
+  TH1F* hEtaReco = new TH1F("hEtaReco", ";#eta;counts", 20, 1., 5.);
+  TH1F* hMomGoodReco = new TH1F("hMomGoodReco", ";p (GeV/c);counts", nMomBins, 0., pMax);
+  TH1F* hEtaGoodReco = new TH1F("hEtaGoodReco", ";#eta;counts", 20, 1., 5.);
+  TH1F** hMomRecoIterCA = new TH1F*[maxIterationsCA];
+  TH1F** hEtaRecoIterCA = new TH1F*[maxIterationsCA];
+  int colors[maxIterationsCA] = {kMagenta + 1, kBlue, kGreen + 1, kOrange + 1, kRed + 1, kRed, kRed - 9, kGray + 2, kGray + 1, kGray};
+  for (int jIteration = 0; jIteration < maxIterationsCA; ++jIteration) {
+    hMomRecoIterCA[jIteration] = new TH1F(Form("hMomRecoIterCA%d", jIteration), ";p (GeV/c);counts", nMomBins, 0., pMax);
+    hEtaRecoIterCA[jIteration] = new TH1F(Form("hEtaRecoIterCA%d", jIteration), ";#eta;counts", 20, 1., 5.);
+  }
+
+  NA6PTrackerCA* tracker = new NA6PTrackerCA();
+  tracker->setNLayers(6);
+  //tracker->setVerbosity(true);
+  if (!tracker->loadGeometry(Form("%s/geometry.root", dirSimu)))
+    return;
+  // pass here the configuration of the tracker via an ini file
+  //tracker->configureFromRecoParam(/* filename.ini */);
+  // alternatively the configuration can be set calling setters for the iterations
+  tracker->setNumberOfIterations(2);
+  tracker->setIterationParams(0,0.06,0.1,6.,0.6,0.05,0.05,5.,5.,5.,6);
+  tracker->setIterationParams(1,0.1,0.6,9.,0.8,0.08,0.08,10.,10.,10.,6);
+  tracker->printConfiguration();
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+
+  TFile* fh = new TFile(Form("%s/HitsMuonSpecModular.root", dirSimu));
+  TTree* th = (TTree*)fh->Get("hitsMuonSpecModular");
+  std::vector<NA6PMuonSpecModularHit> msHits, *msHitsPtr = &msHits;
+  th->SetBranchAddress("MuonSpecModular", &msHitsPtr);
+
+  TFile* fc = new TFile(Form("%s/ClustersMuonSpec.root", dirSimu));
+  printf("Open cluster file: %s\n", fc->GetName());
+  TTree* tc = (TTree*)fc->Get("clustersMuonSpec");
+  std::vector<NA6PMuonSpecCluster> msClus, *msClusPtr = &msClus;
+  tc->SetBranchAddress("MuonSpec", &msClusPtr);
+  int nEv = tc->GetEntries();
+  if (lastEv > nEv || lastEv < 0)
+    lastEv = nEv;
+  if (firstEv < 0)
+    firstEv = 0;
+  TVector3 primVert(0, 0, 0);
+
+  int nIterationsCA = tracker->getNIterations();
+
+  for (int jEv = firstEv; jEv < lastEv; jEv++) {
+    mcTree->GetEvent(jEv);
+    th->GetEvent(jEv);
+    int nPart = mcArr->size();
+    double zvert = 0;
+    // get primary vertex position from the Kine Tree
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      if (curPart.IsPrimary()) {
+        zvert = curPart.Vz();
+        break;
+      }
+    }
+    primVert.SetZ(zvert);
+    uint nHits = msHits.size();
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      int maskHits = 0;
+      int counter = 0;
+      for (size_t jHit = 0; jHit < nHits; ++jHit) {
+        const auto& hit = msHits.at(jHit);
+        int idPart = hit.getTrackID();
+        if (idPart == jp) {
+          counter++;
+        }
+      }
+      if (nLayers == counter) {
+        double pxPart = curPart.Px();
+        double pyPart = curPart.Py();
+        double pzPart = curPart.Pz();
+        double momPart = curPart.P();
+        double phiPart = curPart.Phi();
+        double thetaPart = std::acos(pzPart / momPart);
+        double etaPart = -std::log(std::tan(thetaPart / 2.));
+        hMomGen->Fill(momPart);
+        hEtaGen->Fill(etaPart);
+      }
+    }
+    tc->GetEvent(jEv);
+    tracker->findTracks(msClus, primVert);
+    std::vector<NA6PTrack> trks = tracker->getTracks();
+    int nTrks = trks.size();
+    for (int jT = 0; jT < nTrks; jT++) {
+      NA6PTrack tr = trks[jT];
+      int idPartTrack = tr.getParticleID();
+      int jIteration = tr.getCAIteration();
+      if (tr.getNHits() == 6) {
+        auto curPart = mcArr->at(std::abs(idPartTrack));
+        double pxPart = curPart.Px();
+        double pyPart = curPart.Py();
+        double pzPart = curPart.Pz();
+        double momPart = curPart.P();
+        double phiPart = curPart.Phi();
+        double thetaPart = std::acos(pzPart / momPart);
+        double etaPart = -std::log(std::tan(thetaPart / 2.));
+        hMomReco->Fill(momPart);
+        hEtaReco->Fill(etaPart);
+        if (jIteration >= 0 && jIteration < maxIterationsCA) {
+          hMomRecoIterCA[jIteration]->Fill(momPart);
+          hEtaRecoIterCA[jIteration]->Fill(etaPart);
+        }
+        if (idPartTrack > 0) {
+          hMomGoodReco->Fill(momPart);
+          hEtaGoodReco->Fill(etaPart);
+        }
+      }
+    }
+  }
+
+  TH1F* hPurityMom = (TH1F*)hMomGoodReco->Clone("hPurityMom");
+  hPurityMom->GetYaxis()->SetTitle("purity");
+  for (int iBin = 1; iBin <= hMomGoodReco->GetNbinsX(); iBin++) {
+    double cg = hMomGoodReco->GetBinContent(iBin);
+    double ct = hMomReco->GetBinContent(iBin);
+    if (ct == 0) {
+      hPurityMom->SetBinContent(iBin, 0.);
+      hPurityMom->SetBinError(iBin, 0.);
+    } else {
+      double p = cg / ct;
+      double ep = std::sqrt(p * (1 - p) / ct);
+      hPurityMom->SetBinContent(iBin, p);
+      hPurityMom->SetBinError(iBin, ep);
+    }
+  }
+  TH1F* hPurityEta = (TH1F*)hEtaGoodReco->Clone("hPurityEta");
+  hPurityEta->GetYaxis()->SetTitle("purity");
+  for (int iBin = 1; iBin <= hEtaGoodReco->GetNbinsX(); iBin++) {
+    double cg = hEtaGoodReco->GetBinContent(iBin);
+    double ct = hEtaReco->GetBinContent(iBin);
+    if (ct == 0) {
+      hPurityEta->SetBinContent(iBin, 0.);
+      hPurityEta->SetBinError(iBin, 0.);
+    } else {
+      double p = cg / ct;
+      double ep = std::sqrt(p * (1 - p) / ct);
+      hPurityEta->SetBinContent(iBin, p);
+      hPurityEta->SetBinError(iBin, ep);
+    }
+  }
+
+  TCanvas* cef = new TCanvas("cef", "", 1400, 800);
+  cef->Divide(2, 2);
+  cef->cd(1);
+  hMomGen->SetLineColor(kGray + 1);
+  hMomGen->SetLineWidth(3);
+  hMomGen->Draw();
+  hMomReco->SetLineWidth(2);
+  hMomReco->Draw("same");
+  TLegend* leg = new TLegend(0.5, 0.6, 0.89, 0.8);
+  leg->AddEntry(hMomGen, "Generated, 6 hits in MS");
+  for (int jIteration = 0; jIteration < nIterationsCA; ++jIteration) {
+    if (hMomRecoIterCA[jIteration]->GetEntries() > 0) {
+      hMomRecoIterCA[jIteration]->SetLineColor(colors[jIteration]);
+      hMomRecoIterCA[jIteration]->SetLineWidth(2);
+      hMomRecoIterCA[jIteration]->Draw("same");
+      leg->AddEntry(hMomRecoIterCA[jIteration], Form("Reconstructed Interation %d, 6 hits in MS", jIteration));
+    }
+  }
+  leg->Draw();
+  cef->cd(2);
+  TH1F* hEffMom = (TH1F*)hMomReco->Clone("hEffMom");
+  hEffMom->Divide(hMomReco, hMomGen, 1., 1., "B");
+  hEffMom->GetYaxis()->SetTitle("Efficiency");
+  hEffMom->SetStats(0);
+  hEffMom->Draw();
+  cef->cd(3);
+  hEtaGen->SetLineColor(kGray + 1);
+  hEtaGen->SetLineWidth(3);
+  hEtaGen->Draw();
+  hEtaReco->SetLineWidth(2);
+  hEtaReco->Draw("same");
+  for (int jIteration = 0; jIteration < nIterationsCA; ++jIteration) {
+    if (hEtaRecoIterCA[jIteration]->GetEntries() > 0) {
+      hEtaRecoIterCA[jIteration]->SetLineColor(colors[jIteration]);
+      hEtaRecoIterCA[jIteration]->SetLineWidth(2);
+      hEtaRecoIterCA[jIteration]->Draw("same");
+    }
+  }
+  cef->cd(4);
+  TH1F* hEffEta = (TH1F*)hEtaReco->Clone("hEffEta");
+  hEffEta->Divide(hEtaReco, hEtaGen, 1., 1., "B");
+  hEffEta->GetYaxis()->SetTitle("Efficiency");
+  hEffEta->SetStats(0);
+  hEffEta->Draw();
+
+  TCanvas* cpu = new TCanvas("cpu", "", 1400, 800);
+  cpu->Divide(2, 2);
+  cpu->cd(1);
+  hMomReco->Draw();
+  hMomGoodReco->SetLineColor(kGreen + 1);
+  ;
+  hMomGoodReco->Draw("same");
+  cpu->cd(2);
+  hPurityMom->GetYaxis()->SetTitle("Purity");
+  hPurityMom->SetMinimum(0);
+  hPurityMom->SetStats(0);
+  hPurityMom->Draw();
+  cpu->cd(3);
+  hEtaReco->Draw();
+  hEtaGoodReco->SetLineColor(kGreen + 1);
+  ;
+  hEtaGoodReco->Draw("same");
+  cpu->cd(4);
+  hPurityEta->GetYaxis()->SetTitle("Purity");
+  hPurityEta->SetMinimum(0);
+  hPurityEta->SetStats(0);
+  hPurityEta->Draw();
+}

--- a/test/runMSTracking.C
+++ b/test/runMSTracking.C
@@ -25,7 +25,10 @@ void runMSTracking(int firstEv = 0,
   tc->SetBranchAddress("MuonSpec", &msClusPtr);
   NA6PMuonSpecReconstruction* msrec = new NA6PMuonSpecReconstruction();
   msrec->init(Form("%s/geometry.root",dirSimu));
-
+  auto msTracker = msrec->getTracker();
+  msTracker->setNLayers(6);
+  msTracker->setNumberOfIterations(2);
+  msTracker->setIterationParams(0,0.06,0.1,6.,0.6,0.05,0.05,5.,5.,5.,6);
   int nEv=tc->GetEntries();
   if(lastEv>nEv || lastEv<0) lastEv=nEv;
   if(firstEv<0) firstEv=0;

--- a/test/runMSTracking.C
+++ b/test/runMSTracking.C
@@ -3,13 +3,13 @@
 #include <TFile.h>
 #include <TParticle.h>
 #include <TStopwatch.h>
-#include "NA6PVerTelCluster.h"
-#include "NA6PVerTelReconstruction.h"
+#include "NA6PMuonSpecCluster.h"
+#include "NA6PMuonSpecReconstruction.h"
 #endif
 
-void runVTTracking(int firstEv = 0,
+void runMSTracking(int firstEv = 0,
 		   int lastEv = 99999,
-		   const char *dirSimu = "Angantyr")
+		   const char *dirSimu = "../tst")
 {
   
   // kine file needed to get the primary vertex position (temporary)
@@ -18,14 +18,13 @@ void runVTTracking(int firstEv = 0,
   std::vector<TParticle>* mcArr = nullptr;
   mcTree->SetBranchAddress("tracks", &mcArr);
 
-  TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
+  TFile* fc=new TFile(Form("%s/ClustersMuonSpec.root",dirSimu));
   printf("Open cluster file: %s\n",fc->GetName());
-  TTree* tc=(TTree*)fc->Get("clustersVerTel");
-  std::vector<NA6PVerTelCluster> vtClus, *vtClusPtr = &vtClus;
-  tc->SetBranchAddress("VerTel", &vtClusPtr);
-
-  NA6PVerTelReconstruction* vtrec = new NA6PVerTelReconstruction();
-  vtrec->init(Form("%s/geometry.root",dirSimu));
+  TTree* tc=(TTree*)fc->Get("clustersMuonSpec");
+  std::vector<NA6PMuonSpecCluster> msClus, *msClusPtr = &msClus;
+  tc->SetBranchAddress("MuonSpec", &msClusPtr);
+  NA6PMuonSpecReconstruction* msrec = new NA6PMuonSpecReconstruction();
+  msrec->init(Form("%s/geometry.root",dirSimu));
 
   int nEv=tc->GetEntries();
   if(lastEv>nEv || lastEv<0) lastEv=nEv;
@@ -47,11 +46,11 @@ void runVTTracking(int firstEv = 0,
       }
     }
     tc->GetEvent(jEv);
-    vtrec->setPrimaryVertexPosition(0.,0.,zvert);
-    vtrec->setClusters(vtClus);
-    vtrec->runTracking();
+    msrec->setPrimaryVertexPosition(0.,0.,zvert);
+    msrec->setClusters(msClus);
+    msrec->runTracking();
   }
-  vtrec->closeTracksOutput();
+  msrec->closeTracksOutput();
   
   timer.Stop();
   timer.Print();

--- a/test/runVTTrackFinderCA.C
+++ b/test/runVTTrackFinderCA.C
@@ -1,3 +1,16 @@
+/*
+  CA Track Finder Macro
+  
+  Usage:
+    root -l
+    root [0] .L setup_macros.C     // Load NA6PRoot libraries and setup paths
+    root [1] .L runTrackFinderCA.C+  // Compile the macro with ACLiC
+    root [2] runTrackFinderCA()      // Run with default parameters
+    
+  Or with custom parameters:
+    root [2] runTrackFinderCA(0, 100, "../fullgeo", 5)
+*/
+
 #if !defined(__CINT__) || defined(__MAKECINT__)
 #include <TTree.h>
 #include <TFile.h>
@@ -6,7 +19,7 @@
 #include <TParticle.h>
 #include <TCanvas.h>
 #include <TLegend.h>
-#include "NA6PBaseCluster.h"
+#include "NA6PVerTelCluster.h"
 #include "NA6PTrack.h"
 #include "NA6PTrackerCA.h"
 #include "MagneticField.h"
@@ -15,7 +28,7 @@
 
 const int maxIterationsCA = NA6PTrackerCA::kMaxIterationsCA;
 
-void runTrackFinderCA(int firstEv = 0,
+void runVTTrackFinderCA(int firstEv = 0,
 		      int lastEv = 9999,
 		      const char *dirSimu = "../testN6Proot/pions/latesttag",
 		      int nLayers = 5){
@@ -62,7 +75,7 @@ void runTrackFinderCA(int firstEv = 0,
   TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
   printf("Open cluster file: %s\n",fc->GetName());
   TTree* tc=(TTree*)fc->Get("clustersVerTel");
-  std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
+  std::vector<NA6PVerTelCluster> vtClus, *vtClusPtr = &vtClus;
   tc->SetBranchAddress("VerTel", &vtClusPtr);
   int nEv=tc->GetEntries();
   if(lastEv>nEv || lastEv<0) lastEv=nEv;

--- a/test/runVertexerTracklets.C
+++ b/test/runVertexerTracklets.C
@@ -17,7 +17,7 @@
 #include <TVectorD.h>
 #include <TRandom3.h>
 #include <TStopwatch.h>
-#include "NA6PBaseCluster.h"
+#include "NA6PVerTelCluster.h"
 #include "NA6PVertex.h"
 #include "NA6PVerTelReconstruction.h"
 #endif
@@ -36,7 +36,7 @@ void runVertexerTracklets(int firstEv = 0,
   TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
   printf("Open cluster file: %s\n",fc->GetName());
   TTree* tc=(TTree*)fc->Get("clustersVerTel");
-  std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
+  std::vector<NA6PVerTelCluster> vtClus, *vtClusPtr = &vtClus;
   tc->SetBranchAddress("VerTel", &vtClusPtr);
 
   if(lastEv>nEv || lastEv<0) lastEv=nEv;


### PR DESCRIPTION
This PR introduces the NA6PMuonSpecReconstruction class to steer the muon spectrometer reconstruction.
MS and VT clusters are now represented by two dedicated classes, NA6PMuonSpecCluster and NA6PVerTelCluster, both inheriting from NA6PBaseCluster.
The cellular automaton and track fitter methods that previously relied on NA6PBaseCluster now use templates.
NA6PRecoParam has not yet been split into two; the current values correspond to the VT.

This PR also adds example macros to test the MS reconstruction (runMSTrackFinderCA.C, runMSTracking.C) and generalizes runFastFitOnHits.C.
Attached are some very preliminary efficiencies and resolutions for muons from J/ψ at √s = 8.8 GeV.

<img width="1398" height="876" alt="muon_resolutions" src="https://github.com/user-attachments/assets/f0b385ea-4c20-41a0-9d79-b6a957fd3cd3" />
<img width="1398" height="776" alt="muon_purity" src="https://github.com/user-attachments/assets/ccec3d6e-18f9-4866-98d2-3c9e01f082ad" />
<img width="1198" height="776" alt="muon_imppar" src="https://github.com/user-attachments/assets/09882bc7-0155-498b-880b-2e4c4f1f0d86" />
<img width="1398" height="776" alt="muon_eff" src="https://github.com/user-attachments/assets/fdb9119d-2795-4b30-8c46-2a1f84a59b22" />
