### PR TITLE
Vertexer parameters in NA6PRecoParam + use xbeam and ybeam

### DIFF
--- a/rec/include/NA6PRecoParam.h
+++ b/rec/include/NA6PRecoParam.h
@@ -11,18 +11,40 @@ struct NA6PRecoParam : public na6p::conf::ConfigurableParamHelper<NA6PRecoParam>
   static constexpr int MaxIterationsTrackerCA = 10;
 
   // VerTel reconstruction parameters
-  int    nVerTelLayers = 5;
-  int    nIterationsTrackerCA = 2;
+  int nVerTelLayers = 5;
+  // tracklet vertexer
+  int vertexerLayerToStart = 0;
+  float vertexerMaxDeltaThetaTracklet = 0.6;
+  float vertexerMaxDeltaPhiTracklet = 0.05;
+  float vertexerMaxDeltaTanLamInOut = 1.;
+  float vertexerMaxDeltaPhiInOut = 0.2;
+  float vertexerMaxDeltaPxPzInOut = 99.;
+  float vertexerMaxDeltaPyPzInOut = 0.005;
+  std::string vertexerRecoType = "YZ";
+  float vertexerMaxDCAxy = 0.25;
+  std::string vertexerPeakMethod = "KDE";
+  std::string vertexerWeightedMeanOption = "NoWeight";
+  float vertexerZMin = -20.0;
+  float vertexerZMax = 5.;
+  float vertexerZWindowWidth = 1.25;
+  int vertexerNBinsForPeakFind = 250;
+  int vertexerPeakWidthBins = 3;
+  int vertexerMinCountsInPeak = 3;
+  std::string vertexerKDEOption = "Standard";
+  int vertexerNGridKDE = 500;
+  float vertexerKDEBandwidth = 0.5;
+  // CA tracker
+  int nIterationsTrackerCA = 2;
   float maxDeltaThetaTrackletsCA[MaxIterationsTrackerCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  float maxDeltaPhiTrackletsCA[MaxIterationsTrackerCA]   = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  float maxDeltaTanLCellsCA[MaxIterationsTrackerCA]      = {4., 9., 18., 40., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  float maxDeltaPhiCellsCA[MaxIterationsTrackerCA]       = {0.4, 0.6, 1.2, 2.4, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  float maxDeltaPxPzCellsCA[MaxIterationsTrackerCA]      = {0.02, 0.05, 0.1, 0.2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  float maxDeltaPyPzCellsCA[MaxIterationsTrackerCA]      = {2e-3, 7.5e-3, 1.5e-2, 3.e-2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  float maxChi2TrClCellsCA[MaxIterationsTrackerCA]       = {5., 10., 10., 10.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  float maxChi2ndfCellsCA[MaxIterationsTrackerCA]        = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  float maxChi2ndfTracksCA[MaxIterationsTrackerCA]       = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  int    minNClusTracksCA[MaxIterationsTrackerCA]        = {5, 3, 0, 0, 0, 0, 0, 0, 0, 0};
+  float maxDeltaPhiTrackletsCA[MaxIterationsTrackerCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float maxDeltaTanLCellsCA[MaxIterationsTrackerCA] = {4., 9., 18., 40., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float maxDeltaPhiCellsCA[MaxIterationsTrackerCA] = {0.4, 0.6, 1.2, 2.4, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float maxDeltaPxPzCellsCA[MaxIterationsTrackerCA] = {0.02, 0.05, 0.1, 0.2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float maxDeltaPyPzCellsCA[MaxIterationsTrackerCA] = {2e-3, 7.5e-3, 1.5e-2, 3.e-2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float maxChi2TrClCellsCA[MaxIterationsTrackerCA] = {100., 500., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float maxChi2ndfCellsCA[MaxIterationsTrackerCA] = {100., 500., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float maxChi2ndfTracksCA[MaxIterationsTrackerCA] = {100., 500., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  int minNClusTracksCA[MaxIterationsTrackerCA] = {5, 3, 0, 0, 0, 0, 0, 0, 0, 0};
 
   NA6PParamDef(NA6PRecoParam, "reco");
 };

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -39,7 +39,7 @@ struct CellCandidate {
   int startingLayer;
   int firstTrackletIndex;
   int secondTrackletIndex;
-  std::array<int,3> cluIDs;
+  std::array<int, 3> cluIDs;
   NA6PTrack trackFitFast;
   //    genfit::Track trackFit;
 };
@@ -52,7 +52,7 @@ struct TrackCandidate {
   std::vector<int> cluIDs;
 };
 
-struct TrackFitted{
+struct TrackFitted {
   int innerLayer;
   int outerLayer;
   int nClus;
@@ -62,138 +62,129 @@ struct TrackFitted{
   double chi2ndf;
 };
 
-enum class ExtendDirection { kInward, kOutward };
+enum class ExtendDirection { kInward,
+                             kOutward };
 
 class NA6PTrackerCA
 {
-public:
+ public:
   static constexpr int kMaxIterationsCA = 10;
 
   NA6PTrackerCA();
   ~NA6PTrackerCA();
 
   // setters for configurable parameters
-  void setNLayers(int n) {mNLayers = n;}
-  void setMaxNumberOfSharedClusters(int n) {mMaxSharedClusters = n;}
+  void setNLayers(int n) { mNLayers = n; }
+  void setMaxNumberOfSharedClusters(int n) { mMaxSharedClusters = n; }
   void setNumberOfIterations(int nIter);
   void setIterationParams(int iter,
-			  double maxDeltaThetaTracklets,
-			  double maxDeltaPhiTracklets,
-			  double maxDeltaTanLCells,
-			  double maxDeltaPhiCells,
-			  double maxDeltaPxPzCells,
-			  double maxDeltaPyPzCells,
-			  double maxChi2TrClCells,
-			  double maxChi2ndfCells,
-			  double maxChi2ndfTracks,
-			  int    minNClusTracks);
+                          double maxDeltaThetaTracklets,
+                          double maxDeltaPhiTracklets,
+                          double maxDeltaTanLCells,
+                          double maxDeltaPhiCells,
+                          double maxDeltaPxPzCells,
+                          double maxDeltaPyPzCells,
+                          double maxChi2TrClCells,
+                          double maxChi2ndfCells,
+                          double maxChi2ndfTracks,
+                          int minNClusTracks);
   void configureFromRecoParam(const std::string filename = "");
-  void setVerbosity(bool opt = true) {mVerbose = opt;}
+  void setVerbosity(bool opt = true) { mVerbose = opt; }
 
   void printConfiguration() const;
-  int  getNIterations() const {return mNIterationsCA;}
+  int getNIterations() const { return mNIterationsCA; }
   bool loadGeometry(const char* filename, const char* geoname = "NA6P");
   void findTracks(std::vector<NA6PBaseCluster>& cluArr, TVector3 primVert);
   std::vector<NA6PTrack> getTracks();
 
-  
-protected:
+ protected:
   // methods used in tracking
   void sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,
-				 std::vector<int>& firstIndex,
-				 std::vector<int>& lastIndex);
+                                 std::vector<int>& firstIndex,
+                                 std::vector<int>& lastIndex);
   void sortTrackletsByLayerAndIndex(std::vector<TrackletCandidate>& tracklets,
-				    std::vector<int>& firstIndex,
-				    std::vector<int>& lastIndex);
+                                    std::vector<int>& firstIndex,
+                                    std::vector<int>& lastIndex);
   void sortCellsByLayerAndIndex(std::vector<CellCandidate>& cells,
-				std::vector<int>& firstIndex,
-				std::vector<int>& lastIndex);
+                                std::vector<int>& firstIndex,
+                                std::vector<int>& lastIndex);
   void computeLayerTracklets(const std::vector<NA6PBaseCluster>& cluArr,
-			     const std::vector<int>& firstIndex,
-			     const std::vector<int>& lastIndex,
-			     std::vector<TrackletCandidate>& tracklets,
-			     double deltaThetaMax,
-			     double deltaPhiMax);
+                             const std::vector<int>& firstIndex,
+                             const std::vector<int>& lastIndex,
+                             std::vector<TrackletCandidate>& tracklets,
+                             double deltaThetaMax,
+                             double deltaPhiMax);
   void computeLayerCells(const std::vector<TrackletCandidate>& tracklets,
-			 const std::vector<int>& firstIndex,
-			 const std::vector<int>& lastIndex,
-			 const std::vector<NA6PBaseCluster>& cluArr,
-			 std::vector<CellCandidate>& cells,
-			 double deltaTanLMax,
-			 double deltaPhiMax,
-			 double deltaPxPzMax,
-			 double deltaPyPzMax,
-			 double maxChi2TrClu,
-			 double maxChi2NDF);
+                         const std::vector<int>& firstIndex,
+                         const std::vector<int>& lastIndex,
+                         const std::vector<NA6PBaseCluster>& cluArr,
+                         std::vector<CellCandidate>& cells,
+                         double deltaTanLMax,
+                         double deltaPhiMax,
+                         double deltaPxPzMax,
+                         double deltaPyPzMax,
+                         double maxChi2TrClu,
+                         double maxChi2NDF);
   double computeTrackToClusterChi2(const NA6PTrack& track,
-				   const NA6PBaseCluster& clu);
+                                   const NA6PBaseCluster& clu);
   bool fitTrackPointsFast(const std::vector<int>& cluIDs,
-			  const std::vector<NA6PBaseCluster>& cluArr,
-			  NA6PTrack& fitTrack,
-			  double maxChi2TrClu,
-			  double maxChi2NDF);
+                          const std::vector<NA6PBaseCluster>& cluArr,
+                          NA6PTrack& fitTrack,
+                          double maxChi2TrClu,
+                          double maxChi2NDF);
   void findCellsNeighbours(const std::vector<CellCandidate>& cells,
-			   const std::vector<int>& firstIndex,
-			   const std::vector<int>& lastIndex,
-			   std::vector<std::pair<int,int>>& cneigh,
-			   const std::vector<NA6PBaseCluster>& cluArr,
-			   double maxChi2TrClu);
+                           const std::vector<int>& firstIndex,
+                           const std::vector<int>& lastIndex,
+                           std::vector<std::pair<int, int>>& cneigh,
+                           const std::vector<NA6PBaseCluster>& cluArr,
+                           double maxChi2TrClu);
   std::vector<TrackCandidate> prolongSeed(const TrackCandidate& seed,
-					  const std::vector<CellCandidate>& cells,
-					  const std::vector<int>& firstIndex,
-					  const std::vector<int>& lastIndex,
-					  const std::vector<NA6PBaseCluster>& cluArr,
-					  double maxChi2TrClu,
-					  ExtendDirection dir);
-  void findRoads(const std::vector<std::pair<int,int>>& cneigh,
-		 const std::vector<CellCandidate>& cells,
-		 const std::vector<int>& firstIndex,
-		 const std::vector<int>& lastIndex,
-		 const std::vector<TrackletCandidate>& tracklets,
-		 const std::vector<NA6PBaseCluster>& cluArr,
-		 std::vector<TrackCandidate>& trackCands,
-		 double maxChi2TrClu);
+                                          const std::vector<CellCandidate>& cells,
+                                          const std::vector<int>& firstIndex,
+                                          const std::vector<int>& lastIndex,
+                                          const std::vector<NA6PBaseCluster>& cluArr,
+                                          double maxChi2TrClu,
+                                          ExtendDirection dir);
+  void findRoads(const std::vector<std::pair<int, int>>& cneigh,
+                 const std::vector<CellCandidate>& cells,
+                 const std::vector<int>& firstIndex,
+                 const std::vector<int>& lastIndex,
+                 const std::vector<TrackletCandidate>& tracklets,
+                 const std::vector<NA6PBaseCluster>& cluArr,
+                 std::vector<TrackCandidate>& trackCands,
+                 double maxChi2TrClu);
   void fitAndSelectTracks(const std::vector<TrackCandidate>& trackCands,
-			  const std::vector<NA6PBaseCluster>& cluArr,
-			  std::vector<TrackFitted>& tracks,
-			  double maxChi2TrClu,
-			  int minNClu,
-			  double maxChi2NDF);
-  template<typename T>
+                          const std::vector<NA6PBaseCluster>& cluArr,
+                          std::vector<TrackFitted>& tracks,
+                          double maxChi2TrClu,
+                          int minNClu,
+                          double maxChi2NDF);
+  template <typename T>
   void printStats(const std::vector<T>& candidates,
-		  const std::vector<NA6PBaseCluster>& cluArr,
-		  const std::vector<CellCandidate>& cells,
-		  const std::string& label,
-		  int requiredClus = -1);
+                  const std::vector<NA6PBaseCluster>& cluArr,
+                  const std::vector<CellCandidate>& cells,
+                  const std::string& label,
+                  int requiredClus = -1);
 
-
-
-
-private:
-  
-  int    mNLayers = 5;
+ private:
+  int mNLayers = 5;
   double mPrimVertPos[3] = {};
   NA6PFastTrackFitter* mTrackFitter = nullptr;
   std::vector<bool> mIsClusterUsed = {};
   std::vector<TrackFitted> mFinalTracks = {};
-  int    mMaxSharedClusters = 0;
-  bool   mVerbose = false;
-  int    mNIterationsCA = 2;
+  int mMaxSharedClusters = 0;
+  bool mVerbose = false;
+  int mNIterationsCA = 2;
   double mMaxDeltaThetaTrackletsCA[kMaxIterationsCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   double mMaxDeltaPhiTrackletsCA[kMaxIterationsCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   double mMaxDeltaTanLCellsCA[kMaxIterationsCA] = {4., 9., 18., 40., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   double mMaxDeltaPhiCellsCA[kMaxIterationsCA] = {0.4, 0.6, 1.2, 2.4, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   double mMaxDeltaPxPzCellsCA[kMaxIterationsCA] = {0.02, 0.05, 0.1, 0.2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   double mMaxDeltaPyPzCellsCA[kMaxIterationsCA] = {2e-3, 7.5e-3, 1.5e-2, 3.e-2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxChi2TrClCellsCA[kMaxIterationsCA] = {5., 10., 10., 10.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxChi2ndfCellsCA[kMaxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxChi2ndfTracksCA[kMaxIterationsCA] = {5., 10., 10., 10., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  int    mMinNClusTracksCA[kMaxIterationsCA] = {5, 3, 0, 0, 0, 0, 0, 0, 0, 0};
-
-
-
- 
-  
+  double mMaxChi2TrClCellsCA[kMaxIterationsCA] = {100., 500., 999., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxChi2ndfCellsCA[kMaxIterationsCA] = {100., 500., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  double mMaxChi2ndfTracksCA[kMaxIterationsCA] = {100., 500., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  int mMinNClusTracksCA[kMaxIterationsCA] = {5, 3, 0, 0, 0, 0, 0, 0, 0, 0};
 
   ClassDefNV(NA6PTrackerCA, 1);
 };

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -88,7 +88,7 @@ class NA6PTrackerCA
                           double maxChi2ndfCells,
                           double maxChi2ndfTracks,
                           int minNClusTracks);
-  void configureFromRecoParam(const std::string filename = "");
+  void configureFromRecoParam(const std::string& filename = "");
   void setVerbosity(bool opt = true) { mVerbose = opt; }
 
   void printConfiguration() const;
@@ -112,38 +112,38 @@ class NA6PTrackerCA
                              const std::vector<int>& firstIndex,
                              const std::vector<int>& lastIndex,
                              std::vector<TrackletCandidate>& tracklets,
-                             double deltaThetaMax,
-                             double deltaPhiMax);
+                             double& deltaThetaMax,
+                             double& deltaPhiMax);
   void computeLayerCells(const std::vector<TrackletCandidate>& tracklets,
                          const std::vector<int>& firstIndex,
                          const std::vector<int>& lastIndex,
                          const std::vector<NA6PBaseCluster>& cluArr,
                          std::vector<CellCandidate>& cells,
-                         double deltaTanLMax,
-                         double deltaPhiMax,
-                         double deltaPxPzMax,
-                         double deltaPyPzMax,
-                         double maxChi2TrClu,
-                         double maxChi2NDF);
+                         double& deltaTanLMax,
+                         double& deltaPhiMax,
+                         double& deltaPxPzMax,
+                         double& deltaPyPzMax,
+                         double& maxChi2TrClu,
+                         double& maxChi2NDF);
   double computeTrackToClusterChi2(const NA6PTrack& track,
                                    const NA6PBaseCluster& clu);
   bool fitTrackPointsFast(const std::vector<int>& cluIDs,
                           const std::vector<NA6PBaseCluster>& cluArr,
                           NA6PTrack& fitTrack,
-                          double maxChi2TrClu,
-                          double maxChi2NDF);
+                          double& maxChi2TrClu,
+                          double& maxChi2NDF);
   void findCellsNeighbours(const std::vector<CellCandidate>& cells,
                            const std::vector<int>& firstIndex,
                            const std::vector<int>& lastIndex,
                            std::vector<std::pair<int, int>>& cneigh,
                            const std::vector<NA6PBaseCluster>& cluArr,
-                           double maxChi2TrClu);
+                           double& maxChi2TrClu);
   std::vector<TrackCandidate> prolongSeed(const TrackCandidate& seed,
                                           const std::vector<CellCandidate>& cells,
                                           const std::vector<int>& firstIndex,
                                           const std::vector<int>& lastIndex,
                                           const std::vector<NA6PBaseCluster>& cluArr,
-                                          double maxChi2TrClu,
+                                          double& maxChi2TrClu,
                                           ExtendDirection dir);
   void findRoads(const std::vector<std::pair<int, int>>& cneigh,
                  const std::vector<CellCandidate>& cells,
@@ -152,13 +152,13 @@ class NA6PTrackerCA
                  const std::vector<TrackletCandidate>& tracklets,
                  const std::vector<NA6PBaseCluster>& cluArr,
                  std::vector<TrackCandidate>& trackCands,
-                 double maxChi2TrClu);
+                 double& maxChi2TrClu);
   void fitAndSelectTracks(const std::vector<TrackCandidate>& trackCands,
                           const std::vector<NA6PBaseCluster>& cluArr,
                           std::vector<TrackFitted>& tracks,
-                          double maxChi2TrClu,
-                          int minNClu,
-                          double maxChi2NDF);
+                          double& maxChi2TrClu,
+                          int& minNClu,
+                          double& maxChi2NDF);
   template <typename T>
   void printStats(const std::vector<T>& candidates,
                   const std::vector<NA6PBaseCluster>& cluArr,

--- a/rec/include/NA6PVertex.h
+++ b/rec/include/NA6PVertex.h
@@ -36,12 +36,12 @@ class NA6PVertex
   
   NA6PVertex() = default;
   NA6PVertex(const ROOT::Math::XYZPointF& pos, const std::array<float, kNCov>& cov, int nCont, float chi2);
-  NA6PVertex(const double *xyz, int nCont);
+  NA6PVertex(const float *xyz, int nCont);
   NA6PVertex(const NA6PVertex&) = default;
   NA6PVertex& operator=(const NA6PVertex&) = default;
   virtual ~NA6PVertex() = default;
 
-  void init(const double *xyz, const double *cov, int nCont, float chi2);
+  void init(const float *xyz, const float *cov, int nCont, float chi2);
   void setX(float x) { mPos.SetX(x); }
   void setY(float y) { mPos.SetY(y); }
   void setZ(float z) { mPos.SetZ(z); }

--- a/rec/include/NA6PVertex.h
+++ b/rec/include/NA6PVertex.h
@@ -32,16 +32,18 @@ class NA6PVertex
                         kCovZZ };
   static constexpr int kNCov = 6;
 
-  enum vertTypes {kTrackletPrimaryVertex,kTrackPrimaryVertex,kBaseVertex};
-  
+  enum vertTypes { kTrackletPrimaryVertex,
+                   kTrackPrimaryVertex,
+                   kBaseVertex };
+
   NA6PVertex() = default;
   NA6PVertex(const ROOT::Math::XYZPointF& pos, const std::array<float, kNCov>& cov, int nCont, float chi2);
-  NA6PVertex(const float *xyz, int nCont);
+  NA6PVertex(const float* xyz, int nCont);
   NA6PVertex(const NA6PVertex&) = default;
   NA6PVertex& operator=(const NA6PVertex&) = default;
   virtual ~NA6PVertex() = default;
 
-  void init(const float *xyz, const float *cov, int nCont, float chi2);
+  void init(const float* xyz, const float* cov, int nCont, float chi2);
   void setX(float x) { mPos.SetX(x); }
   void setY(float y) { mPos.SetY(y); }
   void setZ(float z) { mPos.SetZ(z); }
@@ -52,7 +54,7 @@ class NA6PVertex
     setZ(z);
   }
   void setPos(const ROOT::Math::XYZPointF& p) { mPos = p; }
-  
+
   void setSigmaX2(float v) { mCov[kCovXX] = v; }
   void setSigmaY2(float v) { mCov[kCovYY] = v; }
   void setSigmaZ2(float v) { mCov[kCovZZ] = v; }
@@ -62,7 +64,7 @@ class NA6PVertex
   void setSigmaX(float val) { setSigmaX2(val * val); }
   void setSigmaY(float val) { setSigmaY2(val * val); }
   void setSigmaZ(float val) { setSigmaZ2(val * val); }
-  
+
   void setCov(float sxx, float sxy, float syy, float sxz, float syz, float szz)
   {
     setSigmaX2(sxx);
@@ -77,7 +79,7 @@ class NA6PVertex
   void addContributor() { mNContributors++; }
   void setChi2(float v) { mChi2 = v; }
   void setVertexType(short t) { mVertexType = t; }
-  
+
   float getX() const { return mPos.X(); }
   float getY() const { return mPos.Y(); }
   float getZ() const { return mPos.Z(); }
@@ -91,23 +93,22 @@ class NA6PVertex
   float getSigmaY() const { return std::sqrt(getSigmaY2()); }
   float getSigmaZ() const { return std::sqrt(getSigmaZ2()); }
   std::array<float, kNCov> getCov() const { return mCov; }
-  ROOT::Math::XYZPointF getXYZ() const { return mPos; }  
-  int   getNContributors() const { return mNContributors; }
+  ROOT::Math::XYZPointF getXYZ() const { return mPos; }
+  int getNContributors() const { return mNContributors; }
   float getChi2() const { return mChi2; }
   short getVertexType() const { return mVertexType; }
-  
-  virtual void  print() const;
+
+  virtual void print() const;
   std::string asString() const;
 
  protected:
-  ROOT::Math::XYZPointF mPos{0., 0., 0.}; 
-  std::array<float, kNCov> mCov{};     
-  float mChi2 = 0.0;           
-  int   mNContributors = 0; 
+  ROOT::Math::XYZPointF mPos{0., 0., 0.};
+  std::array<float, kNCov> mCov{};
+  float mChi2 = 0.0;
+  int mNContributors = 0;
   short mVertexType = kBaseVertex;
-  
-  ClassDefNV(NA6PVertex,1);
+
+  ClassDefNV(NA6PVertex, 1);
 };
 
 #endif
-

--- a/rec/include/NA6PVertexerTracklets.h
+++ b/rec/include/NA6PVertexerTracklets.h
@@ -27,17 +27,17 @@ struct TrackletForVertex {
   int startingLayer;
   int firstClusterIndex;
   int secondClusterIndex;
-  double tanL;
-  double phi;
-  double pxpz;
-  double pypz;
+  float tanL;
+  float phi;
+  float pxpz;
+  float pypz;
   bool isSignal;
 };
 
 struct TracklIntersection {
-  double zeta;
-  double sigmazeta;
-  double tanl;
+  float zeta;
+  float sigmazeta;
+  float tanl;
   int firstClusterIndex;
   int secondClusterIndex;
 };
@@ -62,7 +62,7 @@ class NA6PVertexerTracklets
   NA6PVertexerTracklets();
   ~NA6PVertexerTracklets() = default;
 
-  void configurePeakFinding(double zmin = -20.0, double zmax = 5., int nbins = 250)
+  void configurePeakFinding(float zmin = -20.0, float zmax = 5., int nbins = 250)
   {
     mZMin = zmin;
     mZMax = zmax;
@@ -70,7 +70,7 @@ class NA6PVertexerTracklets
     mZBinWidth = (mZMax - mZMin) / mNBinsForPeakFind;
     mHistIntersec.assign(nbins, 0);
   }
-  void configureKDE(double width, int nbins = 500)
+  void configureKDE(float width, int nbins = 500)
   {
     mNGridKDE = nbins;
     mKDEBandwidth = width;
@@ -79,25 +79,25 @@ class NA6PVertexerTracklets
   // Settters
   void setNLayersVT(int n) { mNLayersVT = n; }
   void setLayerToStart(int lay) { mLayerToStart = lay; }
-  void setBeamX(double x) { mBeamX = x; }
-  void setBeamY(double y) { mBeamY = y; }
+  void setBeamX(float x) { mBeamX = x; }
+  void setBeamY(float y) { mBeamY = y; }
   void setRecoInYZPlane() { mRecoType = kYZ; }
   void setRecoInXZPlane() { mRecoType = kXZ; }
   void setRecoInRZPlane() { mRecoType = kRZ; }
   void setRecoIn3D() { mRecoType = k3D; }
-  void setMaxDCAxy(double v) { mMaxDCAxy = v; }
-  void setMaxDeltaThetaTracklet(double v) { mMaxDeltaThetaTracklet = v; }
-  void setMaxDeltaPhiTracklet(double v) { mMaxDeltaPhiTracklet = v; }
-  void setMaxDeltaTanLamInOut(double v) { mMaxDeltaTanLamInOut = v; }
-  void setMaxDeltaPhiInOut(double v) { mMaxDeltaPhiInOut = v; }
-  void setMaxDeltaPxPzInOut(double v) { mMaxDeltaPxPzInOut = v; }
-  void setMaxDeltaPyPzInOut(double v) { mMaxDeltaPyPzInOut = v; }
+  void setMaxDCAxy(float v) { mMaxDCAxy = v; }
+  void setMaxDeltaThetaTracklet(float v) { mMaxDeltaThetaTracklet = v; }
+  void setMaxDeltaPhiTracklet(float v) { mMaxDeltaPhiTracklet = v; }
+  void setMaxDeltaTanLamInOut(float v) { mMaxDeltaTanLamInOut = v; }
+  void setMaxDeltaPhiInOut(float v) { mMaxDeltaPhiInOut = v; }
+  void setMaxDeltaPxPzInOut(float v) { mMaxDeltaPxPzInOut = v; }
+  void setMaxDeltaPyPzInOut(float v) { mMaxDeltaPyPzInOut = v; }
   void setUseHistoForPeakFinding() { mMethod = kHistoPeak; }
   void setUseKDEForPeakFinding() { mMethod = kKDE; }
   void setUseNoWeight() { mWeightedMeanOption = kNoWeight; }
   void setUseTanLWeight() { mWeightedMeanOption = kTanL; }
   void setUseSigmaWeight() { mWeightedMeanOption = kSigma; }
-  void setZRange(double zmin, double zmax)
+  void setZRange(float zmin, float zmax)
   {
     mZMin = zmin;
     mZMax = zmax;
@@ -144,7 +144,7 @@ class NA6PVertexerTracklets
   bool findVertexHistoPeak(std::vector<TracklIntersection>& zIntersec,
                            std::vector<NA6PVertex>& vertices);
 
-  double gaussKernel(double u)
+  float gaussKernel(float u)
   {
     return std::exp(-0.5 * u * u) / std::sqrt(2.0 * M_PI);
   }
@@ -165,29 +165,29 @@ class NA6PVertexerTracklets
   int mNLayersVT = 5;                    // number of layers in the VT
   int mLayerToStart = 0;                 // innermost layer used in tracklets
   std::vector<bool> mIsClusterUsed = {}; // flag for used clusters
-  double mBeamX = 0.;                    // beam transverse coordindates
-  double mBeamY = 0.;                    // beam transverse coordindates
-  double mMaxDeltaThetaTracklet = 0.6;   // selections for tracklet building
-  double mMaxDeltaPhiTracklet = 0.05;    // selections for tracklet building
-  double mMaxDeltaTanLamInOut = 1.;      // selections for tracklet validation
-  double mMaxDeltaPhiInOut = 0.2;        // selections for tracklet validation
-  double mMaxDeltaPxPzInOut = 99.;       // selections for tracklet validation
-  double mMaxDeltaPyPzInOut = 0.005;     // selections for tracklet validation
+  float mBeamX = 0.;                     // beam transverse coordindates
+  float mBeamY = 0.;                     // beam transverse coordindates
+  float mMaxDeltaThetaTracklet = 0.6;    // selections for tracklet building
+  float mMaxDeltaPhiTracklet = 0.05;     // selections for tracklet building
+  float mMaxDeltaTanLamInOut = 1.;       // selections for tracklet validation
+  float mMaxDeltaPhiInOut = 0.2;         // selections for tracklet validation
+  float mMaxDeltaPxPzInOut = 99.;        // selections for tracklet validation
+  float mMaxDeltaPyPzInOut = 0.005;      // selections for tracklet validation
   short mRecoType = kYZ;                 // method to compute tracklet intersections with beam axis
-  double mMaxDCAxy = 0.25;               // selection for tracklet intersection, cm
+  float mMaxDCAxy = 0.25;                // selection for tracklet intersection, cm
   short mMethod = kKDE;                  // method for peak finding (KDE vs histo)
   int mWeightedMeanOption = kNoWeight;   // option for weigthed mean
-  double mZMin = -20.0;                  // z range, min, cm
-  double mZMax = 5.;                     // z range, max, cm
-  double mZWindowWidth = 1.25;           // window around peak, cm
+  float mZMin = -20.0;                   // z range, min, cm
+  float mZMax = 5.;                      // z range, max, cm
+  float mZWindowWidth = 1.25;            // window around peak, cm
   int mNBinsForPeakFind = 250;           // 0.1 cm per bin
-  double mZBinWidth = 0.1;               // bin width (recalculated from n bins)
+  float mZBinWidth = 0.1;                // bin width (recalculated from n bins)
   std::vector<int> mHistIntersec;        // histogram for the peak finding method
   int mPeakWidthBins = 3;                // number of bins for integrating histo peak
   int mMinCountsInPeak = 3;              // minimum entries in histo peak
   int mKDEOption = kStandardKDE;         // option for using uncertainties in KDE sigma
   int mNGridKDE = 500;                   // number of points to sample the KDE
-  double mKDEBandwidth = 0.5;            // smoothing parameter, cm
+  float mKDEBandwidth = 0.5;             // smoothing parameter, cm
   bool mVerbose = false;
 
   ClassDefNV(NA6PVertexerTracklets, 1);

--- a/rec/include/NA6PVertexerTracklets.h
+++ b/rec/include/NA6PVertexerTracklets.h
@@ -67,13 +67,13 @@ class NA6PVertexerTracklets
     mZMin = zmin;
     mZMax = zmax;
     mNBinsForPeakFind = nbins;
-    mBinWidth = (mZMax - mZMin) / mNBinsForPeakFind;
+    mZBinWidth = (mZMax - mZMin) / mNBinsForPeakFind;
     mHistIntersec.assign(nbins, 0);
   }
   void configureKDE(double width, int nbins = 500)
   {
     mNGridKDE = nbins;
-    mKDEWidth = width;
+    mKDEBandwidth = width;
   }
 
   // Settters
@@ -114,6 +114,8 @@ class NA6PVertexerTracklets
   void setUseStandardKDE() { mKDEOption = kStandardKDE; }
   void setUseAdaptiveKDE() { mKDEOption = kAdaptiveKDE; }
   void setVerbosity(bool opt = true) { mVerbose = opt; }
+  void configureFromRecoParam(const std::string filename = "");
+  void printConfiguration() const;
 
   // methods for vertex calculation
   void findVertices(std::vector<NA6PBaseCluster>& cluArr,
@@ -179,13 +181,13 @@ class NA6PVertexerTracklets
   double mZMax = 5.;                     // z range, max, cm
   double mZWindowWidth = 1.25;           // window around peak, cm
   int mNBinsForPeakFind = 250;           // 0.1 cm per bin
-  double mBinWidth = 0.1;                // default value
+  double mZBinWidth = 0.1;               // bin width (recalculated from n bins)
   std::vector<int> mHistIntersec;        // histogram for the peak finding method
-  int mPeakWidthBins = 3;
-  int mMinCountsInPeak = 3;
-  int mKDEOption = kAdaptiveKDE;
-  int mNGridKDE = 500;
-  double mKDEWidth = 0.5; // smoothing parameter, cm
+  int mPeakWidthBins = 3;                // number of bins for integrating histo peak
+  int mMinCountsInPeak = 3;              // minimum entries in histo peak
+  int mKDEOption = kStandardKDE;         // option for using uncertainties in KDE sigma
+  int mNGridKDE = 500;                   // number of points to sample the KDE
+  double mKDEBandwidth = 0.5;            // smoothing parameter, cm
   bool mVerbose = false;
 
   ClassDefNV(NA6PVertexerTracklets, 1);

--- a/rec/include/NA6PVertexerTracklets.h
+++ b/rec/include/NA6PVertexerTracklets.h
@@ -114,7 +114,7 @@ class NA6PVertexerTracklets
   void setUseStandardKDE() { mKDEOption = kStandardKDE; }
   void setUseAdaptiveKDE() { mKDEOption = kAdaptiveKDE; }
   void setVerbosity(bool opt = true) { mVerbose = opt; }
-  void configureFromRecoParam(const std::string filename = "");
+  void configureFromRecoParam(const std::string& filename = "");
   void printConfiguration() const;
 
   // methods for vertex calculation

--- a/rec/src/NA6PReconstruction.cxx
+++ b/rec/src/NA6PReconstruction.cxx
@@ -9,11 +9,11 @@
 
 ClassImp(NA6PReconstruction)
 
-
-bool NA6PReconstruction::init(const char* filename, const char* geoname){
+  bool NA6PReconstruction::init(const char* filename, const char* geoname)
+{
   // initialize magnetic field
   if (mIsInitialized) {
-    LOGP(info,"Reconstruction alreary intialized");
+    LOGP(info, "Reconstruction already intialized");
     return true;
   }
   if (TGeoGlobalMagField::Instance()->GetField() == nullptr) {
@@ -22,22 +22,22 @@ bool NA6PReconstruction::init(const char* filename, const char* geoname){
     magField->setAsGlobalField();
   }
   // load geometry
-  if (gGeoManager){
-    LOGP(info,"Geometry was already loaded");
+  if (gGeoManager) {
+    LOGP(info, "Geometry was already loaded");
     mIsInitialized = true;
     return true;
   }
-  if (gSystem->Exec(Form("ls -l %s > /dev/null",filename)) != 0){
-    LOGP(error,"filename {} does not exist",filename);
+  if (gSystem->Exec(Form("ls -l %s > /dev/null", filename)) != 0) {
+    LOGP(error, "filename {} does not exist", filename);
     return false;
   }
   TFile* f = TFile::Open(filename);
   gGeoManager = (TGeoManager*)f->Get(geoname);
-  if (gGeoManager){
+  if (gGeoManager) {
     mIsInitialized = true;
     return true;
-  }else{
-    LOGP(error,"No geometry with name {} found in file {}",geoname,filename);
+  } else {
+    LOGP(error, "No geometry with name {} found in file {}", geoname, filename);
     return false;
   }
 }

--- a/rec/src/NA6PTrackerCA.cxx
+++ b/rec/src/NA6PTrackerCA.cxx
@@ -13,17 +13,15 @@
 
 ClassImp(NA6PTrackerCA)
 
+  //______________________________________________________________________
 
-//______________________________________________________________________
-
-NA6PTrackerCA::NA6PTrackerCA() :
-  mNLayers(5),
-  mPrimVertPos{0.,0.,0.},
-  mTrackFitter{nullptr},
-  mIsClusterUsed{false},
-  mMaxSharedClusters{0},
-  mVerbose{false},
-  mNIterationsCA{2}
+  NA6PTrackerCA::NA6PTrackerCA() : mNLayers(5),
+                                   mPrimVertPos{0., 0., 0.},
+                                   mTrackFitter{nullptr},
+                                   mIsClusterUsed{false},
+                                   mMaxSharedClusters{0},
+                                   mVerbose{false},
+                                   mNIterationsCA{2}
 {
   mTrackFitter = new NA6PFastTrackFitter();
   mTrackFitter->setNLayersVT(mNLayers);
@@ -31,31 +29,34 @@ NA6PTrackerCA::NA6PTrackerCA() :
 }
 //______________________________________________________________________
 
-
-NA6PTrackerCA::~NA6PTrackerCA() 
+NA6PTrackerCA::~NA6PTrackerCA()
 {
-  if (mTrackFitter) delete mTrackFitter;
+  if (mTrackFitter)
+    delete mTrackFitter;
   mTrackFitter = nullptr;
 }
 //______________________________________________________________________
-void NA6PTrackerCA::setNumberOfIterations(int nIter) {
-  if (nIter >= 0 && nIter <= kMaxIterationsCA) mNIterationsCA = nIter;
-  else LOGP(error, "Number of iterations should be <= {}",kMaxIterationsCA);
+void NA6PTrackerCA::setNumberOfIterations(int nIter)
+{
+  if (nIter >= 0 && nIter <= kMaxIterationsCA)
+    mNIterationsCA = nIter;
+  else
+    LOGP(error, "Number of iterations should be <= {}", kMaxIterationsCA);
 }
 void NA6PTrackerCA::setIterationParams(int iter,
-				       double maxDeltaThetaTracklets,
-				       double maxDeltaPhiTracklets,
-				       double maxDeltaTanLCells,
-				       double maxDeltaPhiCells,
-				       double maxDeltaPxPzCells,
-				       double maxDeltaPyPzCells,
-				       double maxChi2TrClCells,
-				       double maxChi2ndfCells,
-				       double maxChi2ndfTracks,
-				       int    minNClusTracks)
+                                       double maxDeltaThetaTracklets,
+                                       double maxDeltaPhiTracklets,
+                                       double maxDeltaTanLCells,
+                                       double maxDeltaPhiCells,
+                                       double maxDeltaPxPzCells,
+                                       double maxDeltaPyPzCells,
+                                       double maxChi2TrClCells,
+                                       double maxChi2ndfCells,
+                                       double maxChi2ndfTracks,
+                                       int minNClusTracks)
 {
   if (iter < 0 || iter >= mNIterationsCA) {
-    LOGP(error, "Iteration {} out of allowed range [0, {}]", iter, mNIterationsCA-1);
+    LOGP(error, "Iteration {} out of allowed range [0, {}]", iter, mNIterationsCA - 1);
     return;
   }
   mMaxDeltaThetaTrackletsCA[iter] = maxDeltaThetaTracklets;
@@ -70,24 +71,25 @@ void NA6PTrackerCA::setIterationParams(int iter,
   mMinNClusTracksCA[iter] = minNClusTracks;
 }
 
-void NA6PTrackerCA::configureFromRecoParam(const std::string filename){
+void NA6PTrackerCA::configureFromRecoParam(const std::string& filename)
+{
   if (filename != "") {
     na6p::conf::ConfigurableParamHelper<NA6PRecoParam>::updateFromFile(filename);
   }
   const auto& param = NA6PRecoParam::Instance();
   setNumberOfIterations(param.nIterationsTrackerCA);
-  for (int jIter = 0; jIter < mNIterationsCA; ++jIter){
+  for (int jIter = 0; jIter < mNIterationsCA; ++jIter) {
     setIterationParams(jIter,
-		       param.maxDeltaThetaTrackletsCA[jIter],
-		       param.maxDeltaPhiTrackletsCA[jIter],
-		       param.maxDeltaTanLCellsCA[jIter],
-		       param.maxDeltaPhiCellsCA[jIter],
-		       param.maxDeltaPxPzCellsCA[jIter],
-		       param.maxDeltaPyPzCellsCA[jIter],
-		       param.maxChi2TrClCellsCA[jIter],
-		       param.maxChi2ndfCellsCA[jIter],
-		       param.maxChi2ndfTracksCA[jIter],
-		       param.minNClusTracksCA[jIter]);
+                       param.maxDeltaThetaTrackletsCA[jIter],
+                       param.maxDeltaPhiTrackletsCA[jIter],
+                       param.maxDeltaTanLCellsCA[jIter],
+                       param.maxDeltaPhiCellsCA[jIter],
+                       param.maxDeltaPxPzCellsCA[jIter],
+                       param.maxDeltaPyPzCellsCA[jIter],
+                       param.maxChi2TrClCellsCA[jIter],
+                       param.maxChi2ndfCellsCA[jIter],
+                       param.maxChi2ndfTracksCA[jIter],
+                       param.minNClusTracksCA[jIter]);
   }
 }
 
@@ -96,43 +98,43 @@ void NA6PTrackerCA::printConfiguration() const
   std::cout << "=== Tracker CA Configuration ===\n";
   std::cout << "Number of iterations: " << mNIterationsCA << "\n\n";
 
-  std::cout << std::setw(5)  << "Iter"
-	    << std::setw(10) << "dThetaTrk"
-	    << std::setw(10) << "dPhiTrk"
-	    << std::setw(10) << "dTanLCell"
-	    << std::setw(10) << "dPhiCell"
-	    << std::setw(10) << "dPxPz"
-	    << std::setw(10) << "dPyPz"
-	    << std::setw(10) << "Chi2Cell"
-	    << std::setw(10) << "Chi2CellNdf"
-	    << std::setw(10) << "Chi2TrackNdf"
-	    << std::setw(8)  << "MinNClu"
-	    << "\n";
-  
-  for (int i = 0; i < mNIterationsCA; ++i)
-    {
-      std::cout << std::setw(5)  << i
-		<< std::setw(10) << mMaxDeltaThetaTrackletsCA[i]
-		<< std::setw(10) << mMaxDeltaPhiTrackletsCA[i]
-		<< std::setw(10) << mMaxDeltaTanLCellsCA[i]
-		<< std::setw(10) << mMaxDeltaPhiCellsCA[i]
-		<< std::setw(10) << mMaxDeltaPxPzCellsCA[i]
-		<< std::setw(10) << mMaxDeltaPyPzCellsCA[i]
-		<< std::setw(10) << mMaxChi2TrClCellsCA[i]
-		<< std::setw(10) << mMaxChi2ndfCellsCA[i]
-		<< std::setw(10) << mMaxChi2ndfTracksCA[i]
-		<< std::setw(8)  << mMinNClusTracksCA[i]
-		<< "\n";
-    }
+  std::cout << std::setw(5) << "Iter"
+            << std::setw(10) << "dThetaTrk"
+            << std::setw(10) << "dPhiTrk"
+            << std::setw(10) << "dTanLCell"
+            << std::setw(10) << "dPhiCell"
+            << std::setw(10) << "dPxPz"
+            << std::setw(10) << "dPyPz"
+            << std::setw(10) << "Chi2Cell"
+            << std::setw(10) << "Chi2CellNdf"
+            << std::setw(10) << "Chi2TrackNdf"
+            << std::setw(8) << "MinNClu"
+            << "\n";
+
+  for (int i = 0; i < mNIterationsCA; ++i) {
+    std::cout << std::setw(5) << i
+              << std::setw(10) << mMaxDeltaThetaTrackletsCA[i]
+              << std::setw(10) << mMaxDeltaPhiTrackletsCA[i]
+              << std::setw(10) << mMaxDeltaTanLCellsCA[i]
+              << std::setw(10) << mMaxDeltaPhiCellsCA[i]
+              << std::setw(10) << mMaxDeltaPxPzCellsCA[i]
+              << std::setw(10) << mMaxDeltaPyPzCellsCA[i]
+              << std::setw(10) << mMaxChi2TrClCellsCA[i]
+              << std::setw(10) << mMaxChi2ndfCellsCA[i]
+              << std::setw(10) << mMaxChi2ndfTracksCA[i]
+              << std::setw(8) << mMinNClusTracksCA[i]
+              << "\n";
+  }
   std::cout << "==============================\n";
 }
 
 //______________________________________________________________________
 
-bool NA6PTrackerCA::loadGeometry(const char* filename, const char* geoname){
+bool NA6PTrackerCA::loadGeometry(const char* filename, const char* geoname)
+{
 
   if (!mTrackFitter) {
-    LOGP(error,"Fitter not yet instantiated");
+    LOGP(error, "Fitter not yet instantiated");
     return false;
   }
   return mTrackFitter->loadGeometry(filename, geoname);
@@ -141,14 +143,15 @@ bool NA6PTrackerCA::loadGeometry(const char* filename, const char* geoname){
 //______________________________________________________________________
 
 void NA6PTrackerCA::sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluArr,
-					      std::vector<int>& firstIndex,
-					      std::vector<int>& lastIndex){
-  
+                                              std::vector<int>& firstIndex,
+                                              std::vector<int>& lastIndex)
+{
+
   // count clus per layer
   std::vector<int> count(mNLayers, 0);
   for (const auto& clu : cluArr) {
-    int jDet=clu.getDetectorID();
-    int jLay=jDet/4;
+    int jDet = clu.getDetectorID();
+    int jLay = jDet / 4;
     if (jLay >= 0 && jLay < mNLayers) {
       count[jLay]++;
     }
@@ -166,8 +169,9 @@ void NA6PTrackerCA::sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluA
   std::vector<int> countReord = firstIndex;
   std::vector<NA6PBaseCluster> reordered(cluArr.size());
   for (const auto& clu : cluArr) {
-    int jLay=clu.getDetectorID()/4;
-    if(jLay >= 0 && jLay < mNLayers) reordered[countReord[jLay]++] = clu;
+    int jLay = clu.getDetectorID() / 4;
+    if (jLay >= 0 && jLay < mNLayers)
+      reordered[countReord[jLay]++] = clu;
   }
   cluArr = std::move(reordered);
   // sort by theta within each layer (use z^2/r^2 as a proxy of theta to avoid sqrt and atan)
@@ -176,7 +180,7 @@ void NA6PTrackerCA::sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluA
   const double pvz = mPrimVertPos[2];
   for (int jLay = 0; jLay < mNLayers; jLay++) {
     auto first = cluArr.begin() + firstIndex[jLay];
-    auto last  = cluArr.begin() + lastIndex[jLay];
+    auto last = cluArr.begin() + lastIndex[jLay];
     std::sort(first, last, [pvx, pvy, pvz](const NA6PBaseCluster& a, const NA6PBaseCluster& b) {
       double xa = a.getX() - pvx;
       double ya = a.getY() - pvy;
@@ -184,9 +188,9 @@ void NA6PTrackerCA::sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluA
       double xb = b.getX() - pvx;
       double yb = b.getY() - pvy;
       double zb = b.getZ() - pvz;
-      double r2a = xa*xa + ya*ya;
-      double r2b = xb*xb + yb*yb;
-      return za*za * r2b < zb*zb * r2a;
+      double r2a = xa * xa + ya * ya;
+      double r2b = xb * xb + yb * yb;
+      return za * za * r2b < zb * zb * r2a;
     });
   }
 }
@@ -194,65 +198,67 @@ void NA6PTrackerCA::sortClustersByLayerAndEta(std::vector<NA6PBaseCluster>& cluA
 //______________________________________________________________________
 
 void NA6PTrackerCA::sortTrackletsByLayerAndIndex(std::vector<TrackletCandidate>& tracklets,
-						 std::vector<int>& firstIndex,
-						 std::vector<int>& lastIndex){
-  
+                                                 std::vector<int>& firstIndex,
+                                                 std::vector<int>& lastIndex)
+{
+
   // count clusters per layer
-  std::vector<int> count(mNLayers-1, 0);
+  std::vector<int> count(mNLayers - 1, 0);
   for (const auto& trkl : tracklets) {
-    int jLay=trkl.startingLayer;
-    if (jLay >= 0 && jLay < mNLayers-1) {
+    int jLay = trkl.startingLayer;
+    if (jLay >= 0 && jLay < mNLayers - 1) {
       count[jLay]++;
     }
   }
   // starting offset for each layer
-  firstIndex.resize(mNLayers-1);
-  lastIndex.resize(mNLayers-1);
+  firstIndex.resize(mNLayers - 1);
+  lastIndex.resize(mNLayers - 1);
   firstIndex[0] = 0;
   lastIndex[0] = count[0];
-  for (int jLay = 1; jLay < mNLayers-1; jLay++) {
+  for (int jLay = 1; jLay < mNLayers - 1; jLay++) {
     firstIndex[jLay] = firstIndex[jLay - 1] + count[jLay - 1];
     lastIndex[jLay] = firstIndex[jLay] + count[jLay];
   }
   // Create a reordered vector based on layer grouping
   std::vector<int> countReord = firstIndex;
   std::vector<TrackletCandidate> reordered(tracklets.size());
-  for (const auto& trkl :tracklets) {
-    int jLay=trkl.startingLayer;
-    if(jLay >= 0 && jLay < mNLayers-1) reordered[countReord[jLay]++] = trkl;
+  for (const auto& trkl : tracklets) {
+    int jLay = trkl.startingLayer;
+    if (jLay >= 0 && jLay < mNLayers - 1)
+      reordered[countReord[jLay]++] = trkl;
   }
   tracklets = std::move(reordered);
-  // sort by cluster index within each layer 
-  for (int jLay = 0; jLay < mNLayers-1; jLay++) {
+  // sort by cluster index within each layer
+  for (int jLay = 0; jLay < mNLayers - 1; jLay++) {
     auto first = tracklets.begin() + firstIndex[jLay];
-    auto last  = tracklets.begin() + lastIndex[jLay];
+    auto last = tracklets.begin() + lastIndex[jLay];
     std::sort(first, last, [](const TrackletCandidate& a, const TrackletCandidate& b) {
       return a.firstClusterIndex < b.firstClusterIndex || (a.firstClusterIndex == b.firstClusterIndex && a.secondClusterIndex < b.secondClusterIndex);
     });
   }
 }
 
-
 //______________________________________________________________________
 
 void NA6PTrackerCA::sortCellsByLayerAndIndex(std::vector<CellCandidate>& cells,
-					     std::vector<int>& firstIndex,
-					     std::vector<int>& lastIndex){
-  
+                                             std::vector<int>& firstIndex,
+                                             std::vector<int>& lastIndex)
+{
+
   // count cells per layer
-  std::vector<int> count(mNLayers-2, 0);
+  std::vector<int> count(mNLayers - 2, 0);
   for (const auto& cell : cells) {
-    int jLay=cell.startingLayer;
-    if (jLay >= 0 && jLay < mNLayers-2) {
+    int jLay = cell.startingLayer;
+    if (jLay >= 0 && jLay < mNLayers - 2) {
       count[jLay]++;
     }
   }
   // starting offset for each layer
-  firstIndex.resize(mNLayers-2);
-  lastIndex.resize(mNLayers-2);
+  firstIndex.resize(mNLayers - 2);
+  lastIndex.resize(mNLayers - 2);
   firstIndex[0] = 0;
   lastIndex[0] = count[0];
-  for (int jLay = 1; jLay < mNLayers-2; jLay++) {
+  for (int jLay = 1; jLay < mNLayers - 2; jLay++) {
     firstIndex[jLay] = firstIndex[jLay - 1] + count[jLay - 1];
     lastIndex[jLay] = firstIndex[jLay] + count[jLay];
   }
@@ -260,92 +266,97 @@ void NA6PTrackerCA::sortCellsByLayerAndIndex(std::vector<CellCandidate>& cells,
   std::vector<int> countReord = firstIndex;
   std::vector<CellCandidate> reordered(cells.size());
   for (const auto& cell : cells) {
-    int jLay=cell.startingLayer;
-    if(jLay >= 0 && jLay < mNLayers-2) reordered[countReord[jLay]++] = cell;
+    int jLay = cell.startingLayer;
+    if (jLay >= 0 && jLay < mNLayers - 2)
+      reordered[countReord[jLay]++] = cell;
   }
   cells = std::move(reordered);
-  // sort by tracklet index within each layer 
-  for (int jLay = 0; jLay < mNLayers-2; jLay++) {
+  // sort by tracklet index within each layer
+  for (int jLay = 0; jLay < mNLayers - 2; jLay++) {
     auto first = cells.begin() + firstIndex[jLay];
-    auto last  = cells.begin() + lastIndex[jLay];
+    auto last = cells.begin() + lastIndex[jLay];
     std::sort(first, last, [](const CellCandidate& a, const CellCandidate& b) {
       return a.firstTrackletIndex < b.firstTrackletIndex || (a.firstTrackletIndex == b.firstTrackletIndex && a.secondTrackletIndex < b.secondTrackletIndex);
     });
   }
 }
 
-
 //______________________________________________________________________
 
 void NA6PTrackerCA::computeLayerTracklets(const std::vector<NA6PBaseCluster>& cluArr,
-					  const std::vector<int>& firstIndex,
-					  const std::vector<int>& lastIndex,
-					  std::vector<TrackletCandidate>& tracklets,
-					  double deltaThetaMax,
-					  double deltaPhiMax){
-  
+                                          const std::vector<int>& firstIndex,
+                                          const std::vector<int>& lastIndex,
+                                          std::vector<TrackletCandidate>& tracklets,
+                                          double& deltaThetaMax,
+                                          double& deltaPhiMax)
+{
+
   tracklets.clear();
   const double pvx = mPrimVertPos[0];
   const double pvy = mPrimVertPos[1];
   const double pvz = mPrimVertPos[2];
 
   for (int iLayer = 0; iLayer < mNLayers - 1; ++iLayer) {
-    auto layerBegin = cluArr.begin() + firstIndex[iLayer+1];
-    auto layerEnd = cluArr.begin() + lastIndex[iLayer+1];
+    auto layerBegin = cluArr.begin() + firstIndex[iLayer + 1];
+    auto layerEnd = cluArr.begin() + lastIndex[iLayer + 1];
     for (int jClu1 = firstIndex[iLayer]; jClu1 < lastIndex[iLayer]; ++jClu1) {
-      if (mIsClusterUsed[jClu1]) continue;
+      if (mIsClusterUsed[jClu1])
+        continue;
       const NA6PBaseCluster& clu1 = cluArr[jClu1];
       double x1 = clu1.getX() - pvx;
       double y1 = clu1.getY() - pvy;
       double z1 = clu1.getZ() - pvz;
-      double r1 = std::sqrt(x1*x1 + y1*y1);
+      double r1 = std::sqrt(x1 * x1 + y1 * y1);
       double theta1 = std::atan2(z1, r1);
-      double phi1 = std::atan2(y1,x1);
-      double tanth2Min = std::max(0.,std::tan(theta1 - 1.2 * deltaThetaMax)); // 1.2 is a safety margin, the tan(theta) range is limited at zero to protect for the case in which theta1 - 1.2 * deltaThetaMax is <0, which would give a negative tangent. The minimum acceptable value for theta is 0
+      double phi1 = std::atan2(y1, x1);
+      double tanth2Min = std::max(0., std::tan(theta1 - 1.2 * deltaThetaMax)); // 1.2 is a safety margin, the tan(theta) range is limited at zero to protect for the case in which theta1 - 1.2 * deltaThetaMax is <0, which would give a negative tangent. The minimum acceptable value for theta is 0
       double tanth2Max = std::tan(theta1 + 1.2 * deltaThetaMax);
-      auto lower = std::partition_point(layerBegin, layerEnd, 
-					[pvx, pvy, pvz, tanth2Min](const NA6PBaseCluster& clu){
-					  double x = clu.getX() - pvx;
-					  double y = clu.getY() - pvy;
-					  double z = clu.getZ() - pvz;
-					  double r2 = x*x + y*y;
-					  double tan2 = z*z / r2;
-					  return tan2 < tanth2Min*tanth2Min;
-					});
+      auto lower = std::partition_point(layerBegin, layerEnd,
+                                        [pvx, pvy, pvz, tanth2Min](const NA6PBaseCluster& clu) {
+                                          double x = clu.getX() - pvx;
+                                          double y = clu.getY() - pvy;
+                                          double z = clu.getZ() - pvz;
+                                          double r2 = x * x + y * y;
+                                          double tan2 = z * z / r2;
+                                          return tan2 < tanth2Min * tanth2Min;
+                                        });
 
-      auto upper = std::partition_point(layerBegin, layerEnd, 
-					[pvx, pvy, pvz, tanth2Max](const NA6PBaseCluster& clu){
-					  double x = clu.getX() - pvx;
-					  double y = clu.getY() - pvy;
-					  double z = clu.getZ() - pvz;
-					  double r2 = x*x + y*y;
-					  double tan2 = z*z / r2;
-					  return tan2 <= tanth2Max*tanth2Max;  
-					});
+      auto upper = std::partition_point(layerBegin, layerEnd,
+                                        [pvx, pvy, pvz, tanth2Max](const NA6PBaseCluster& clu) {
+                                          double x = clu.getX() - pvx;
+                                          double y = clu.getY() - pvy;
+                                          double z = clu.getZ() - pvz;
+                                          double r2 = x * x + y * y;
+                                          double tan2 = z * z / r2;
+                                          return tan2 <= tanth2Max * tanth2Max;
+                                        });
       int lowerIdx = std::distance(cluArr.begin(), lower);
       int upperIdx = std::distance(cluArr.begin(), upper);
       for (int jClu2 = lowerIdx; jClu2 < upperIdx; ++jClu2) {
-	if (mIsClusterUsed[jClu2]) continue;
-	const NA6PBaseCluster& clu2 = cluArr[jClu2];
-	double x2 = clu2.getX() - pvx;
-	double y2 = clu2.getY() - pvy;
-	double z2 = clu2.getZ() - pvz;
-	double r2 = std::sqrt(x2*x2 + y2*y2);
-	double theta2 = std::atan2(z2, r2);
-	double phi2 = std::atan2(y2,x2);
-	double dphi = phi2-phi1;
-	if (dphi > M_PI) dphi -= 2*M_PI;
-	else if (dphi < -M_PI) dphi += 2*M_PI;
-	if (std::abs(theta2-theta1) < deltaThetaMax && std::abs(dphi) < deltaPhiMax){
-	  double phi = std::atan2(y2 - y1, x2 - x1);
-	  double tanL = (z2 - z1) / (r2 - r1);
-	  double pxpz = (x2 - x1) / (z2 - z1);
-	  double pypz = (y2 - y1) / (z2 - z1);
-	  tracklets.emplace_back(iLayer, jClu1, jClu2, tanL, phi,pxpz,pypz);
-	  // do not assign the clusters as used, it will be done when the tracklets are used into tracks
-	  // mIsClusterUsed[jClu1] = true;
-	  // mIsClusterUsed[jClu2] = true;
-	}
+        if (mIsClusterUsed[jClu2])
+          continue;
+        const NA6PBaseCluster& clu2 = cluArr[jClu2];
+        double x2 = clu2.getX() - pvx;
+        double y2 = clu2.getY() - pvy;
+        double z2 = clu2.getZ() - pvz;
+        double r2 = std::sqrt(x2 * x2 + y2 * y2);
+        double theta2 = std::atan2(z2, r2);
+        double phi2 = std::atan2(y2, x2);
+        double dphi = phi2 - phi1;
+        if (dphi > M_PI)
+          dphi -= 2 * M_PI;
+        else if (dphi < -M_PI)
+          dphi += 2 * M_PI;
+        if (std::abs(theta2 - theta1) < deltaThetaMax && std::abs(dphi) < deltaPhiMax) {
+          double phi = std::atan2(y2 - y1, x2 - x1);
+          double tanL = (z2 - z1) / (r2 - r1);
+          double pxpz = (x2 - x1) / (z2 - z1);
+          double pypz = (y2 - y1) / (z2 - z1);
+          tracklets.emplace_back(iLayer, jClu1, jClu2, tanL, phi, pxpz, pypz);
+          // do not assign the clusters as used, it will be done when the tracklets are used into tracks
+          // mIsClusterUsed[jClu1] = true;
+          // mIsClusterUsed[jClu2] = true;
+        }
       }
     }
   }
@@ -354,50 +365,54 @@ void NA6PTrackerCA::computeLayerTracklets(const std::vector<NA6PBaseCluster>& cl
 //______________________________________________________________________
 
 void NA6PTrackerCA::computeLayerCells(const std::vector<TrackletCandidate>& tracklets,
-				      const std::vector<int>& firstIndex,
-				      const std::vector<int>& lastIndex,
-				      const std::vector<NA6PBaseCluster>& cluArr,
-				      std::vector<CellCandidate>& cells,
-				      double deltaTanLMax,
-				      double deltaPhiMax,
-				      double deltaPxPzMax,
-				      double deltaPyPzMax,
-				      double maxChi2TrClu,
-				      double maxChi2NDF){
+                                      const std::vector<int>& firstIndex,
+                                      const std::vector<int>& lastIndex,
+                                      const std::vector<NA6PBaseCluster>& cluArr,
+                                      std::vector<CellCandidate>& cells,
+                                      double& deltaTanLMax,
+                                      double& deltaPhiMax,
+                                      double& deltaPxPzMax,
+                                      double& deltaPyPzMax,
+                                      double& maxChi2TrClu,
+                                      double& maxChi2NDF)
+{
 
   cells.clear();
   for (int iLayer = 0; iLayer < mNLayers - 2; ++iLayer) {
-    auto layerBegin = tracklets.begin() + firstIndex[iLayer+1];
-    auto layerEnd = tracklets.begin() + lastIndex[iLayer+1];
+    auto layerBegin = tracklets.begin() + firstIndex[iLayer + 1];
+    auto layerEnd = tracklets.begin() + lastIndex[iLayer + 1];
     for (int jTrkl1 = firstIndex[iLayer]; jTrkl1 < lastIndex[iLayer]; ++jTrkl1) {
       const TrackletCandidate& trkl1 = tracklets[jTrkl1];
       const int nextLayerClusterIndex = trkl1.secondClusterIndex;
       auto lower = std::partition_point(layerBegin, layerEnd,
-					[nextLayerClusterIndex](const TrackletCandidate& trkl){
-					  return trkl.firstClusterIndex < nextLayerClusterIndex;
-					});
+                                        [nextLayerClusterIndex](const TrackletCandidate& trkl) {
+                                          return trkl.firstClusterIndex < nextLayerClusterIndex;
+                                        });
       auto upper = std::partition_point(layerBegin, layerEnd,
-					[nextLayerClusterIndex](const TrackletCandidate& trkl){
-					  return trkl.firstClusterIndex <= nextLayerClusterIndex;
-					});
+                                        [nextLayerClusterIndex](const TrackletCandidate& trkl) {
+                                          return trkl.firstClusterIndex <= nextLayerClusterIndex;
+                                        });
       for (auto it = lower; it != upper; ++it) {
-	int jTrkl2 = it - tracklets.begin();
-	const TrackletCandidate& trkl2 = *it;
-	if (trkl2.firstClusterIndex != nextLayerClusterIndex) continue;
-	const double deltaTanLambda = std::abs(trkl2.tanL - trkl1.tanL);
-	double dphi = trkl2.phi - trkl1.phi;
-	if (dphi > M_PI) dphi -= 2*M_PI;
-	else if (dphi < -M_PI) dphi += 2*M_PI;
-	double deltapxpz = std::abs(trkl2.pxpz - trkl1.pxpz);
-	double deltapypz = std::abs(trkl2.pypz - trkl1.pypz);
-	if (deltapypz < deltaPyPzMax && deltapxpz < deltaPxPzMax && deltaTanLambda < deltaTanLMax && std::abs(dphi) < deltaPhiMax) {
-	  std::array<int, 3> cluIDs = {trkl1.firstClusterIndex,trkl2.firstClusterIndex,trkl2.secondClusterIndex};
-	  NA6PTrack fitTrackFast;
-	  //	  genfit::Track fitTrack;
-	  if(fitTrackPointsFast(std::vector<int>(cluIDs.begin(), cluIDs.end()),cluArr, fitTrackFast, maxChi2TrClu, maxChi2NDF)){
-	    cells.emplace_back(iLayer, jTrkl1, jTrkl2, std::move(cluIDs), fitTrackFast);
-	  }
-	}
+        int jTrkl2 = it - tracklets.begin();
+        const TrackletCandidate& trkl2 = *it;
+        if (trkl2.firstClusterIndex != nextLayerClusterIndex)
+          continue;
+        const double deltaTanLambda = std::abs(trkl2.tanL - trkl1.tanL);
+        double dphi = trkl2.phi - trkl1.phi;
+        if (dphi > M_PI)
+          dphi -= 2 * M_PI;
+        else if (dphi < -M_PI)
+          dphi += 2 * M_PI;
+        double deltapxpz = std::abs(trkl2.pxpz - trkl1.pxpz);
+        double deltapypz = std::abs(trkl2.pypz - trkl1.pypz);
+        if (deltapypz < deltaPyPzMax && deltapxpz < deltaPxPzMax && deltaTanLambda < deltaTanLMax && std::abs(dphi) < deltaPhiMax) {
+          std::array<int, 3> cluIDs = {trkl1.firstClusterIndex, trkl2.firstClusterIndex, trkl2.secondClusterIndex};
+          NA6PTrack fitTrackFast;
+          //	  genfit::Track fitTrack;
+          if (fitTrackPointsFast(std::vector<int>(cluIDs.begin(), cluIDs.end()), cluArr, fitTrackFast, maxChi2TrClu, maxChi2NDF)) {
+            cells.emplace_back(iLayer, jTrkl1, jTrkl2, std::move(cluIDs), fitTrackFast);
+          }
+        }
       }
     }
   }
@@ -406,94 +421,103 @@ void NA6PTrackerCA::computeLayerCells(const std::vector<TrackletCandidate>& trac
 //______________________________________________________________________
 
 double NA6PTrackerCA::computeTrackToClusterChi2(const NA6PTrack& track,
-				 const NA6PBaseCluster& clu){
-  
+                                                const NA6PBaseCluster& clu)
+{
+
   double meas[2] = {clu.getYTF(), clu.getZTF()}; // ideal cluster coordinate, tracking (AliExtTrParam frame)
   double measErr2[3] = {clu.getSigYY(), clu.getSigYZ(), clu.getSigZZ()};
   NA6PTrack copyToProp = track;
   copyToProp.propagateToZBxByBz(clu.getZ()); // no material correction temporarily
-  double cluchi2 = copyToProp.getTrackExtParam().getPredictedChi2(meas,measErr2);
+  double cluchi2 = copyToProp.getTrackExtParam().getPredictedChi2(meas, measErr2);
   return cluchi2;
 }
 
 //______________________________________________________________________
 
 bool NA6PTrackerCA::fitTrackPointsFast(const std::vector<int>& cluIDs,
-				       const std::vector<NA6PBaseCluster>& cluArr,
-				       NA6PTrack& fitTrack,
-				       double maxChi2TrClu,
-				       double maxChi2NDF){
-  
+                                       const std::vector<NA6PBaseCluster>& cluArr,
+                                       NA6PTrack& fitTrack,
+                                       double& maxChi2TrClu,
+                                       double& maxChi2NDF)
+{
+
   int nClus = cluIDs.size();
   mTrackFitter->cleanupAndStartFit();
   mTrackFitter->setMaxChi2Cl(maxChi2TrClu);
   std::vector<NA6PBaseCluster*> clusters;
   clusters.reserve(nClus);
-  for (int jClu = 0; jClu < nClus; jClu++){
-    int cluID =  cluIDs[jClu];
+  for (int jClu = 0; jClu < nClus; jClu++) {
+    int cluID = cluIDs[jClu];
     const auto& clu = cluArr[cluID];
-    int nLay=clu.getDetectorID()/4;
+    int nLay = clu.getDetectorID() / 4;
     NA6PBaseCluster* cluForFit = new NA6PBaseCluster(clu);
     // no need to delete these pointer: the fitter will take ownership
     clusters.push_back(cluForFit);
-    mTrackFitter->addClusterVT(nLay,cluForFit);
+    mTrackFitter->addClusterVT(nLay, cluForFit);
   }
-  
+
   std::unique_ptr<NA6PTrack> fitTrackPtr(mTrackFitter->fitTrackPointsVT());
-  if (!fitTrackPtr) return false;
-  
+  if (!fitTrackPtr)
+    return false;
+
   double chi2ndf = fitTrackPtr->getNormChi2();
-  if (chi2ndf > maxChi2NDF) return false;
+  if (chi2ndf > maxChi2NDF)
+    return false;
 
   fitTrack = *fitTrackPtr;
-  for (int jClu = 0; jClu < nClus; jClu++){
+  for (int jClu = 0; jClu < nClus; jClu++) {
     double meas[2] = {clusters[jClu]->getYTF(), clusters[jClu]->getZTF()}; // tracking (ExtTrParam) frame)
     double measErr2[3] = {clusters[jClu]->getSigYY(), clusters[jClu]->getSigYZ(), clusters[jClu]->getSigZZ()};
-    mTrackFitter->propagateToZ(fitTrackPtr.get(),clusters[jClu]->getZLab());
-    double cluchi2 = fitTrackPtr->getTrackExtParam().getPredictedChi2(meas,measErr2);
-    if (cluchi2 > maxChi2TrClu) return false;
+    mTrackFitter->propagateToZ(fitTrackPtr.get(), clusters[jClu]->getZLab());
+    double cluchi2 = fitTrackPtr->getTrackExtParam().getPredictedChi2(meas, measErr2);
+    if (cluchi2 > maxChi2TrClu)
+      return false;
   }
-  return true;  
+  return true;
 }
 
 //______________________________________________________________________
 
 void NA6PTrackerCA::findCellsNeighbours(const std::vector<CellCandidate>& cells,
-					const std::vector<int>& firstIndex,
-					const std::vector<int>& lastIndex,
-					std::vector<std::pair<int,int>>& cneigh,
-					const std::vector<NA6PBaseCluster>& cluArr,
-					double maxChi2TrClu){
-  
+                                        const std::vector<int>& firstIndex,
+                                        const std::vector<int>& lastIndex,
+                                        std::vector<std::pair<int, int>>& cneigh,
+                                        const std::vector<NA6PBaseCluster>& cluArr,
+                                        double& maxChi2TrClu)
+{
+
   cneigh.clear();
 
   for (int iLayer = 0; iLayer < mNLayers - 3; ++iLayer) {
-    auto layerBegin = cells.begin() + firstIndex[iLayer+1];
-    auto layerEnd = cells.begin() + lastIndex[iLayer+1];
+    auto layerBegin = cells.begin() + firstIndex[iLayer + 1];
+    auto layerEnd = cells.begin() + lastIndex[iLayer + 1];
     for (int jCe1 = firstIndex[iLayer]; jCe1 < lastIndex[iLayer]; ++jCe1) {
       const CellCandidate& cell1 = cells[jCe1];
       const int nextLayerTrackletIndex = cell1.secondTrackletIndex;
       auto lower = std::partition_point(layerBegin, layerEnd,
-                                        [&](const CellCandidate& c){ return c.firstTrackletIndex < nextLayerTrackletIndex; });
+                                        [&](const CellCandidate& c) { return c.firstTrackletIndex < nextLayerTrackletIndex; });
       auto upper = std::partition_point(layerBegin, layerEnd,
-                                        [&](const CellCandidate& c){ return c.firstTrackletIndex <= nextLayerTrackletIndex; });
+                                        [&](const CellCandidate& c) { return c.firstTrackletIndex <= nextLayerTrackletIndex; });
       for (auto it = lower; it != upper; ++it) {
-	int jCe2 = it - cells.begin();
-	const CellCandidate& cell2 = *it;
-	if (cell2.firstTrackletIndex != nextLayerTrackletIndex) continue;
-	if (cell1.cluIDs[1] != cell2.cluIDs[0] || cell1.cluIDs[2] != cell2.cluIDs[1]){
-	  LOGP(error, "mismatch in cluIDs");
-	  continue;
-	}
-	int jClu2 = cell2.cluIDs[2];
-	const auto& clu2 = cluArr[jClu2];
-	double cluchi2a = computeTrackToClusterChi2(cell1.trackFitFast, clu2);
-	if (cluchi2a > maxChi2TrClu) continue;
-	int jClu0 = cell1.cluIDs[0];
-	const auto& clu0 = cluArr[jClu0];
-	double cluchi2b = computeTrackToClusterChi2(cell2.trackFitFast, clu0);
-	if (cluchi2b > maxChi2TrClu) continue;
-	cneigh.push_back(std::make_pair(jCe1, jCe2));
+        int jCe2 = it - cells.begin();
+        const CellCandidate& cell2 = *it;
+        if (cell2.firstTrackletIndex != nextLayerTrackletIndex)
+          continue;
+        if (cell1.cluIDs[1] != cell2.cluIDs[0] || cell1.cluIDs[2] != cell2.cluIDs[1]) {
+          LOGP(error, "mismatch in cluIDs");
+          continue;
+        }
+        int jClu2 = cell2.cluIDs[2];
+        const auto& clu2 = cluArr[jClu2];
+        double cluchi2a = computeTrackToClusterChi2(cell1.trackFitFast, clu2);
+        if (cluchi2a > maxChi2TrClu)
+          continue;
+        int jClu0 = cell1.cluIDs[0];
+        const auto& clu0 = cluArr[jClu0];
+        double cluchi2b = computeTrackToClusterChi2(cell2.trackFitFast, clu0);
+        if (cluchi2b > maxChi2TrClu)
+          continue;
+        cneigh.push_back(std::make_pair(jCe1, jCe2));
       }
     }
   }
@@ -501,22 +525,23 @@ void NA6PTrackerCA::findCellsNeighbours(const std::vector<CellCandidate>& cells,
 
 //______________________________________________________________________
 std::vector<TrackCandidate> NA6PTrackerCA::prolongSeed(const TrackCandidate& seed,
-						       const std::vector<CellCandidate>& cells,
-						       const std::vector<int>& firstIndex,
-						       const std::vector<int>& lastIndex,
-						       const std::vector<NA6PBaseCluster>& cluArr,
-						       double maxChi2TrClu,
-						       ExtendDirection dir){
-  
+                                                       const std::vector<CellCandidate>& cells,
+                                                       const std::vector<int>& firstIndex,
+                                                       const std::vector<int>& lastIndex,
+                                                       const std::vector<NA6PBaseCluster>& cluArr,
+                                                       double& maxChi2TrClu,
+                                                       ExtendDirection dir)
+{
+
   std::vector<TrackCandidate> current = {seed};
   std::vector<TrackCandidate> next;
   std::vector<TrackCandidate> result;
-  
+
   int step = (dir == ExtendDirection::kInward) ? -1 : 1;
   int startLayer = (dir == ExtendDirection::kInward) ? seed.innerLayer - 1 : seed.outerLayer + 1;
   int endLayer = (dir == ExtendDirection::kInward) ? -1 : mNLayers;
   int maxValidLayerToSearch = firstIndex.size();
-  
+
   for (int iLayer = startLayer; iLayer != endLayer; iLayer += step) {
     next.clear();
     bool foundAnyProlongation = false;
@@ -524,77 +549,83 @@ std::vector<TrackCandidate> NA6PTrackerCA::prolongSeed(const TrackCandidate& see
       const CellCandidate& refCell = (dir == ExtendDirection::kInward) ? cells[cand.innerCellIndex] : cells[cand.outerCellIndex];
       const int nextLayerTrackletIndex = (dir == ExtendDirection::kInward) ? refCell.firstTrackletIndex : refCell.secondTrackletIndex;
       // in case of outward prolongation, pick up firstIndex and lastIndex at iLayer-2 (the cell contains 3 clus in layers: iLayer-2, iLayer-1 and iLayer)
-      int layToSearch =  (dir == ExtendDirection::kInward) ? iLayer : iLayer-2;
-      if (layToSearch < 0 || layToSearch >= maxValidLayerToSearch){
-	LOGP(error,"in prolongSeed direction {}: layToSearch out of range {}",step,layToSearch);
-	continue;
+      int layToSearch = (dir == ExtendDirection::kInward) ? iLayer : iLayer - 2;
+      if (layToSearch < 0 || layToSearch >= maxValidLayerToSearch) {
+        LOGP(error, "in prolongSeed direction {}: layToSearch out of range {}", step, layToSearch);
+        continue;
       }
       for (int jCe = firstIndex[layToSearch]; jCe < lastIndex[layToSearch]; ++jCe) {
-	const CellCandidate& ccNext = cells[jCe];
-	if ((dir == ExtendDirection::kInward && ccNext.secondTrackletIndex != nextLayerTrackletIndex) ||
-	    (dir == ExtendDirection::kOutward && ccNext.firstTrackletIndex != nextLayerTrackletIndex)) continue;
-	// --- CluID continuity checks ---
-	if (dir == ExtendDirection::kInward) {
-	  if (ccNext.cluIDs[1] != refCell.cluIDs[0] || ccNext.cluIDs[2] != refCell.cluIDs[1]){
-	    LOGP(error,"mismatch in CluIDs in prolongSeed in inward direction");
-	    continue;
-	  }
-	} else {
-	  if (ccNext.cluIDs[0] != refCell.cluIDs[1] || ccNext.cluIDs[1] != refCell.cluIDs[2]){
-	    LOGP(error,"mismatch in CluIDs in prolongSeed in outward direction");
-	    continue;
-	  }
-	}
-	// --- Chi2 checks ---
-	const auto& fitNext = ccNext.trackFitFast;
-	int cluRefIndex = (dir == ExtendDirection::kInward) ? 2 : 0;
-	const auto& cluRef = cluArr[refCell.cluIDs[cluRefIndex]];
-	double chi2a = computeTrackToClusterChi2(fitNext, cluRef);
-	if (chi2a > maxChi2TrClu) continue;
-	const auto& fitRef = refCell.trackFitFast;
-	int cluNextIndex = (dir == ExtendDirection::kInward) ? 0 : 2;
-	const auto& cluNext = cluArr[ccNext.cluIDs[cluNextIndex]];
-	double chi2b = computeTrackToClusterChi2(fitRef, cluNext);
-	if (chi2b > maxChi2TrClu) continue;
-	// create new prolonged track
-	TrackCandidate extended = cand;
-	if (dir == ExtendDirection::kInward) {
-	  extended.innerCellIndex = jCe;
-	  extended.innerLayer = ccNext.startingLayer;
-	  int nLay = cluArr[ccNext.cluIDs[0]].getDetectorID() / 4;
-	  extended.cluIDs[nLay] = ccNext.cluIDs[0];
-	} else {
-	  extended.outerCellIndex = jCe;
-	  extended.outerLayer = ccNext.startingLayer;
-	  int nLay = cluArr[ccNext.cluIDs[2]].getDetectorID() / 4;
-	  extended.cluIDs[nLay] = ccNext.cluIDs[2];
-	}
-	next.push_back(std::move(extended));
-	foundAnyProlongation = true;
+        const CellCandidate& ccNext = cells[jCe];
+        if ((dir == ExtendDirection::kInward && ccNext.secondTrackletIndex != nextLayerTrackletIndex) ||
+            (dir == ExtendDirection::kOutward && ccNext.firstTrackletIndex != nextLayerTrackletIndex))
+          continue;
+        // --- CluID continuity checks ---
+        if (dir == ExtendDirection::kInward) {
+          if (ccNext.cluIDs[1] != refCell.cluIDs[0] || ccNext.cluIDs[2] != refCell.cluIDs[1]) {
+            LOGP(error, "mismatch in CluIDs in prolongSeed in inward direction");
+            continue;
+          }
+        } else {
+          if (ccNext.cluIDs[0] != refCell.cluIDs[1] || ccNext.cluIDs[1] != refCell.cluIDs[2]) {
+            LOGP(error, "mismatch in CluIDs in prolongSeed in outward direction");
+            continue;
+          }
+        }
+        // --- Chi2 checks ---
+        const auto& fitNext = ccNext.trackFitFast;
+        int cluRefIndex = (dir == ExtendDirection::kInward) ? 2 : 0;
+        const auto& cluRef = cluArr[refCell.cluIDs[cluRefIndex]];
+        double chi2a = computeTrackToClusterChi2(fitNext, cluRef);
+        if (chi2a > maxChi2TrClu)
+          continue;
+        const auto& fitRef = refCell.trackFitFast;
+        int cluNextIndex = (dir == ExtendDirection::kInward) ? 0 : 2;
+        const auto& cluNext = cluArr[ccNext.cluIDs[cluNextIndex]];
+        double chi2b = computeTrackToClusterChi2(fitRef, cluNext);
+        if (chi2b > maxChi2TrClu)
+          continue;
+        // create new prolonged track
+        TrackCandidate extended = cand;
+        if (dir == ExtendDirection::kInward) {
+          extended.innerCellIndex = jCe;
+          extended.innerLayer = ccNext.startingLayer;
+          int nLay = cluArr[ccNext.cluIDs[0]].getDetectorID() / 4;
+          extended.cluIDs[nLay] = ccNext.cluIDs[0];
+        } else {
+          extended.outerCellIndex = jCe;
+          extended.outerLayer = ccNext.startingLayer;
+          int nLay = cluArr[ccNext.cluIDs[2]].getDetectorID() / 4;
+          extended.cluIDs[nLay] = ccNext.cluIDs[2];
+        }
+        next.push_back(std::move(extended));
+        foundAnyProlongation = true;
       }
     }
-    if (!foundAnyProlongation) break;
+    if (!foundAnyProlongation)
+      break;
     current.swap(next);
   }
   // add remaining candidates from last layer
-  for (auto& cand : current) result.push_back(cand);
+  for (auto& cand : current)
+    result.push_back(cand);
   return result;
 }
-  
+
 //______________________________________________________________________
-void NA6PTrackerCA::findRoads(const std::vector<std::pair<int,int>>& cneigh,
-			      const std::vector<CellCandidate>& cells,
-			      const std::vector<int>& firstIndex,
-			      const std::vector<int>& lastIndex,
-			      const std::vector<TrackletCandidate>& tracklets,
-			      const std::vector<NA6PBaseCluster>& cluArr,
-			      std::vector<TrackCandidate>& trackCands,
-			      double maxChi2TrClu){
+void NA6PTrackerCA::findRoads(const std::vector<std::pair<int, int>>& cneigh,
+                              const std::vector<CellCandidate>& cells,
+                              const std::vector<int>& firstIndex,
+                              const std::vector<int>& lastIndex,
+                              const std::vector<TrackletCandidate>& tracklets,
+                              const std::vector<NA6PBaseCluster>& cluArr,
+                              std::vector<TrackCandidate>& trackCands,
+                              double& maxChi2TrClu)
+{
 
   trackCands.clear();
   int nCellPairs = cneigh.size();
-  for (int jPair = 0; jPair < nCellPairs; jPair++){
-    const auto& thisPair =cneigh[jPair];
+  for (int jPair = 0; jPair < nCellPairs; jPair++) {
+    const auto& thisPair = cneigh[jPair];
     int jCe1 = thisPair.first;
     int jCe2 = thisPair.second;
     const CellCandidate& cc1 = cells[jCe1];
@@ -606,34 +637,36 @@ void NA6PTrackerCA::findRoads(const std::vector<std::pair<int,int>>& cneigh,
     const CellCandidate& outer = cells[outerIndex];
 
     // build initial candidate
-    std::vector<int> cluIDsFull(mNLayers,-1);
+    std::vector<int> cluIDsFull(mNLayers, -1);
     int nClusIn = inner.cluIDs.size();
     int innerLay = 99;
-    for(int jClu = 0; jClu < nClusIn; jClu++){
-      int cluID =  inner.cluIDs[jClu];
-      int nLay = cluArr[cluID].getDetectorID()/4;
+    for (int jClu = 0; jClu < nClusIn; jClu++) {
+      int cluID = inner.cluIDs[jClu];
+      int nLay = cluArr[cluID].getDetectorID() / 4;
       cluIDsFull[nLay] = cluID;
-      if (nLay < innerLay) innerLay = nLay;
+      if (nLay < innerLay)
+        innerLay = nLay;
     }
     int nClusOut = outer.cluIDs.size();
     int outerLay = 0;
-    for(int jClu = 0; jClu < nClusOut; jClu++){
-      int cluID =  outer.cluIDs[jClu];
-      int nLay = cluArr[cluID].getDetectorID()/4;
-      if(cluIDsFull[nLay] != -1 && cluIDsFull[nLay] != cluID){
-	LOGP(error,"clu mismatch in layer {}",nLay);
-	continue;
+    for (int jClu = 0; jClu < nClusOut; jClu++) {
+      int cluID = outer.cluIDs[jClu];
+      int nLay = cluArr[cluID].getDetectorID() / 4;
+      if (cluIDsFull[nLay] != -1 && cluIDsFull[nLay] != cluID) {
+        LOGP(error, "clu mismatch in layer {}", nLay);
+        continue;
       }
       cluIDsFull[nLay] = cluID;
-      if (nLay > outerLay) outerLay = nLay;
+      if (nLay > outerLay)
+        outerLay = nLay;
     }
     // consistency checks
-    if (innerLay != inner.startingLayer){
-      LOGP(error,"mismatch on inner layer");
+    if (innerLay != inner.startingLayer) {
+      LOGP(error, "mismatch on inner layer");
       continue;
     }
-    if (outerLay != outer.startingLayer+2){
-      LOGP(error,"mismatch on outer layer");
+    if (outerLay != outer.startingLayer + 2) {
+      LOGP(error, "mismatch on outer layer");
       continue;
     }
     TrackCandidate seed{innerLay, innerIndex, outerLay, outerIndex, cluIDsFull};
@@ -641,15 +674,15 @@ void NA6PTrackerCA::findRoads(const std::vector<std::pair<int,int>>& cneigh,
     for (const auto& track : inwardTracks) {
       auto fullTracks = prolongSeed(track, cells, firstIndex, lastIndex, cluArr, maxChi2TrClu, ExtendDirection::kOutward);
       for (auto& finalTrack : fullTracks) {
- 	trackCands.push_back(std::move(finalTrack));
+        trackCands.push_back(std::move(finalTrack));
       }
     }
   }
   // remove duplicated roads
   std::sort(trackCands.begin(), trackCands.end(), [](const TrackCandidate& a, const TrackCandidate& b) {
-    return a.cluIDs < b.cluIDs;  
+    return a.cluIDs < b.cluIDs;
   });
-  auto last = std::unique(trackCands.begin(), trackCands.end(), [](const TrackCandidate& a, const TrackCandidate& b){
+  auto last = std::unique(trackCands.begin(), trackCands.end(), [](const TrackCandidate& a, const TrackCandidate& b) {
     return a.cluIDs == b.cluIDs;
   });
   trackCands.erase(last, trackCands.end());
@@ -658,11 +691,12 @@ void NA6PTrackerCA::findRoads(const std::vector<std::pair<int,int>>& cneigh,
 //______________________________________________________________________
 
 void NA6PTrackerCA::fitAndSelectTracks(const std::vector<TrackCandidate>& trackCands,
-				       const std::vector<NA6PBaseCluster>& cluArr,
-				       std::vector<TrackFitted>& tracks,
-				       double maxChi2TrClu,
-				       int minNClu,
-				       double maxChi2NDF){
+                                       const std::vector<NA6PBaseCluster>& cluArr,
+                                       std::vector<TrackFitted>& tracks,
+                                       double& maxChi2TrClu,
+                                       int& minNClu,
+                                       double& maxChi2NDF)
+{
 
   std::vector<TrackFitted> fittedTracks;
   fittedTracks.reserve(trackCands.size());
@@ -673,24 +707,26 @@ void NA6PTrackerCA::fitAndSelectTracks(const std::vector<TrackCandidate>& trackC
     std::vector<int> cluIDsForfit;
     for (int cluID : cand.cluIDs) {
       if (cluID >= 0) { // cluID == -1 correspond to no clu on that layer
-	nClus++;
-	cluIDsForfit.push_back(cluID);
+        nClus++;
+        cluIDsForfit.push_back(cluID);
       }
     }
     // fit the track
     //    genfit::Track fitTrack;
     NA6PTrack fitTrackFast;
     //    bool fitSuccess = fitTrackPoints(cluIDsForfit,cluArr,fitter,fitTrack,9999999.,maxChi2NDF);
-    bool fitSuccess = fitTrackPointsFast(cluIDsForfit,cluArr,fitTrackFast,maxChi2TrClu,maxChi2NDF);
-    if (!fitSuccess) continue; // skip if fit failed
+    bool fitSuccess = fitTrackPointsFast(cluIDsForfit, cluArr, fitTrackFast, maxChi2TrClu, maxChi2NDF);
+    if (!fitSuccess)
+      continue;                      // skip if fit failed
     nClus = fitTrackFast.getNHits(); // some clusters could have been rejected in the fit
-    if (nClus < minNClu) continue; 
+    if (nClus < minNClu)
+      continue;
     // const genfit::AbsTrackRep* rep = fitTrack.getTrackRep(0);
     // double chi2 = fitTrack.getFitStatus(rep)->getChi2();
     // double ndf = fitTrack.getFitStatus(rep)->getNdf();
     // double chi2ndf = (ndf > 0) ? chi2 / ndf : 9999.0;
     double chi2ndf = fitTrackFast.getNormChi2();
-    fittedTracks.emplace_back(cand.innerLayer,cand.outerLayer,nClus,cand.cluIDs,std::move(fitTrackFast),chi2ndf);
+    fittedTracks.emplace_back(cand.innerLayer, cand.outerLayer, nClus, cand.cluIDs, std::move(fitTrackFast), chi2ndf);
   }
   // sort by chi2 in view of selection
   std::sort(fittedTracks.begin(), fittedTracks.end(), [](const TrackFitted& a, const TrackFitted& b) {
@@ -700,47 +736,50 @@ void NA6PTrackerCA::fitAndSelectTracks(const std::vector<TrackCandidate>& trackC
   for (auto& track : fittedTracks) {
     int nShared = 0;
     for (int cluID : track.cluIDs) {
-      if (cluID >= 0 && mIsClusterUsed[cluID]) nShared++;
+      if (cluID >= 0 && mIsClusterUsed[cluID])
+        nShared++;
     }
-    if (nShared > mMaxSharedClusters){
+    if (nShared > mMaxSharedClusters) {
       // tracks should not be stored in the list of selected tracks
       continue;
     }
     // mark the clusters of the selected track as used
     for (int cluID : track.cluIDs) {
-      if (cluID >= 0) mIsClusterUsed[cluID] = true;
+      if (cluID >= 0)
+        mIsClusterUsed[cluID] = true;
     }
     // assign overall MC label to the track
     int nClus = track.cluIDs.size();
-    std::vector<std::pair<int,int>> counts;
+    std::vector<std::pair<int, int>> counts;
     for (int jClu = 0; jClu < nClus; jClu++) {
       int cluID = track.cluIDs[jClu];
       if (cluID >= 0) {
         const auto& clu = cluArr[cluID];
         int idPartClu = clu.getParticleID();
         bool found = false;
-        for (auto &p : counts) {
-	  if (p.first == idPartClu) {
-	    ++p.second;
-	    found = true;
-	    break;
-	  }
+        for (auto& p : counts) {
+          if (p.first == idPartClu) {
+            ++p.second;
+            found = true;
+            break;
+          }
         }
         if (!found) {
-	  counts.push_back({idPartClu, 1});
+          counts.push_back({idPartClu, 1});
         }
       }
     }
     int idPartTrack = -9999999;
     int maxCount = 0;
-    for (const auto &p : counts) {
+    for (const auto& p : counts) {
       if (p.second > maxCount) {
         maxCount = p.second;
         idPartTrack = p.first;
       }
     }
     // assign negative label to tracks with misassociations
-    if (counts.size() > 1 && idPartTrack > 0) idPartTrack *= -1;
+    if (counts.size() > 1 && idPartTrack > 0)
+      idPartTrack *= -1;
     track.trackFitFast.setParticleID(idPartTrack);
     tracks.push_back(std::move(track));
   }
@@ -748,80 +787,91 @@ void NA6PTrackerCA::fitAndSelectTracks(const std::vector<TrackCandidate>& trackC
 
 //______________________________________________________________________
 
-void NA6PTrackerCA::findTracks(std::vector<NA6PBaseCluster>& cluArr, TVector3 primVert) {
+void NA6PTrackerCA::findTracks(std::vector<NA6PBaseCluster>& cluArr, TVector3 primVert)
+{
 
   mFinalTracks.clear();
-  uint nClus=cluArr.size();
+  uint nClus = cluArr.size();
   mPrimVertPos[0] = primVert.X();
   mPrimVertPos[1] = primVert.Y();
   mPrimVertPos[2] = primVert.Z();
-  LOGP(info,"Process event with nClusters {}, primary vertex in z = {} cm",nClus,mPrimVertPos[2]);
+  LOGP(info, "Process event with nClusters {}, primary vertex in z = {} cm", nClus, mPrimVertPos[2]);
   mIsClusterUsed.resize(nClus);
-  for(uint jClu = 0; jClu < nClus; jClu++) mIsClusterUsed[jClu] = false;
+  for (uint jClu = 0; jClu < nClus; jClu++)
+    mIsClusterUsed[jClu] = false;
   std::vector<int> firstCluPerLay;
   std::vector<int> lastCluPerLay;
-  sortClustersByLayerAndEta(cluArr,firstCluPerLay,lastCluPerLay);
+  sortClustersByLayerAndEta(cluArr, firstCluPerLay, lastCluPerLay);
   std::vector<TrackletCandidate> foundTracklets;
   std::vector<CellCandidate> foundCells;
   std::vector<std::pair<int, int>> cellsNeighbours;
   std::vector<TrackCandidate> trackCandidates;
   std::vector<TrackFitted> iterationTracks;
-  for (int jIteration = 0; jIteration < mNIterationsCA; ++jIteration){
-    if (mVerbose) LOGP(info," -> Iteration {} <-",jIteration);
+  for (int jIteration = 0; jIteration < mNIterationsCA; ++jIteration) {
+    if (mVerbose)
+      LOGP(info, " -> Iteration {} <-", jIteration);
     foundTracklets.clear();
     foundCells.clear();
     cellsNeighbours.clear();
     trackCandidates.clear();
     iterationTracks.clear();
-    computeLayerTracklets(cluArr,firstCluPerLay,lastCluPerLay,foundTracklets,mMaxDeltaThetaTrackletsCA[jIteration],mMaxDeltaPhiTrackletsCA[jIteration]);
+    computeLayerTracklets(cluArr, firstCluPerLay, lastCluPerLay, foundTracklets, mMaxDeltaThetaTrackletsCA[jIteration], mMaxDeltaPhiTrackletsCA[jIteration]);
     std::vector<int> firstTrklPerLay;
     std::vector<int> lastTrklPerLay;
-    sortTrackletsByLayerAndIndex(foundTracklets,firstTrklPerLay,lastTrklPerLay);
-    if (mVerbose) printStats(foundTracklets,cluArr,foundCells,"tracklets");
+    sortTrackletsByLayerAndIndex(foundTracklets, firstTrklPerLay, lastTrklPerLay);
+    if (mVerbose)
+      printStats(foundTracklets, cluArr, foundCells, "tracklets");
     //
-    computeLayerCells(foundTracklets,firstTrklPerLay,lastTrklPerLay,cluArr,foundCells,mMaxDeltaTanLCellsCA[jIteration],mMaxDeltaPhiCellsCA[jIteration],mMaxDeltaPxPzCellsCA[jIteration],mMaxDeltaPyPzCellsCA[jIteration],mMaxChi2TrClCellsCA[jIteration],mMaxChi2ndfCellsCA[jIteration]);
+    computeLayerCells(foundTracklets, firstTrklPerLay, lastTrklPerLay, cluArr, foundCells, mMaxDeltaTanLCellsCA[jIteration], mMaxDeltaPhiCellsCA[jIteration], mMaxDeltaPxPzCellsCA[jIteration], mMaxDeltaPyPzCellsCA[jIteration], mMaxChi2TrClCellsCA[jIteration], mMaxChi2ndfCellsCA[jIteration]);
     std::vector<int> firstCellPerLay;
     std::vector<int> lastCellPerLay;
-    sortCellsByLayerAndIndex(foundCells,firstCellPerLay,lastCellPerLay);
-    if (mVerbose) printStats(foundCells,cluArr,foundCells,"cells");
+    sortCellsByLayerAndIndex(foundCells, firstCellPerLay, lastCellPerLay);
+    if (mVerbose)
+      printStats(foundCells, cluArr, foundCells, "cells");
     //
-    findCellsNeighbours(foundCells,firstCellPerLay,lastCellPerLay,cellsNeighbours,cluArr,mMaxChi2TrClCellsCA[jIteration]);
-    if (mVerbose) printStats(cellsNeighbours,cluArr,foundCells,"cell pairs");
+    findCellsNeighbours(foundCells, firstCellPerLay, lastCellPerLay, cellsNeighbours, cluArr, mMaxChi2TrClCellsCA[jIteration]);
+    if (mVerbose)
+      printStats(cellsNeighbours, cluArr, foundCells, "cell pairs");
     //
-    findRoads(cellsNeighbours,foundCells,firstCellPerLay,lastCellPerLay,foundTracklets,cluArr,trackCandidates,mMaxChi2TrClCellsCA[jIteration]);
-    if (mVerbose) printStats(trackCandidates,cluArr,foundCells,"track candidates");
+    findRoads(cellsNeighbours, foundCells, firstCellPerLay, lastCellPerLay, foundTracklets, cluArr, trackCandidates, mMaxChi2TrClCellsCA[jIteration]);
+    if (mVerbose)
+      printStats(trackCandidates, cluArr, foundCells, "track candidates");
     //
-    fitAndSelectTracks(trackCandidates,cluArr,iterationTracks,mMaxChi2TrClCellsCA[jIteration],mMinNClusTracksCA[jIteration],mMaxChi2ndfTracksCA[jIteration]);
+    fitAndSelectTracks(trackCandidates, cluArr, iterationTracks, mMaxChi2TrClCellsCA[jIteration], mMinNClusTracksCA[jIteration], mMaxChi2ndfTracksCA[jIteration]);
     if (mVerbose) {
-      printStats(iterationTracks,cluArr,foundCells,"selected tracks");
-      printStats(iterationTracks,cluArr,foundCells,"selected tracks",5);
-      printStats(iterationTracks,cluArr,foundCells,"selected tracks",4);
+      printStats(iterationTracks, cluArr, foundCells, "selected tracks");
+      printStats(iterationTracks, cluArr, foundCells, "selected tracks", 5);
+      printStats(iterationTracks, cluArr, foundCells, "selected tracks", 4);
     }
     for (auto& track : iterationTracks) {
       track.trackFitFast.setCAIteration(jIteration);
     }
-    mFinalTracks.insert(mFinalTracks.end(),iterationTracks.begin(),iterationTracks.end());
+    mFinalTracks.insert(mFinalTracks.end(), iterationTracks.begin(), iterationTracks.end());
   }
 }
 
 //______________________________________________________________________
-std::vector<NA6PTrack> NA6PTrackerCA::getTracks() {
+std::vector<NA6PTrack> NA6PTrackerCA::getTracks()
+{
   std::vector<NA6PTrack> trackArr;
-  trackArr.reserve(mFinalTracks.size());  
-  for (auto& track : mFinalTracks) trackArr.push_back(std::move(track.trackFitFast));
+  trackArr.reserve(mFinalTracks.size());
+  for (auto& track : mFinalTracks)
+    trackArr.push_back(std::move(track.trackFitFast));
   return trackArr;
 }
 
 //______________________________________________________________________
-template<typename T>
+template <typename T>
 void NA6PTrackerCA::printStats(const std::vector<T>& candidates,
-			       const std::vector<NA6PBaseCluster>& cluArr,
-			       const std::vector<CellCandidate>& cells,
-			       const std::string& label,
-			       int requiredClus){
-  
+                               const std::vector<NA6PBaseCluster>& cluArr,
+                               const std::vector<CellCandidate>& cells,
+                               const std::string& label,
+                               int requiredClus)
+{
+
   int nFound = candidates.size();
-  if(requiredClus < 0) LOGP(info,"Number of {} = {}",label.c_str(),nFound);
+  if (requiredClus < 0)
+    LOGP(info, "Number of {} = {}", label.c_str(), nFound);
   int nGood = 0;
   int nSelected = 0;
   double aveClus = 0;
@@ -833,59 +883,66 @@ void NA6PTrackerCA::printStats(const std::vector<T>& candidates,
     if constexpr (std::is_same_v<T, TrackletCandidate>) {
       nClus = 2;
       idClus[0] = tr.firstClusterIndex;
-      idClus[1] =  tr.secondClusterIndex;
+      idClus[1] = tr.secondClusterIndex;
       startLay = tr.startingLayer;
-    } else if constexpr (std::is_same_v<T, std::pair<int,int>>) {
+    } else if constexpr (std::is_same_v<T, std::pair<int, int>>) {
       int jCe1 = tr.first;
       int jCe2 = tr.second;
       CellCandidate cc1 = cells[jCe1];
       CellCandidate cc2 = cells[jCe2];
-      nClus = cc1.cluIDs.size()+1;
-      for (int jClu = 0; jClu < nClus; jClu++){
-	if(jClu < nClus-1) idClus[jClu] = cc1.cluIDs[jClu];
-	else idClus[jClu] = cc2.cluIDs[2];
+      nClus = cc1.cluIDs.size() + 1;
+      for (int jClu = 0; jClu < nClus; jClu++) {
+        if (jClu < nClus - 1)
+          idClus[jClu] = cc1.cluIDs[jClu];
+        else
+          idClus[jClu] = cc2.cluIDs[2];
       }
-      startLay = std::min(cc1.startingLayer,cc2.startingLayer);
+      startLay = std::min(cc1.startingLayer, cc2.startingLayer);
     } else if constexpr (std::is_same_v<T, TrackCandidate> || std::is_same_v<T, TrackFitted>) {
       nClus = tr.cluIDs.size();
-      for (int jClu = 0; jClu < nClus; jClu++) idClus[jClu] = tr.cluIDs[jClu];
+      for (int jClu = 0; jClu < nClus; jClu++)
+        idClus[jClu] = tr.cluIDs[jClu];
       startLay = tr.innerLayer;
-    }else{
+    } else {
       nClus = tr.cluIDs.size();
-      for (int jClu = 0; jClu < nClus; jClu++) idClus[jClu] = tr.cluIDs[jClu];
+      for (int jClu = 0; jClu < nClus; jClu++)
+        idClus[jClu] = tr.cluIDs[jClu];
       startLay = tr.startingLayer;
     }
     int idPartTrack = -9999999;
-    int nTrueClus = 0;      
+    int nTrueClus = 0;
     for (int jClu = 0; jClu < nClus; jClu++) {
       int cluID = idClus[jClu];
-      if(cluID >= 0){
-	++nTrueClus;
-	const auto& clu = cluArr[cluID];
-	int jLay = clu.getDetectorID()/ 4;
-	if (jClu == 0 && jLay != startLay)
-	  LOGP(error,"mismatch in {} layers: {} {}",label.c_str(), jLay, startLay);
-	int idPartClu = clu.getParticleID();
-	if (jClu == 0) idPartTrack = idPartClu;
-	else if (idPartClu != idPartTrack && idPartTrack > 0) idPartTrack *= (-1);
+      if (cluID >= 0) {
+        ++nTrueClus;
+        const auto& clu = cluArr[cluID];
+        int jLay = clu.getDetectorID() / 4;
+        if (jClu == 0 && jLay != startLay)
+          LOGP(error, "mismatch in {} layers: {} {}", label.c_str(), jLay, startLay);
+        int idPartClu = clu.getParticleID();
+        if (jClu == 0)
+          idPartTrack = idPartClu;
+        else if (idPartClu != idPartTrack && idPartTrack > 0)
+          idPartTrack *= (-1);
       }
     }
-    if(requiredClus > 0 && nTrueClus != requiredClus) continue;
+    if (requiredClus > 0 && nTrueClus != requiredClus)
+      continue;
     nSelected++;
-    if (idPartTrack > 0) nGood++;
+    if (idPartTrack > 0)
+      nGood++;
     aveClus += nTrueClus;
   }
-  if(requiredClus > 0) {
-    if(nSelected > 0) {
-      LOGP(info,"{} with {} clus: Fraction of good = {} / {} = {}  --- average clus = {}",
-	   label.c_str(), requiredClus, nGood, nSelected, (double)nGood / (double)nSelected,aveClus / (double)nSelected);
-    }else{
-      LOGP(info,"No {} having {} clus",label.c_str(),requiredClus);
+  if (requiredClus > 0) {
+    if (nSelected > 0) {
+      LOGP(info, "{} with {} clus: Fraction of good = {} / {} = {}  --- average clus = {}",
+           label.c_str(), requiredClus, nGood, nSelected, (double)nGood / (double)nSelected, aveClus / (double)nSelected);
+    } else {
+      LOGP(info, "No {} having {} clus", label.c_str(), requiredClus);
     }
-  }else{
+  } else {
     if (nFound > 0)
-      LOGP(info,"Fraction of good {} = {} / {} = {}  --- average clus = {}",
-	   label.c_str(), nGood, nFound, (double)nGood / (double)nFound,aveClus / (double)nFound);
+      LOGP(info, "Fraction of good {} = {} / {} = {}  --- average clus = {}",
+           label.c_str(), nGood, nFound, (double)nGood / (double)nFound, aveClus / (double)nFound);
   }
 }
-

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -14,6 +14,7 @@ ClassImp(NA6PVerTelReconstruction)
   NA6PVerTelReconstruction::NA6PVerTelReconstruction() : NA6PReconstruction("VerTel")
 {
   mVTTrackletVertexer = new NA6PVertexerTracklets();
+  mVTTrackletVertexer->configureFromRecoParam();
   createVerticesOutput();
 }
 

--- a/rec/src/NA6PVertex.cxx
+++ b/rec/src/NA6PVertex.cxx
@@ -16,7 +16,7 @@ NA6PVertex::NA6PVertex(const ROOT::Math::XYZPointF& pos, const std::array<float,
 {
 }
 //_______________________________________________________________________
-NA6PVertex::NA6PVertex(const double *xyz, int nCont) :
+NA6PVertex::NA6PVertex(const float *xyz, int nCont) :
   mPos{},
   mCov{},
   mChi2{0.0},
@@ -26,7 +26,7 @@ NA6PVertex::NA6PVertex(const double *xyz, int nCont) :
   setXYZ(xyz[0],xyz[1],xyz[2]);  
 }
 //_______________________________________________________________________
-void NA6PVertex::init(const double *xyz, const double *cov, int nCont, float chi2)
+void NA6PVertex::init(const float *xyz, const float *cov, int nCont, float chi2)
 {
   setXYZ(xyz[0],xyz[1],xyz[2]);
   setCov(cov[kCovXX],cov[kCovXY],cov[kCovYY],cov[kCovXZ],cov[kCovYZ],cov[kCovZZ]);

--- a/rec/src/NA6PVertex.cxx
+++ b/rec/src/NA6PVertex.cxx
@@ -6,30 +6,28 @@
 
 ClassImp(NA6PVertex)
 
-//_______________________________________________________________________
-NA6PVertex::NA6PVertex(const ROOT::Math::XYZPointF& pos, const std::array<float, kNCov>& cov, int nCont, float chi2) :
-  mPos{pos},
-  mCov{cov},
-  mChi2{chi2},
-  mNContributors{nCont},
-  mVertexType{kBaseVertex}
+  //_______________________________________________________________________
+  NA6PVertex::NA6PVertex(const ROOT::Math::XYZPointF& pos, const std::array<float, kNCov>& cov, int nCont, float chi2) : mPos{pos},
+                                                                                                                         mCov{cov},
+                                                                                                                         mChi2{chi2},
+                                                                                                                         mNContributors{nCont},
+                                                                                                                         mVertexType{kBaseVertex}
 {
 }
 //_______________________________________________________________________
-NA6PVertex::NA6PVertex(const float *xyz, int nCont) :
-  mPos{},
-  mCov{},
-  mChi2{0.0},
-  mNContributors{nCont},
-  mVertexType{kBaseVertex}
+NA6PVertex::NA6PVertex(const float* xyz, int nCont) : mPos{},
+                                                      mCov{},
+                                                      mChi2{0.0},
+                                                      mNContributors{nCont},
+                                                      mVertexType{kBaseVertex}
 {
-  setXYZ(xyz[0],xyz[1],xyz[2]);  
+  setXYZ(xyz[0], xyz[1], xyz[2]);
 }
 //_______________________________________________________________________
-void NA6PVertex::init(const float *xyz, const float *cov, int nCont, float chi2)
+void NA6PVertex::init(const float* xyz, const float* cov, int nCont, float chi2)
 {
-  setXYZ(xyz[0],xyz[1],xyz[2]);
-  setCov(cov[kCovXX],cov[kCovXY],cov[kCovYY],cov[kCovXZ],cov[kCovYZ],cov[kCovZZ]);
+  setXYZ(xyz[0], xyz[1], xyz[2]);
+  setCov(cov[kCovXX], cov[kCovXY], cov[kCovYY], cov[kCovXZ], cov[kCovYZ], cov[kCovZZ]);
   mChi2 = chi2;
   mNContributors = nCont;
 }
@@ -38,7 +36,7 @@ void NA6PVertex::init(const float *xyz, const float *cov, int nCont, float chi2)
 std::string NA6PVertex::asString() const
 {
   return fmt::format("Vtx {{{:+.4e},{:+.4e},{:+.4e}}} Cov.:{{{{{:.3e}..}},{{{:.3e},{:.3e}..}},{{{:.3e},{:.3e},{:.3e}}}}} Contributors {}  Chi2 {}",
-                     mPos.X(), mPos.Y(), mPos.Z(), mCov[0], mCov[1], mCov[2], mCov[3], mCov[4], mCov[5],mNContributors,mChi2);
+                     mPos.X(), mPos.Y(), mPos.Z(), mCov[0], mCov[1], mCov[2], mCov[3], mCov[4], mCov[5], mNContributors, mChi2);
 }
 
 //_______________________________________________________________________
@@ -46,4 +44,3 @@ void NA6PVertex::print() const
 {
   LOGP(info, "{}", asString());
 }
-

--- a/rec/src/NA6PVertexerTracklets.cxx
+++ b/rec/src/NA6PVertexerTracklets.cxx
@@ -607,7 +607,7 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
   } else {
     zMean = (sumW > 0) ? sumZW / sumW : 0.0;
   }
-  double pos[3] = {mBeamX, mBeamY, zMean};
+  float pos[3] = {mBeamX, mBeamY, zMean};
   NA6PVertex vert(pos, nContrib);
   vert.setVertexType(NA6PVertex::kTrackletPrimaryVertex);
   vertices.push_back(vert);
@@ -700,7 +700,7 @@ bool NA6PVertexerTracklets::findVertexKDE(const std::vector<TracklIntersection>&
       mIsClusterUsed[zInt.secondClusterIndex] = true;
     }
   }
-  double pos[3] = {mBeamX, mBeamY, zPeak};
+  float pos[3] = {mBeamX, mBeamY, zPeak};
   NA6PVertex vert(pos, nContrib);
   vert.setVertexType(NA6PVertex::kTrackletPrimaryVertex);
   vertices.push_back(vert);

--- a/rec/src/NA6PVertexerTracklets.cxx
+++ b/rec/src/NA6PVertexerTracklets.cxx
@@ -150,14 +150,14 @@ void NA6PVertexerTracklets::sortClustersByLayerAndEta(std::vector<NA6PBaseCluste
     auto first = cluArr.begin() + firstIndex[jLay];
     auto last = cluArr.begin() + lastIndex[jLay];
     std::sort(first, last, [](const NA6PBaseCluster& a, const NA6PBaseCluster& b) {
-      double xa = a.getX();
-      double ya = a.getY();
-      double za = a.getZ();
-      double xb = b.getX();
-      double yb = b.getY();
-      double zb = b.getZ();
-      double r2a = xa * xa + ya * ya;
-      double r2b = xb * xb + yb * yb;
+      float xa = a.getX();
+      float ya = a.getY();
+      float za = a.getZ();
+      float xb = b.getX();
+      float yb = b.getY();
+      float zb = b.getZ();
+      float r2a = xa * xa + ya * ya;
+      float r2b = xb * xb + yb * yb;
       return za * za * r2b < zb * zb * r2a;
     });
   }
@@ -220,53 +220,53 @@ void NA6PVertexerTracklets::computeLayerTracklets(const std::vector<NA6PBaseClus
     auto layerEnd = cluArr.begin() + lastIndex[iLayer + 1];
     for (int jClu1 = firstIndex[iLayer]; jClu1 < lastIndex[iLayer]; ++jClu1) {
       const NA6PBaseCluster& clu1 = cluArr[jClu1];
-      double x1 = clu1.getX();
-      double y1 = clu1.getY();
-      double z1 = clu1.getZ();
-      double r1 = std::sqrt(x1 * x1 + y1 * y1);
-      double theta1 = std::atan2(z1, r1);
-      double phi1 = std::atan2(y1, x1);
-      double tanth2Min = std::max(0., std::tan(theta1 - 1.2 * mMaxDeltaThetaTracklet)); // 1.2 is a safety margin
-      double tanth2Max = std::tan(std::min(M_PI / 2.001, theta1 + 1.2 * mMaxDeltaThetaTracklet));
+      float x1 = clu1.getX();
+      float y1 = clu1.getY();
+      float z1 = clu1.getZ();
+      float r1 = std::sqrt(x1 * x1 + y1 * y1);
+      float theta1 = std::atan2(z1, r1);
+      float phi1 = std::atan2(y1, x1);
+      float tanth2Min = std::max(0., std::tan(theta1 - 1.2 * mMaxDeltaThetaTracklet)); // 1.2 is a safety margin
+      float tanth2Max = std::tan(std::min(M_PI / 2.001, theta1 + 1.2 * mMaxDeltaThetaTracklet));
       auto lower = std::partition_point(layerBegin, layerEnd,
                                         [&](const NA6PBaseCluster& clu) {
-                                          double x = clu.getX();
-                                          double y = clu.getY();
-                                          double z = clu.getZ();
-                                          double r2 = x * x + y * y;
-                                          double tan2 = z * z / r2;
+                                          float x = clu.getX();
+                                          float y = clu.getY();
+                                          float z = clu.getZ();
+                                          float r2 = x * x + y * y;
+                                          float tan2 = z * z / r2;
                                           return tan2 < tanth2Min * tanth2Min;
                                         });
 
       auto upper = std::partition_point(layerBegin, layerEnd,
                                         [&](const NA6PBaseCluster& clu) {
-                                          double x = clu.getX();
-                                          double y = clu.getY();
-                                          double z = clu.getZ();
-                                          double r2 = x * x + y * y;
-                                          double tan2 = z * z / r2;
+                                          float x = clu.getX();
+                                          float y = clu.getY();
+                                          float z = clu.getZ();
+                                          float r2 = x * x + y * y;
+                                          float tan2 = z * z / r2;
                                           return tan2 <= tanth2Max * tanth2Max;
                                         });
       int lowerIdx = std::distance(cluArr.begin(), lower);
       int upperIdx = std::distance(cluArr.begin(), upper);
       for (int jClu2 = lowerIdx; jClu2 < upperIdx; ++jClu2) {
         const NA6PBaseCluster& clu2 = cluArr[jClu2];
-        double x2 = clu2.getX();
-        double y2 = clu2.getY();
-        double z2 = clu2.getZ();
-        double r2 = std::sqrt(x2 * x2 + y2 * y2);
-        double theta2 = std::atan2(z2, r2);
-        double phi2 = std::atan2(y2, x2);
-        double dphi = phi2 - phi1;
+        float x2 = clu2.getX();
+        float y2 = clu2.getY();
+        float z2 = clu2.getZ();
+        float r2 = std::sqrt(x2 * x2 + y2 * y2);
+        float theta2 = std::atan2(z2, r2);
+        float phi2 = std::atan2(y2, x2);
+        float dphi = phi2 - phi1;
         if (dphi > M_PI)
           dphi -= 2 * M_PI;
         else if (dphi < -M_PI)
           dphi += 2 * M_PI;
         if (std::abs(theta2 - theta1) < mMaxDeltaThetaTracklet && std::abs(dphi) < mMaxDeltaPhiTracklet) {
-          double phi = std::atan2(y2 - y1, x2 - x1);
-          double tanL = (z2 - z1) / (r2 - r1);
-          double pxpz = (x2 - x1) / (z2 - z1);
-          double pypz = (y2 - y1) / (z2 - z1);
+          float phi = std::atan2(y2 - y1, x2 - x1);
+          float tanL = (z2 - z1) / (r2 - r1);
+          float pxpz = (x2 - x1) / (z2 - z1);
+          float pypz = (y2 - y1) / (z2 - z1);
           bool signal = false;
           if (clu1.getParticleID() == clu2.getParticleID())
             signal = true;
@@ -308,14 +308,14 @@ void NA6PVertexerTracklets::selectTracklets(const std::vector<TrackletForVertex>
       const TrackletForVertex& trkl12 = *it;
       if (trkl12.firstClusterIndex != nextLayerClusterIndex)
         continue;
-      const double deltaTanLambda = std::abs(trkl12.tanL - trkl01.tanL);
-      double dphi = trkl12.phi - trkl01.phi;
+      const float deltaTanLambda = std::abs(trkl12.tanL - trkl01.tanL);
+      float dphi = trkl12.phi - trkl01.phi;
       if (dphi > M_PI)
         dphi -= 2 * M_PI;
       else if (dphi < -M_PI)
         dphi += 2 * M_PI;
-      double deltapxpz = std::abs(trkl12.pxpz - trkl01.pxpz);
-      double deltapypz = std::abs(trkl12.pypz - trkl01.pypz);
+      float deltapxpz = std::abs(trkl12.pxpz - trkl01.pxpz);
+      float deltapypz = std::abs(trkl12.pypz - trkl01.pypz);
       if (deltapypz < mMaxDeltaPyPzInOut && deltapxpz < mMaxDeltaPxPzInOut && deltaTanLambda < mMaxDeltaTanLamInOut && std::abs(dphi) < mMaxDeltaPhiInOut) {
         // if(trkl01.isSignal) isTrackletSelected[jTrkl0] = true;
         isTrackletSelected[jTrkl0] = true;
@@ -349,65 +349,65 @@ void NA6PVertexerTracklets::computeIntersections(const std::vector<TrackletForVe
   for (auto& trkl : selTracklets) {
     auto clu0 = cluArr[trkl.firstClusterIndex];
     auto clu1 = cluArr[trkl.secondClusterIndex];
-    double x0 = clu0.getX();
-    double y0 = clu0.getY();
-    double z0 = clu0.getZ();
-    double x1 = clu1.getX();
-    double y1 = clu1.getY();
-    double z1 = clu1.getZ();
-    double sigmayClu0 = std::sqrt(clu0.getSigYY());
-    double sigmayClu1 = std::sqrt(clu1.getSigYY());
-    double dx = x1 - x0;
-    double dy = y1 - y0;
-    double dz = z1 - z0;
-    double zi = -99999.;
-    double sigmazi = 0.1;
+    float x0 = clu0.getX();
+    float y0 = clu0.getY();
+    float z0 = clu0.getZ();
+    float x1 = clu1.getX();
+    float y1 = clu1.getY();
+    float z1 = clu1.getZ();
+    float sigmayClu0 = std::sqrt(clu0.getSigYY());
+    float sigmayClu1 = std::sqrt(clu1.getSigYY());
+    float dx = x1 - x0;
+    float dy = y1 - y0;
+    float dz = z1 - z0;
+    float zi = -99999.;
+    float sigmazi = 0.1;
     switch (mRecoType) {
       case kYZ: {
         // work in the yz plane (non bending) to use straight line approximation of traks
         // slo = dy/dz  y = slo*z + q --> q = y0-slo*z0 --> yBeam = slo*zv + q --> zv =  = (ybeam-q)/slo = ybeam/slo + z0 - y0/slo = z0 - (y0-yeman)/slo
-        double slo = dy / dz;
+        float slo = dy / dz;
         zi = z0 - (y0 - mBeamY) / slo;
-        double sigmaSlo = std::sqrt(sigmayClu0 * sigmayClu0 + sigmayClu1 * sigmayClu1) / std::abs(dz);
-        double invSlo = 1.0 / slo;
-        double term1 = (sigmayClu0 * invSlo) * (sigmayClu0 * invSlo);
-        double term2 = (y0 * sigmaSlo / (slo * slo)) * (y0 * sigmaSlo / (slo * slo));
+        float sigmaSlo = std::sqrt(sigmayClu0 * sigmayClu0 + sigmayClu1 * sigmayClu1) / std::abs(dz);
+        float invSlo = 1.0 / slo;
+        float term1 = (sigmayClu0 * invSlo) * (sigmayClu0 * invSlo);
+        float term2 = (y0 * sigmaSlo / (slo * slo)) * (y0 * sigmaSlo / (slo * slo));
         sigmazi = std::sqrt(term1 + term2);
         break;
       }
       case kXZ: {
         // work in the xz plane (bending) just for debug purposes
-        double slo = dx / dz;
+        float slo = dx / dz;
         zi = z0 - (x0 - mBeamX) / slo;
         break;
       }
       case kRZ: {
         // solution in the r/z plane (as in AliRoot)
-        double dx0 = x0 - mBeamX;
-        double dy0 = y0 - mBeamY;
-        double dx1 = x1 - mBeamX;
-        double dy1 = y1 - mBeamY;
+        float dx0 = x0 - mBeamX;
+        float dy0 = y0 - mBeamY;
+        float dx1 = x1 - mBeamX;
+        float dy1 = y1 - mBeamY;
 
-        double r0 = std::sqrt(dx0 * dx0 + dy0 * dy0);
-        double r1 = std::sqrt(dx1 * dx1 + dy1 * dy1);
-        double slo = (r1 - r0) / (z1 - z0);
+        float r0 = std::sqrt(dx0 * dx0 + dy0 * dy0);
+        float r1 = std::sqrt(dx1 * dx1 + dy1 * dy1);
+        float slo = (r1 - r0) / (z1 - z0);
         // r = slo * z + q --> q = r0 - slo * z0 --> slo * zv + q = = --> zv = -q/slo = -(r0 - slo*z0)/slo = z0 - r0/slo
         zi = z0 - r0 / slo;
         break;
       }
       case k3D: {
         // 3D solution for DCA between lines
-        double denomXY = dx * dx + dy * dy;
+        float denomXY = dx * dx + dy * dy;
         if (denomXY < 1e-8)
           continue;
-        double tBeam = -((x0 - mBeamX) * dx + (y0 - mBeamY) * dy) / denomXY;
-        double xi = x0 + tBeam * dx;
-        double yi = y0 + tBeam * dy;
-        double ri2 = xi * xi + yi * yi;
+        float tBeam = -((x0 - mBeamX) * dx + (y0 - mBeamY) * dy) / denomXY;
+        float xi = x0 + tBeam * dx;
+        float yi = y0 + tBeam * dy;
+        float ri2 = xi * xi + yi * yi;
         if (ri2 > mMaxDCAxy * mMaxDCAxy)
           continue;
         zi = z0 + tBeam * dz;
-        double sigmaDCA = sigmayClu0 * std::sqrt(2.0) * (1.0 + std::abs(tBeam));
+        float sigmaDCA = sigmayClu0 * std::sqrt(2.0) * (1.0 + std::abs(tBeam));
         sigmazi = sigmaDCA * std::abs(dz) / std::sqrt(denomXY);
         break;
       }
@@ -428,7 +428,7 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
 {
   std::fill(mHistIntersec.begin(), mHistIntersec.end(), 0.0);
   for (const auto& zInt : zIntersec) {
-    double zi = zInt.zeta;
+    float zi = zInt.zeta;
     if (zi >= mZMin && zi < mZMax) {
       int bin = int((zi - mZMin) / mZBinWidth);
       mHistIntersec[bin]++;
@@ -448,7 +448,7 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
     if (mHistIntersec[jBin] == maxHeight) {
       int lowBin = std::max(jBin - mPeakWidthBins, 0);
       int highBin = std::min(jBin + mPeakWidthBins, mNBinsForPeakFind - 1);
-      double integral = 0;
+      float integral = 0;
       for (int jPeak = lowBin; jPeak <= highBin; ++jPeak)
         integral += mHistIntersec[jPeak];
       peaks.push_back(std::make_pair(jBin, integral));
@@ -478,7 +478,7 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
     jMainPeak = 0;
     nPeaksSameIntegral = 1;
   }
-  double zPeak, zWinMin, zWinMax;
+  float zPeak, zWinMin, zWinMax;
   bool peakFound = false;
   if (jMainPeak >= 0 && (nPeaks == 1 || (nPeaks > 1 && nPeaksSameIntegral == 1))) {
     // compute the z position for the peak
@@ -525,8 +525,8 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
       }
     }
     if (!ambiguous) {
-      double zFirst = mZMin + (clusters[jLargestClu].firstBin + 0.5) * mZBinWidth;
-      double zLast = mZMin + (clusters[jLargestClu].lastBin + 0.5) * mZBinWidth;
+      float zFirst = mZMin + (clusters[jLargestClu].firstBin + 0.5) * mZBinWidth;
+      float zLast = mZMin + (clusters[jLargestClu].lastBin + 0.5) * mZBinWidth;
       zPeak = 0.5 * (zFirst + zLast);
       zWinMin = zFirst - mZWindowWidth;
       zWinMax = zLast + mZWindowWidth;
@@ -545,21 +545,21 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
             });
   // std::sort(zIntersec.begin(),zIntersec.end());
   auto lower = std::lower_bound(zIntersec.begin(), zIntersec.end(), zWinMin,
-                                [](const TracklIntersection& a, double value) {
+                                [](const TracklIntersection& a, float value) {
                                   return a.zeta < value;
                                 });
 
   auto upper = std::upper_bound(zIntersec.begin(), zIntersec.end(), zWinMax,
-                                [](double value, const TracklIntersection& a) {
+                                [](float value, const TracklIntersection& a) {
                                   return value < a.zeta;
                                 });
   int nContrib = 0;
-  double sumZ = 0.;
-  double sumZW = 0.;
-  double sumW = 0.;
+  float sumZ = 0.;
+  float sumZW = 0.;
+  float sumW = 0.;
   for (auto it = lower; it != upper; ++it) {
-    double zp = it->zeta;
-    double w = 1.0 / (1.0 + it->tanl * it->tanl);
+    float zp = it->zeta;
+    float w = 1.0 / (1.0 + it->tanl * it->tanl);
     if (mWeightedMeanOption == kSigma)
       w = 1.0 / (it->sigmazeta * it->sigmazeta);
     sumZ += zp;
@@ -567,9 +567,9 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
     sumW += w;
     ++nContrib;
   }
-  double zMean;
+  float zMean;
   if (mWeightedMeanOption == kNoWeight) {
-    zMean = (nContrib > 0) ? sumZ / (double)nContrib : 0.0;
+    zMean = (nContrib > 0) ? sumZ / (float)nContrib : 0.0;
   } else {
     zMean = (sumW > 0) ? sumZW / sumW : 0.0;
   }
@@ -577,12 +577,12 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
   zWinMin = zMean - mZWindowWidth;
   zWinMax = zMean + mZWindowWidth;
   lower = std::lower_bound(zIntersec.begin(), zIntersec.end(), zWinMin,
-                           [](const TracklIntersection& a, double value) {
+                           [](const TracklIntersection& a, float value) {
                              return a.zeta < value;
                            });
 
   upper = std::upper_bound(zIntersec.begin(), zIntersec.end(), zWinMax,
-                           [](double value, const TracklIntersection& a) {
+                           [](float value, const TracklIntersection& a) {
                              return value < a.zeta;
                            });
   nContrib = 0;
@@ -590,8 +590,8 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
   sumZW = 0.;
   sumW = 0.;
   for (auto it = lower; it != upper; ++it) {
-    double zp = it->zeta;
-    double w = 1.0 / (1.0 + it->tanl * it->tanl);
+    float zp = it->zeta;
+    float w = 1.0 / (1.0 + it->tanl * it->tanl);
     if (mWeightedMeanOption == kSigma)
       w = 1.0 / (it->sigmazeta * it->sigmazeta);
     sumZ += zp;
@@ -603,7 +603,7 @@ bool NA6PVertexerTracklets::findVertexHistoPeak(std::vector<TracklIntersection>&
     ++nContrib;
   }
   if (mWeightedMeanOption == kNoWeight) {
-    zMean = (nContrib > 0) ? sumZ / (double)nContrib : 0.0;
+    zMean = (nContrib > 0) ? sumZ / (float)nContrib : 0.0;
   } else {
     zMean = (sumW > 0) ? sumZW / sumW : 0.0;
   }
@@ -624,25 +624,25 @@ bool NA6PVertexerTracklets::findVertexKDE(const std::vector<TracklIntersection>&
     return false;
 
   // Prepare grid
-  std::vector<double> gridZ(mNGridKDE);
-  double dz = (mZMax - mZMin) / (mNGridKDE - 1);
+  std::vector<float> gridZ(mNGridKDE);
+  float dz = (mZMax - mZMin) / (mNGridKDE - 1);
   for (int jg = 0; jg < mNGridKDE; ++jg)
     gridZ[jg] = mZMin + jg * dz;
   // Evaluate KDE at each grid point
-  std::vector<double> fkde(mNGridKDE, 0.0);
+  std::vector<float> fkde(mNGridKDE, 0.0);
   for (int jg = 0; jg < mNGridKDE; ++jg) {
-    double z = gridZ[jg];
-    double sum = 0.0;
-    double sumW = 0.0;
-    double sumGW = 0.0;
+    float z = gridZ[jg];
+    float sum = 0.0;
+    float sumW = 0.0;
+    float sumGW = 0.0;
     for (const auto& zInt : zIntersec) {
-      double zi = zInt.zeta;
-      double sigma = mKDEBandwidth;
+      float zi = zInt.zeta;
+      float sigma = mKDEBandwidth;
       if (mKDEOption == kAdaptiveKDE)
         sigma = std::sqrt(mKDEBandwidth * mKDEBandwidth + zInt.sigmazeta * zInt.sigmazeta);
-      double u = (z - zi) / sigma;
-      double g = gaussKernel(u);
-      double w = 1.0 / (1.0 + zInt.tanl * zInt.tanl);
+      float u = (z - zi) / sigma;
+      float g = gaussKernel(u);
+      float w = 1.0 / (1.0 + zInt.tanl * zInt.tanl);
       if (mKDEOption == kStandardKDE && mWeightedMeanOption == kSigma)
         w = 1.0 / (zInt.sigmazeta * zInt.sigmazeta);
       sum += g;
@@ -656,7 +656,7 @@ bool NA6PVertexerTracklets::findVertexKDE(const std::vector<TracklIntersection>&
     }
   }
   // Find global maximum on the grid
-  double fMax = -1.0;
+  float fMax = -1.0;
   int jMax = -1;
   for (int jg = 0; jg < mNGridKDE; ++jg) {
     if (fkde[jg] > fMax) {
@@ -667,21 +667,21 @@ bool NA6PVertexerTracklets::findVertexKDE(const std::vector<TracklIntersection>&
   if (jMax < 0)
     return false;
   // Quadratic interpolation for sub-grid precision
-  double zPeak = gridZ[jMax];
+  float zPeak = gridZ[jMax];
   if (jMax > 0 && jMax < mNGridKDE - 1) {
-    double f0 = fkde[jMax - 1];
-    double f1 = fkde[jMax];
-    double f2 = fkde[jMax + 1];
-    double denom = 2. * (f0 - 2. * f1 + f2);
+    float f0 = fkde[jMax - 1];
+    float f1 = fkde[jMax];
+    float f2 = fkde[jMax + 1];
+    float denom = 2. * (f0 - 2. * f1 + f2);
     if (std::abs(denom) > 1e-12) {
-      double delta = (f0 - f2) / denom;
+      float delta = (f0 - f2) / denom;
       zPeak += delta * dz;
     }
   }
   // check peak height in small bin
   int nInPeak = 0;
   for (const auto& zInt : zIntersec) {
-    double zi = zInt.zeta;
+    float zi = zInt.zeta;
     if (zi > zPeak - 0.5 * mZBinWidth && zi < zPeak + 0.5 * mZBinWidth)
       ++nInPeak;
   }
@@ -689,11 +689,11 @@ bool NA6PVertexerTracklets::findVertexKDE(const std::vector<TracklIntersection>&
     return false;
 
   // count contributors and mark used hits
-  double zWinMin = zPeak - mZWindowWidth;
-  double zWinMax = zPeak + mZWindowWidth;
+  float zWinMin = zPeak - mZWindowWidth;
+  float zWinMax = zPeak + mZWindowWidth;
   int nContrib = 0;
   for (const auto& zInt : zIntersec) {
-    double zi = zInt.zeta;
+    float zi = zInt.zeta;
     if (zi > zWinMin && zi < zWinMax) {
       ++nContrib;
       mIsClusterUsed[zInt.firstClusterIndex] = true;
@@ -800,5 +800,5 @@ void NA6PVertexerTracklets::printStats(const std::vector<TrackletForVertex>& can
   }
   if (nFound > 0)
     LOGP(info, "Fraction of good {} = {} / {} = {}",
-         label.c_str(), nGood, nFound, (double)nGood / (double)nFound);
+         label.c_str(), nGood, nFound, (float)nGood / (float)nFound);
 }

--- a/rec/src/NA6PVertexerTracklets.cxx
+++ b/rec/src/NA6PVertexerTracklets.cxx
@@ -14,7 +14,7 @@ ClassImp(NA6PVertexerTracklets)
   configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
 }
 
-void NA6PVertexerTracklets::configureFromRecoParam(const std::string filename)
+void NA6PVertexerTracklets::configureFromRecoParam(const std::string& filename)
 {
   if (filename != "") {
     na6p::conf::ConfigurableParamHelper<NA6PRecoParam>::updateFromFile(filename);

--- a/test/inspectVertexerTracklets.C
+++ b/test/inspectVertexerTracklets.C
@@ -24,123 +24,140 @@
 
 void inspectVertexerTracklets(int firstEv = 0,
                               int lastEv = 999999,
-                              const char *dirSimu = "../testN6Proot/pions/latesttag")
-//			const char *dirSimu = "Angantyr") 
+                              const char* dirSimu = "../testN6Proot/pions/latesttag")
+//			const char *dirSimu = "Angantyr")
 {
-  TFile* fk=new TFile(Form("%s/MCKine.root",dirSimu));
-  TTree* mcTree=(TTree*)fk->Get("mckine");
-  int nEv=mcTree->GetEntries();
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  int nEv = mcTree->GetEntries();
   std::vector<TParticle>* mcArr = nullptr;
   mcTree->SetBranchAddress("tracks", &mcArr);
 
-  TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
-  printf("Open cluster file: %s\n",fc->GetName());
-  TTree* tc=(TTree*)fc->Get("clustersVerTel");
+  TFile* fc = new TFile(Form("%s/ClustersVerTel.root", dirSimu));
+  printf("Open cluster file: %s\n", fc->GetName());
+  TTree* tc = (TTree*)fc->Get("clustersVerTel");
   std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
   tc->SetBranchAddress("VerTel", &vtClusPtr);
 
-  if(lastEv>nEv || lastEv<0) lastEv=nEv;
-  if(firstEv<0) firstEv=0;
+  if (lastEv > nEv || lastEv < 0)
+    lastEv = nEv;
+  if (firstEv < 0)
+    firstEv = 0;
 
-  TH1F* hdz = new TH1F("hdz","",100,-0.5,0.5);
-  TH1F* hncontr = new TH1F("hncontr","",100,-0.5,999.5);
-  TH1F* hnvert = new TH1F("hnvert","",11,-0.5,10.5);
-  TH1D* histocheck = new TH1D("histocheck","",250,-20.,5.);
-  int kMaxPileupVertices = NA6PVertexerTracklets::kMaxPileupVertices;  
+  TH1F* hdz = new TH1F("hdz", "", 100, -0.5, 0.5);
+  TH1F* hncontr = new TH1F("hncontr", "", 100, -0.5, 999.5);
+  TH1F* hnvert = new TH1F("hnvert", "", 11, -0.5, 10.5);
+  TH1D* histocheck = new TH1D("histocheck", "; z_{intersection} (cm); counts", 250, -20., 5.);
+  int kMaxPileupVertices = NA6PVertexerTracklets::kMaxPileupVertices;
   TH1D* histocheck2[kMaxPileupVertices];
   for (int jPil = 0; jPil < kMaxPileupVertices; jPil++) {
-    histocheck2[jPil] = new TH1D(Form("histocheckPil%d",jPil+1),"",250,-20.,5.);
+    histocheck2[jPil] = new TH1D(Form("histocheckPil%d", jPil + 1), "", 250, -20., 5.);
   }
-  TH1F* hSigmaZ = new TH1F("hSigmaZ","",100,0.,10.);
-
+  TH1F* hSigmaZ = new TH1F("hSigmaZ", "", 100, 0., 10.);
 
   NA6PVertexerTracklets* vertxr = new NA6PVertexerTracklets();
-  
-  for(int jEv=firstEv;jEv<lastEv; jEv++){
+
+  for (int jEv = firstEv; jEv < lastEv; jEv++) {
     mcTree->GetEvent(jEv);
     tc->GetEvent(jEv);
-    int nPart=mcArr->size();
+    int nPart = mcArr->size();
+    double xVertGen = 0;
+    double yVertGen = 0;
     double zVertGen = 0;
     // get primary vertex position from the Kine Tree
-    for(int jp=0; jp<nPart; jp++){
-      auto curPart=mcArr->at(jp);
-      if(curPart.IsPrimary()){
-        zVertGen =  curPart.Vz();
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      if (curPart.IsPrimary()) {
+        xVertGen = curPart.Vx();
+        yVertGen = curPart.Vy();
+        zVertGen = curPart.Vz();
         break;
       }
     }
     std::vector<TracklIntersection> zIntersec;
-    int nClus=vtClus.size();
+    int nClus = vtClus.size();
+    printf("--- Process event %d, nClus = %d, primary vertex in %.2f %.2f %.2f cm ---\n", jEv, nClus, xVertGen, yVertGen, zVertGen);
+    vertxr->setBeamX(xVertGen);
+    vertxr->setBeamY(yVertGen);
     vertxr->resetClusters(nClus);
     std::vector<int> firstCluPerLay;
     std::vector<int> lastCluPerLay;
-    vertxr->sortClustersByLayerAndEta(vtClus,firstCluPerLay,lastCluPerLay);
+    vertxr->sortClustersByLayerAndEta(vtClus, firstCluPerLay, lastCluPerLay);
     std::vector<TrackletForVertex> allTracklets;
     std::vector<TrackletForVertex> selTracklets;
-    vertxr->computeLayerTracklets(vtClus,firstCluPerLay,lastCluPerLay,allTracklets);
+    vertxr->computeLayerTracklets(vtClus, firstCluPerLay, lastCluPerLay, allTracklets);
     std::vector<int> firstTrklPerLay;
     std::vector<int> lastTrklPerLay;
-    vertxr->sortTrackletsByLayerAndIndex(allTracklets,firstTrklPerLay,lastTrklPerLay);
-    vertxr->printStats(allTracklets,vtClus,"tracklets");
-    vertxr->selectTracklets(allTracklets,firstTrklPerLay,lastTrklPerLay,vtClus,selTracklets);
-    vertxr->printStats(selTracklets,vtClus,"selected tracklets");
-    vertxr->computeIntersections(selTracklets,vtClus,zIntersec);
+    vertxr->sortTrackletsByLayerAndIndex(allTracklets, firstTrklPerLay, lastTrklPerLay);
+    vertxr->printStats(allTracklets, vtClus, "tracklets");
+    vertxr->selectTracklets(allTracklets, firstTrklPerLay, lastTrklPerLay, vtClus, selTracklets);
+    vertxr->printStats(selTracklets, vtClus, "selected tracklets");
+    vertxr->computeIntersections(selTracklets, vtClus, zIntersec);
     std::vector<NA6PVertex> zVertices;
     bool retCode;
-    if(vertxr->getMethodForPeakFinding() == NA6PVertexerTracklets::kKDE) retCode = vertxr->findVertexKDE(zIntersec,zVertices);
-    else retCode = vertxr->findVertexHistoPeak(zIntersec,zVertices);
+    if (vertxr->getMethodForPeakFinding() == NA6PVertexerTracklets::kKDE)
+      retCode = vertxr->findVertexKDE(zIntersec, zVertices);
+    else
+      retCode = vertxr->findVertexHistoPeak(zIntersec, zVertices);
     histocheck->Reset("MICE");
-    for (auto zi : zIntersec){
+    for (auto zi : zIntersec) {
       histocheck->Fill(zi.zeta);
       hSigmaZ->Fill(zi.sigmazeta);
     }
     int nVertices = zVertices.size();
-    int jv=0;
+    int jv = 0;
     for (auto vert : zVertices) {
       double zRec = vert.getZ();
-      printf("Vertex %d, z = %f contrib = %d\n",jv++,zRec,vert.getNContributors());
-      hdz->Fill(zRec-zVertGen);
+      printf("Vertex %d, z = %f contrib = %d\n", jv++, zRec, vert.getNContributors());
+      hdz->Fill(zRec - zVertGen);
       hncontr->Fill(vert.getNContributors());
     }
     // pileup detection
-    std::vector<TrackletForVertex> remainingTracklets;      
+    std::vector<TrackletForVertex> remainingTracklets;
     for (int jPil = 0; jPil < kMaxPileupVertices; jPil++) {
-      vertxr->filterOutUsedTracklets(selTracklets,remainingTracklets);
-      vertxr->printStats(remainingTracklets,vtClus,"remaining tracklets");
-      vertxr->computeIntersections(remainingTracklets,vtClus,zIntersec);
-      if(vertxr->getMethodForPeakFinding() == NA6PVertexerTracklets::kKDE) retCode = vertxr->findVertexKDE(zIntersec,zVertices);
-      else retCode = vertxr->findVertexHistoPeak(zIntersec,zVertices);
+      vertxr->filterOutUsedTracklets(selTracklets, remainingTracklets);
+      vertxr->printStats(remainingTracklets, vtClus, "remaining tracklets");
+      vertxr->computeIntersections(remainingTracklets, vtClus, zIntersec);
+      if (vertxr->getMethodForPeakFinding() == NA6PVertexerTracklets::kKDE)
+        retCode = vertxr->findVertexKDE(zIntersec, zVertices);
+      else
+        retCode = vertxr->findVertexHistoPeak(zIntersec, zVertices);
       histocheck2[jPil]->Reset("MICES");
-      for (auto zi : zIntersec) histocheck2[jPil]->Fill(zi.zeta);
-      if (!retCode) break;
+      for (auto zi : zIntersec)
+        histocheck2[jPil]->Fill(zi.zeta);
+      if (!retCode)
+        break;
       selTracklets.swap(remainingTracklets);
     }
     nVertices = zVertices.size();
     hnvert->Fill(nVertices);
-    printf("After pileup search: nVertices = %d\n",nVertices);
-    jv=0;
+    printf("After pileup search: nVertices = %d\n", nVertices);
+    jv = 0;
     for (auto vert : zVertices) {
       double zRec = vert.getZ();
-      printf("Vertex %d, z = %f nContrib = %d\n",jv++,zRec,vert.getNContributors());
+      printf("Vertex %d, z = %f nContrib = %d\n", jv++, zRec, vert.getNContributors());
     }
   }
 
-  TCanvas* coutp= new TCanvas("coutp","",1200,800);
-  coutp->Divide(3,2);
-  coutp->cd(1);
+  TCanvas* cev = new TCanvas("cev", "", 1200, 500);
+  histocheck->SetLineWidth(2);
   histocheck->Draw();
   for (int jPil = 0; jPil < kMaxPileupVertices; jPil++) {
-    if(histocheck2[jPil]->GetEntries() > 0){
-      histocheck2[jPil]->SetLineColor(jPil+2);
+    if (histocheck2[jPil]->GetEntries() > 0) {
+      histocheck2[jPil]->SetLineColor(jPil + 2);
+      histocheck2[jPil]->SetLineWidth(2);
       histocheck2[jPil]->Draw("sames");
     }
   }
-  coutp->cd(2);
+
+  TCanvas* coutp = new TCanvas("coutp", "", 1200, 800);
+  coutp->Divide(2, 2);
+  coutp->cd(1);
   hnvert->Draw();
-  coutp->cd(3);
+  coutp->cd(2);
   hdz->Draw();
-  coutp->cd(4);
+  coutp->cd(3);
   hncontr->Draw();
-  coutp->cd(5);
+  coutp->cd(4);
   hSigmaZ->Draw();
 }

--- a/test/runFastFitOnHits.C
+++ b/test/runFastFitOnHits.C
@@ -28,47 +28,49 @@
 #include "NA6PLayoutParam.h"
 #endif
 
-
 // simple macro with an example of how to use NA6PFastFitter to fit tracks starting from their hits in the VT
 // uses the MC truth information to group the hits produced by the same particle
 
-void SuperposHistos(TH1* h1, TH1* h2, TH1* h3){
+void SuperposHistos(TH1* h1, TH1* h2, TH1* h3)
+{
   h1->SetLineColor(1);
   h1->SetLineWidth(2);
-  if(h2->GetMaximum()>h1->GetMaximum()) h1->SetMaximum(1.02*h2->GetMaximum());
-  if(h3->GetMaximum()>h1->GetMaximum()) h1->SetMaximum(1.02*h3->GetMaximum());
+  if (h2->GetMaximum() > h1->GetMaximum())
+    h1->SetMaximum(1.02 * h2->GetMaximum());
+  if (h3->GetMaximum() > h1->GetMaximum())
+    h1->SetMaximum(1.02 * h3->GetMaximum());
   h1->SetMinimum(0);
   h1->Draw();
   h2->SetLineColor(2);
   h2->SetLineWidth(2);
   h2->Draw("sames");
-  h3->SetLineColor(kGreen+1);
+  h3->SetLineColor(kGreen + 1);
   h3->SetLineWidth(2);
   h3->Draw("sames");
   gPad->Update();
-  TPaveStats* st1=(TPaveStats*)h1->GetListOfFunctions()->FindObject("stats");
-  if(st1){
+  TPaveStats* st1 = (TPaveStats*)h1->GetListOfFunctions()->FindObject("stats");
+  if (st1) {
     st1->SetY1NDC(0.72);
     st1->SetY2NDC(0.92);
     st1->SetTextColor(1);
   }
-  TPaveStats* st2=(TPaveStats*)h2->GetListOfFunctions()->FindObject("stats");
-  if(st2){
+  TPaveStats* st2 = (TPaveStats*)h2->GetListOfFunctions()->FindObject("stats");
+  if (st2) {
     st2->SetY1NDC(0.51);
     st2->SetY2NDC(0.71);
     st2->SetTextColor(2);
   }
-  TPaveStats* st3=(TPaveStats*)h3->GetListOfFunctions()->FindObject("stats");
-  if(st3){
+  TPaveStats* st3 = (TPaveStats*)h3->GetListOfFunctions()->FindObject("stats");
+  if (st3) {
     st3->SetY1NDC(0.30);
     st3->SetY2NDC(0.50);
-    st3->SetTextColor(kGreen+1);
+    st3->SetTextColor(kGreen + 1);
   }
   gPad->Modified();
 }
 
-
-void FillMeanAndRms(TH2F* hImpParVsP, TH1F* hImpParMean, TH1F* hImpParRms, TH1F* hImpParSig){
+void FillMeanAndRms(TH2F* hImpParVsP, TH1F* hImpParMean, TH1F* hImpParRms, TH1F* hImpParSig)
+{
   if (!hImpParVsP || !hImpParMean || !hImpParRms || !hImpParSig) {
     printf("One of pointers is not set: hImpParVsP=%p hImpParMean=%p hImpParRms=%p hImpParSig=%p\n", hImpParVsP, hImpParMean, hImpParRms, hImpParSig);
     return;
@@ -77,261 +79,273 @@ void FillMeanAndRms(TH2F* hImpParVsP, TH1F* hImpParMean, TH1F* hImpParRms, TH1F*
   hImpParMean->SetStats(0);
   hImpParRms->SetStats(0);
   hImpParSig->SetStats(0);
-  for(int jp = 1; jp <= nMomBins; jp++){
-    TH1D* htmp1 = hImpParVsP->ProjectionY("htmp1",jp,jp);
+  for (int jp = 1; jp <= nMomBins; jp++) {
+    TH1D* htmp1 = hImpParVsP->ProjectionY("htmp1", jp, jp);
     double mean = htmp1->GetMean();
     double emean = htmp1->GetMeanError();
     double rms = htmp1->GetRMS();
     double erms = htmp1->GetRMSError();
-    hImpParMean->SetBinContent(jp,mean);
-    hImpParMean->SetBinError(jp,emean);
-    hImpParRms->SetBinContent(jp,rms);
-    hImpParRms->SetBinError(jp,erms);
+    hImpParMean->SetBinContent(jp, mean);
+    hImpParMean->SetBinError(jp, emean);
+    hImpParRms->SetBinContent(jp, rms);
+    hImpParRms->SetBinError(jp, erms);
     double gw = rms;
     double egw = erms;
-    if(htmp1->GetEntries()>20. && htmp1->Fit("gaus","Q","",-3.*rms,3.*rms)) {
+    if (htmp1->GetEntries() > 20. && htmp1->Fit("gaus", "Q", "", -3. * rms, 3. * rms)) {
       TF1* fg = (TF1*)htmp1->GetListOfFunctions()->FindObject("gaus");
-      if (!fg) continue;
+      if (!fg)
+        continue;
       gw = fg->GetParameter(2);
       egw = fg->GetParError(2);
     }
-    hImpParSig->SetBinContent(jp,gw);
-    hImpParSig->SetBinError(jp,egw);
+    hImpParSig->SetBinContent(jp, gw);
+    hImpParSig->SetBinError(jp, egw);
     delete htmp1;
   }
 }
 
 void runFastFitOnHits(int firstEv = 0,
-		      int lastEv = 99999999,
-		      double clures = 5.e-4,
-		      const char *dirSimu = "../testN6Proot/pions/50evwithtarget",
-		      int minITShits=5) {
-  
+                      int lastEv = 99999999,
+                      double clures = 5.e-4,
+                      const char* dirSimu = "../../testN6Proot/pions/latesttag",
+                      int minITShits = 5)
+{
+
   // na6p::conf::ConfigurableParam::updateFromFile(Form("%s/na6pLayout.ini",dirSimu),"",true);
   // const auto& param = NA6PLayoutParam::Instance();
-  
-  TFile* fk=new TFile(Form("%s/MCKine.root",dirSimu));
-  TTree* mcTree=(TTree*)fk->Get("mckine");
-  int nEv=mcTree->GetEntries();
+
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  int nEv = mcTree->GetEntries();
   std::vector<TParticle>* mcArr = nullptr;
   mcTree->SetBranchAddress("tracks", &mcArr);
 
-  TFile* fh=new TFile(Form("%s/HitsVerTel.root",dirSimu));
-  TTree* th=(TTree*)fh->Get("hitsVerTel");
+  TFile* fh = new TFile(Form("%s/HitsVerTel.root", dirSimu));
+  TTree* th = (TTree*)fh->Get("hitsVerTel");
   std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
   th->SetBranchAddress("VerTel", &vtHitsPtr);
 
   int nMomBins = 20;
   double maxP = 10.;
-  TH1F* hEtaGen = new TH1F("hEtaGen",";#eta;counts",20,0.,5.);
-  TH1F* hEtaReco = new TH1F("hEtaReco",";#eta;counts",20,0.,5.);
-  TH1F* hDeltaPx = new TH1F("hDeltaPx",";p_{x}^{rec}-p_{x}^{gen} (GeV/c);counts",100,-0.2,0.2);
-  TH1F* hDeltaPy = new TH1F("hDeltaPy",";p_{y}^{rec}-p_{y}^{gen} (GeV/c);counts",100,-0.2,0.2);
-  TH1F* hDeltaPz = new TH1F("hDeltaPz",";p_{z}^{rec}-p_{z}^{gen} (GeV/c);counts",100,-0.5,0.5);
-  TH1F* hDeltaP = new TH1F("hDeltaP",";p^{rec}-p^{gen} (GeV/c);counts",100,-0.5,0.5);
-  TH1F* hDeltaPhi = new TH1F("hDeltaPhi",";#varphi^{rec}-#varphi^{gen};counts",100,-M_PI/4.,M_PI/4.);
-  TH1F* hDeltaEta = new TH1F("hDeltaEta",";#eta^{rec}-#eta^{gen};counts",100,-0.5,0.5);
-  TH1F* hImpParX = new TH1F("hImpParX",";Track Imp. Par. X (#mum)};counts",100,-500,500);
-  TH1F* hImpParY = new TH1F("hImpParY",";Track Imp. Par. Y (#mum)};counts",100,-500,500);
-  TH2F* hImpParXVsP = new TH2F("hImpParXVsP",";p (GeV/c);Track Imp. Par. X (#mum)};counts",nMomBins,0.,maxP,100,-500.,500.);
-  TH2F* hImpParYVsP = new TH2F("hImpParYVsP",";p (GeV/c);Track Imp. Par. Y (#mum)};counts",nMomBins,0.,maxP,100,-500.,500.);
-  TH2F* hDeltaPxVsP = new TH2F("hDeltaPxVsP",";p (GeV/c);p_{x}^{rec}-p_{x}^{gen} (GeV/c);counts",nMomBins,0.,maxP,500,-0.5,0.5);
-  TH2F* hDeltaPyVsP = new TH2F("hDeltaPyVsP",";p (GeV/c);p_{y}^{rec}-p_{y}^{gen} (GeV/c);counts",nMomBins,0.,maxP,500,-0.5,0.5);
-  TH2F* hDeltaPzVsP = new TH2F("hDeltaPzVsP",";p (GeV/c);p_{z}^{rec}-p_{z}^{gen} (GeV/c);counts",nMomBins,0.,maxP,500,-0.5,0.5);
-  TH2F* hDeltaPVsP = new TH2F("hDeltaPVsP",";p (GeV/c);p^{rec}-p^{gen} (GeV/c);counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH2F* hRelDeltaPxVsP = new TH2F("hRelDeltaPxVsP",";p (GeV/c);(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen};counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH2F* hRelDeltaPyVsP = new TH2F("hRelDeltaPyVsP",";p (GeV/c);(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen};counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH2F* hRelDeltaPzVsP = new TH2F("hRelDeltaPzVsP",";p (GeV/c);(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen};counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH2F* hRelDeltaPVsP = new TH2F("hRelDeltaPVsP",";p (GeV/c);(p^{rec}-p^{gen})/p_{gen};counts",nMomBins,0.,maxP,100,-0.5,0.5);
-  TH1F* hIsGood = new TH1F("hIsGood","",2,-0.5,1.5);
-  hIsGood->GetXaxis()->SetBinLabel(1,"bad");
-  hIsGood->GetXaxis()->SetBinLabel(2,"good");
-  TH1F* hNclu = new TH1F("hNclu",";n_{ITSclus};counts",7,-0.5,6.5);
-  TH1F* hChi2NDF = new TH1F("hChi2NDF",";#chi^{2}/nDOF;counts",100,0.,10.);
+  TH1F* hEtaGen = new TH1F("hEtaGen", ";#eta;counts", 20, 0., 5.);
+  TH1F* hEtaReco = new TH1F("hEtaReco", ";#eta;counts", 20, 0., 5.);
+  TH1F* hDeltaPx = new TH1F("hDeltaPx", ";p_{x}^{rec}-p_{x}^{gen} (GeV/c);counts", 100, -0.2, 0.2);
+  TH1F* hDeltaPy = new TH1F("hDeltaPy", ";p_{y}^{rec}-p_{y}^{gen} (GeV/c);counts", 100, -0.2, 0.2);
+  TH1F* hDeltaPz = new TH1F("hDeltaPz", ";p_{z}^{rec}-p_{z}^{gen} (GeV/c);counts", 100, -0.5, 0.5);
+  TH1F* hDeltaP = new TH1F("hDeltaP", ";p^{rec}-p^{gen} (GeV/c);counts", 100, -0.5, 0.5);
+  TH1F* hDeltaPhi = new TH1F("hDeltaPhi", ";#varphi^{rec}-#varphi^{gen};counts", 100, -M_PI / 4., M_PI / 4.);
+  TH1F* hDeltaEta = new TH1F("hDeltaEta", ";#eta^{rec}-#eta^{gen};counts", 100, -0.5, 0.5);
+  TH1F* hImpParX = new TH1F("hImpParX", ";Track Imp. Par. X (#mum)};counts", 100, -500, 500);
+  TH1F* hImpParY = new TH1F("hImpParY", ";Track Imp. Par. Y (#mum)};counts", 100, -500, 500);
+  TH2F* hImpParXVsP = new TH2F("hImpParXVsP", ";p (GeV/c);Track Imp. Par. X (#mum)};counts", nMomBins, 0., maxP, 100, -500., 500.);
+  TH2F* hImpParYVsP = new TH2F("hImpParYVsP", ";p (GeV/c);Track Imp. Par. Y (#mum)};counts", nMomBins, 0., maxP, 100, -500., 500.);
+  TH2F* hDeltaPxVsP = new TH2F("hDeltaPxVsP", ";p (GeV/c);p_{x}^{rec}-p_{x}^{gen} (GeV/c);counts", nMomBins, 0., maxP, 500, -0.5, 0.5);
+  TH2F* hDeltaPyVsP = new TH2F("hDeltaPyVsP", ";p (GeV/c);p_{y}^{rec}-p_{y}^{gen} (GeV/c);counts", nMomBins, 0., maxP, 500, -0.5, 0.5);
+  TH2F* hDeltaPzVsP = new TH2F("hDeltaPzVsP", ";p (GeV/c);p_{z}^{rec}-p_{z}^{gen} (GeV/c);counts", nMomBins, 0., maxP, 500, -0.5, 0.5);
+  TH2F* hDeltaPVsP = new TH2F("hDeltaPVsP", ";p (GeV/c);p^{rec}-p^{gen} (GeV/c);counts", nMomBins, 0., maxP, 100, -0.5, 0.5);
+  TH2F* hRelDeltaPxVsP = new TH2F("hRelDeltaPxVsP", ";p (GeV/c);(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen};counts", nMomBins, 0., maxP, 100, -0.5, 0.5);
+  TH2F* hRelDeltaPyVsP = new TH2F("hRelDeltaPyVsP", ";p (GeV/c);(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen};counts", nMomBins, 0., maxP, 100, -0.5, 0.5);
+  TH2F* hRelDeltaPzVsP = new TH2F("hRelDeltaPzVsP", ";p (GeV/c);(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen};counts", nMomBins, 0., maxP, 100, -0.5, 0.5);
+  TH2F* hRelDeltaPVsP = new TH2F("hRelDeltaPVsP", ";p (GeV/c);(p^{rec}-p^{gen})/p_{gen};counts", nMomBins, 0., maxP, 100, -0.5, 0.5);
+  TH1F* hIsGood = new TH1F("hIsGood", "", 2, -0.5, 1.5);
+  hIsGood->GetXaxis()->SetBinLabel(1, "bad");
+  hIsGood->GetXaxis()->SetBinLabel(2, "good");
+  TH1F* hNclu = new TH1F("hNclu", ";n_{ITSclus};counts", 7, -0.5, 6.5);
+  TH1F* hChi2NDF = new TH1F("hChi2NDF", ";#chi^{2}/nDOF;counts", 100, 0., 10.);
 
-  if(lastEv>nEv || lastEv<0) lastEv=nEv;
-  if(firstEv<0) firstEv=0;
-  
+  if (lastEv > nEv || lastEv < 0)
+    lastEv = nEv;
+  if (firstEv < 0)
+    firstEv = 0;
+
   NA6PTreeStreamRedirector outTr("fitCheck.root");
 
   NA6PFastTrackFitter* fitter = new NA6PFastTrackFitter();
-  fitter->loadGeometry(Form("%s/geometry.root",dirSimu));
+  fitter->loadGeometry(Form("%s/geometry.root", dirSimu));
   fitter->setNLayersVT(5);
-  fitter->setMaxChi2Cl(10.);
+  fitter->setMaxChi2Cl(100.);
   fitter->setPropagateToPrimaryVertex(true);
   // fitter->setSeedFromTwoOutermostHits();
   // fitter->setCharge(2);
   // fitter->setParticleHypothesis(2212);
   // fitter->disableMaterialCorrections();
-  for(int jEv=firstEv;jEv<lastEv; jEv++){
+  for (int jEv = firstEv; jEv < lastEv; jEv++) {
     mcTree->GetEvent(jEv);
     th->GetEvent(jEv);
-    int nPart=mcArr->size();
-    int nHits=vtHits.size();
+    int nPart = mcArr->size();
+    int nHits = vtHits.size();
+    double xvert = 0;
+    double yvert = 0;
     double zvert = 0;
     // get primary vertex position from the Kine Tree
-    for(int jp=0; jp<nPart; jp++){
-      auto curPart=mcArr->at(jp);
-      if(curPart.IsPrimary()){
-	zvert =  curPart.Vz();
-	break;
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      if (curPart.IsPrimary()) {
+        xvert = curPart.Vx();
+        yvert = curPart.Vy();
+        zvert = curPart.Vz();
+        break;
       }
     }
     fitter->setPrimaryVertexZ(zvert);
-    for(int jp=0; jp<nPart; jp++){
-      const auto& curPart=mcArr->at(jp);
-      double pxPart=curPart.Px();
-      double pyPart=curPart.Py();
-      double pzPart=curPart.Pz();
-      double momPart=curPart.P();
-      double phiPart=curPart.Phi();
-      double thetaPart=std::acos(pzPart/momPart);
-      double etaPart=-std::log(std::tan(thetaPart/2.));
-      std::array<std::unique_ptr<NA6PBaseCluster>, 5> clusters{ nullptr, nullptr, nullptr, nullptr, nullptr };
-      double xclu[5],yclu[5],zclu[5];
-      if(curPart.IsPrimary()){
-	hEtaGen->Fill(etaPart);
-	int maskHits = 0;
-	fitter->cleanupAndStartFit();
-	for(const auto& hit : vtHits) {
-	  int idPart=hit.getTrackID();
-	  if(idPart==jp){
-	    int nDet=hit.getDetectorID();
-	    int nLay=nDet/4;
-	    maskHits += (1<<nLay);
-	    if(clures > 0){
-	      xclu[nLay] = gRandom->Gaus(hit.getX(),clures); 
-	      yclu[nLay] = gRandom->Gaus(hit.getY(),clures); 
-	      zclu[nLay] = hit.getZ(); 
-	    }else{
-	      xclu[nLay] = hit.getX(); 
-	      yclu[nLay] = hit.getY(); 
-	      zclu[nLay] = hit.getZ(); 
-	    }
-	    NA6PBaseCluster* clu = new NA6PBaseCluster(xclu[nLay], yclu[nLay], zclu[nLay], idPart);
-	    clu->setDetectorID(nDet);
-	    if(clures>0)  clu->setErr(clures*clures,0.,clures*clures);
-	    else clu->setErr(1.e-6,0.,1e-6);
-	    fitter->addClusterVT(nLay,clu);
-	  }
-	}
-	// track only particles with 5 hits in the VT
-	if (maskHits != 31) continue;
+    for (int jp = 0; jp < nPart; jp++) {
+      const auto& curPart = mcArr->at(jp);
+      double pxPart = curPart.Px();
+      double pyPart = curPart.Py();
+      double pzPart = curPart.Pz();
+      double momPart = curPart.P();
+      double phiPart = curPart.Phi();
+      double thetaPart = std::acos(pzPart / momPart);
+      double etaPart = -std::log(std::tan(thetaPart / 2.));
+      std::array<std::unique_ptr<NA6PBaseCluster>, 5> clusters{nullptr, nullptr, nullptr, nullptr, nullptr};
+      double xclu[5], yclu[5], zclu[5];
+      if (curPart.IsPrimary()) {
+        hEtaGen->Fill(etaPart);
+        int maskHits = 0;
+        fitter->cleanupAndStartFit();
+        for (const auto& hit : vtHits) {
+          int idPart = hit.getTrackID();
+          if (idPart == jp) {
+            int nDet = hit.getDetectorID();
+            int nLay = nDet / 4;
+            maskHits += (1 << nLay);
+            if (clures > 0) {
+              xclu[nLay] = gRandom->Gaus(hit.getX(), clures);
+              yclu[nLay] = gRandom->Gaus(hit.getY(), clures);
+              zclu[nLay] = hit.getZ();
+            } else {
+              xclu[nLay] = hit.getX();
+              yclu[nLay] = hit.getY();
+              zclu[nLay] = hit.getZ();
+            }
+            NA6PBaseCluster* clu = new NA6PBaseCluster(xclu[nLay], yclu[nLay], zclu[nLay], idPart);
+            clu->setDetectorID(nDet);
+            if (clures > 0)
+              clu->setErr(clures * clures, 0., clures * clures);
+            else
+              clu->setErr(1.e-6, 0., 1e-6);
+            fitter->addClusterVT(nLay, clu);
+          }
+        }
+        // track only particles with 5 hits in the VT
+        if (maskHits != 31)
+          continue;
 
-	
-	// Uncomment the next lines to use the MC truth as seed for the track
-	//	double xyz0[3]={xclu[4],yclu[4],zclu[4]};	
-	//	double pxyz0[3]={curPart.Px(),curPart.Py(),curPart.Pz()};
-	//	printf("Initialize seed at %f %f %f p = %f %f %f\n",xyz0[0],xyz0[1],xyz0[2],pxyz0[0],pxyz0[1],pxyz0[2]);
-	//	int sign = curPart.GetPdgCode() > 0 ? 1 : -1;
-	//	fitter->setSeed(xyz0,pxyz0,sign);
+        // Uncomment the next lines to use the MC truth as seed for the track
+        //	double xyz0[3]={xclu[4],yclu[4],zclu[4]};
+        //	double pxyz0[3]={curPart.Px(),curPart.Py(),curPart.Pz()};
+        //	printf("Initialize seed at %f %f %f p = %f %f %f\n",xyz0[0],xyz0[1],xyz0[2],pxyz0[0],pxyz0[1],pxyz0[2]);
+        //	int sign = curPart.GetPdgCode() > 0 ? 1 : -1;
+        //	fitter->setSeed(xyz0,pxyz0,sign);
 
-	NA6PTrack* currTr = fitter->fitTrackPointsVT();
-	//	fitter->propagateToZ(currTr,zvert); 
-	double chiFit = -1.;
-	if(currTr){
-	  hIsGood->Fill(1);
-	  int nClusters = currTr->getNVTHits();
-	  hNclu->Fill(nClusters);
-	  if(nClusters<5) continue;
-	  chiFit = currTr->getChi2();
-	  //	  printf("chi2 = %f  chi2/ndf = %f\n",chiFit,currTr->GetNormChi2());
-	  double pxyz[3];
-	  currTr->getPXYZ(pxyz);
-	  double pxtr=pxyz[0];
-	  double pytr=pxyz[1];
-	  double pztr=pxyz[2];
-	  double momtr=currTr->getP();
-	  double phitr=std::atan2(pytr,pxtr);
-	  double thetatr=std::acos(pztr/momtr);
-	  double etatr=-std::log(std::tan(thetatr/2.));
-	  double impparX = currTr->getXLab();
-	  double impparY = currTr->getYLab();
-	  hEtaReco->Fill(etatr);
-	  hDeltaPx->Fill(pxtr-pxPart);
-	  hDeltaPy->Fill(pytr-pyPart);
-	  hDeltaPz->Fill(pztr-pzPart);
-	  hDeltaP->Fill(momtr-momPart);
-	  hDeltaPxVsP->Fill(momtr,pxtr-pxPart);
-	  hDeltaPyVsP->Fill(momtr,pytr-pyPart);
-	  hDeltaPzVsP->Fill(momtr,pztr-pzPart);
-	  hDeltaPVsP->Fill(momtr,momtr-momPart);
-	  hRelDeltaPxVsP->Fill(momtr,(pxtr-pxPart)/pxPart);
-	  hRelDeltaPyVsP->Fill(momtr,(pytr-pyPart)/pyPart);
-	  hRelDeltaPzVsP->Fill(momtr,(pztr-pzPart)/pzPart);
-	  hRelDeltaPVsP->Fill(momtr,(momtr-momPart)/momPart);
-	  hDeltaPhi->Fill(phitr-phiPart);
-	  hDeltaEta->Fill(etatr-etaPart);
-	  hImpParX->Fill(impparX*1e4);
-	  hImpParY->Fill(impparY*1e4);
-	  hImpParXVsP->Fill(momtr,impparX*1e4);
-	  hImpParYVsP->Fill(momtr,impparY*1e4);
-	  hChi2NDF->Fill(chiFit);
-	}else{
-	  hIsGood->Fill(0); 
-	}	
-	TParticle trFit;
-	if (currTr) {
-	  double pos[3],mom[3];
-	  currTr->getPXYZ(mom);
-	  TLorentzVector v;
-	  v.SetXYZM(mom[0], mom[1], mom[2], 0.14);
-	  trFit.SetMomentum(v);
-	  trFit.SetProductionVertex(currTr->getXLab(), currTr->getYLab(), currTr->getZLab(), 0);
-	}
-	outTr << "out" << "mcTr=" << curPart << "fitTr=" << trFit << "fitChi2=" << chiFit << "\n";
+        NA6PTrack* currTr = fitter->fitTrackPointsVT();
+        //  fitter->propagateToZ(currTr,zvert);
+        double chiFit = -1.;
+        if (currTr) {
+          hIsGood->Fill(1);
+          int nClusters = currTr->getNVTHits();
+          hNclu->Fill(nClusters);
+          if (nClusters < 5)
+            continue;
+          chiFit = currTr->getChi2();
+          //	  printf("chi2 = %f  chi2/ndf = %f\n",chiFit,currTr->GetNormChi2());
+          double pxyz[3];
+          currTr->getPXYZ(pxyz);
+          double pxtr = pxyz[0];
+          double pytr = pxyz[1];
+          double pztr = pxyz[2];
+          double momtr = currTr->getP();
+          double phitr = std::atan2(pytr, pxtr);
+          double thetatr = std::acos(pztr / momtr);
+          double etatr = -std::log(std::tan(thetatr / 2.));
+          double impparX = currTr->getXLab() - xvert;
+          double impparY = currTr->getYLab() - yvert;
+          hEtaReco->Fill(etatr);
+          hDeltaPx->Fill(pxtr - pxPart);
+          hDeltaPy->Fill(pytr - pyPart);
+          hDeltaPz->Fill(pztr - pzPart);
+          hDeltaP->Fill(momtr - momPart);
+          hDeltaPxVsP->Fill(momtr, pxtr - pxPart);
+          hDeltaPyVsP->Fill(momtr, pytr - pyPart);
+          hDeltaPzVsP->Fill(momtr, pztr - pzPart);
+          hDeltaPVsP->Fill(momtr, momtr - momPart);
+          hRelDeltaPxVsP->Fill(momtr, (pxtr - pxPart) / pxPart);
+          hRelDeltaPyVsP->Fill(momtr, (pytr - pyPart) / pyPart);
+          hRelDeltaPzVsP->Fill(momtr, (pztr - pzPart) / pzPart);
+          hRelDeltaPVsP->Fill(momtr, (momtr - momPart) / momPart);
+          hDeltaPhi->Fill(phitr - phiPart);
+          hDeltaEta->Fill(etatr - etaPart);
+          hImpParX->Fill(impparX * 1e4);
+          hImpParY->Fill(impparY * 1e4);
+          hImpParXVsP->Fill(momtr, impparX * 1e4);
+          hImpParYVsP->Fill(momtr, impparY * 1e4);
+          hChi2NDF->Fill(chiFit);
+        } else {
+          hIsGood->Fill(0);
+        }
+        TParticle trFit;
+        if (currTr) {
+          double pos[3], mom[3];
+          currTr->getPXYZ(mom);
+          TLorentzVector v;
+          v.SetXYZM(mom[0], mom[1], mom[2], 0.14);
+          trFit.SetMomentum(v);
+          trFit.SetProductionVertex(currTr->getXLab(), currTr->getYLab(), currTr->getZLab(), 0);
+        }
+        outTr << "out"
+              << "mcTr=" << curPart << "fitTr=" << trFit << "fitChi2=" << chiFit << "\n";
       }
     }
   }
   outTr.Close();
 
-  TH1F* hImpParXMean = new TH1F("hImpParXMean",";p (GeV/c);<Imp Par X> (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParYMean = new TH1F("hImpParYMean",";p (GeV/c);<Imp Par Y> (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParXRms = new TH1F("hImpParXRms",";p (GeV/c);rms (Imp Par X) (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParYRms = new TH1F("hImpParYRms",";p (GeV/c);rms (Imp Par Y) (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParXSig = new TH1F("hImpParXSig",";p (GeV/c);#sigma(Imp Par X) (#mum)",nMomBins,0.,maxP);
-  TH1F* hImpParYSig = new TH1F("hImpParYSig",";p (GeV/c);#sigma(Imp Par Y) (#mum)",nMomBins,0.,maxP);
-  FillMeanAndRms(hImpParXVsP,hImpParXMean,hImpParXRms,hImpParXSig);
-  FillMeanAndRms(hImpParYVsP,hImpParYMean,hImpParYRms,hImpParYSig);
+  TH1F* hImpParXMean = new TH1F("hImpParXMean", ";p (GeV/c);<Imp Par X> (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParYMean = new TH1F("hImpParYMean", ";p (GeV/c);<Imp Par Y> (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParXRms = new TH1F("hImpParXRms", ";p (GeV/c);rms (Imp Par X) (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParYRms = new TH1F("hImpParYRms", ";p (GeV/c);rms (Imp Par Y) (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParXSig = new TH1F("hImpParXSig", ";p (GeV/c);#sigma(Imp Par X) (#mum)", nMomBins, 0., maxP);
+  TH1F* hImpParYSig = new TH1F("hImpParYSig", ";p (GeV/c);#sigma(Imp Par Y) (#mum)", nMomBins, 0., maxP);
+  FillMeanAndRms(hImpParXVsP, hImpParXMean, hImpParXRms, hImpParXSig);
+  FillMeanAndRms(hImpParYVsP, hImpParYMean, hImpParYRms, hImpParYSig);
 
-  TH1F* hDeltaPMean = new TH1F("hDeltaPMean",";p (GeV/c);<p_{rec}-p_{gen}> (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPRms = new TH1F("hDeltaPRms",";p (GeV/c);rms (p_{rec}-p_{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPSig = new TH1F("hDeltaPSig",";p (GeV/c);#sigma(p_{rec}-p_{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPMean = new TH1F("hRelDeltaPMean",";p (GeV/c);<(p_{rec}-p_{gen})/p_{gen}>",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPRms = new TH1F("hRelDeltaPRms",";p (GeV/c);rms (p_{rec}-p_{gen})/p_{gen}",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPSig = new TH1F("hRelDeltaPSig",";p (GeV/c);#sigma(p_{rec}-p_{gen})/p_{gen} (GeV/c)",nMomBins,0.,maxP);
-  FillMeanAndRms(hDeltaPVsP,hDeltaPMean,hDeltaPRms,hDeltaPSig);
-  FillMeanAndRms(hRelDeltaPVsP,hRelDeltaPMean,hRelDeltaPRms,hRelDeltaPSig);
-  
-  TH1F* hDeltaPxMean = new TH1F("hDeltaPxMean",";p (GeV/c);<p_{x}^{rec}-p_{x}^{gen}> (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPxRms = new TH1F("hDeltaPxRms",";p (GeV/c);rms (p_{x}^{rec}-p_{x}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPxSig = new TH1F("hDeltaPxSig",";p (GeV/c);#sigma(p_{x}^{rec}-p_{x}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPxMean = new TH1F("hRelDeltaPxMean",";p (GeV/c);<(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen}>",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPxRms = new TH1F("hRelDeltaPxRms",";p (GeV/c);rms (p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen}",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPxSig = new TH1F("hRelDeltaPxSig",";p (GeV/c);#sigma(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen} (GeV/c)",nMomBins,0.,maxP);
-  FillMeanAndRms(hDeltaPxVsP,hDeltaPxMean,hDeltaPxRms,hDeltaPxSig);
-  FillMeanAndRms(hRelDeltaPxVsP,hRelDeltaPxMean,hRelDeltaPxRms,hRelDeltaPxSig);
+  TH1F* hDeltaPMean = new TH1F("hDeltaPMean", ";p (GeV/c);<p_{rec}-p_{gen}> (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPRms = new TH1F("hDeltaPRms", ";p (GeV/c);rms (p_{rec}-p_{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPSig = new TH1F("hDeltaPSig", ";p (GeV/c);#sigma(p_{rec}-p_{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPMean = new TH1F("hRelDeltaPMean", ";p (GeV/c);<(p_{rec}-p_{gen})/p_{gen}>", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPRms = new TH1F("hRelDeltaPRms", ";p (GeV/c);rms (p_{rec}-p_{gen})/p_{gen}", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPSig = new TH1F("hRelDeltaPSig", ";p (GeV/c);#sigma(p_{rec}-p_{gen})/p_{gen} (GeV/c)", nMomBins, 0., maxP);
+  FillMeanAndRms(hDeltaPVsP, hDeltaPMean, hDeltaPRms, hDeltaPSig);
+  FillMeanAndRms(hRelDeltaPVsP, hRelDeltaPMean, hRelDeltaPRms, hRelDeltaPSig);
 
-  TH1F* hDeltaPyMean = new TH1F("hDeltaPyMean",";p (GeV/c);<p_{y}^{rec}-p_{x}^{gen}> (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPyRms = new TH1F("hDeltaPyRms",";p (GeV/c);rms (p_{y}^{rec}-p_{x}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPySig = new TH1F("hDeltaPySig",";p (GeV/c);#sigma(p_{y}^{rec}-p_{x}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-   TH1F* hRelDeltaPyMean = new TH1F("hRelDeltaPyMean",";p (GeV/c);<(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen}>",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPyRms = new TH1F("hRelDeltaPyRms",";p (GeV/c);rms (p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen}",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPySig = new TH1F("hRelDeltaPySig",";p (GeV/c);#sigma(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen} (GeV/c)",nMomBins,0.,maxP);
-  FillMeanAndRms(hDeltaPyVsP,hDeltaPyMean,hDeltaPyRms,hDeltaPySig);
-  FillMeanAndRms(hRelDeltaPyVsP,hRelDeltaPyMean,hRelDeltaPyRms,hRelDeltaPySig);
+  TH1F* hDeltaPxMean = new TH1F("hDeltaPxMean", ";p (GeV/c);<p_{x}^{rec}-p_{x}^{gen}> (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPxRms = new TH1F("hDeltaPxRms", ";p (GeV/c);rms (p_{x}^{rec}-p_{x}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPxSig = new TH1F("hDeltaPxSig", ";p (GeV/c);#sigma(p_{x}^{rec}-p_{x}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPxMean = new TH1F("hRelDeltaPxMean", ";p (GeV/c);<(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen}>", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPxRms = new TH1F("hRelDeltaPxRms", ";p (GeV/c);rms (p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen}", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPxSig = new TH1F("hRelDeltaPxSig", ";p (GeV/c);#sigma(p_{x}^{rec}-p_{x}^{gen})/p_{x}^{gen} (GeV/c)", nMomBins, 0., maxP);
+  FillMeanAndRms(hDeltaPxVsP, hDeltaPxMean, hDeltaPxRms, hDeltaPxSig);
+  FillMeanAndRms(hRelDeltaPxVsP, hRelDeltaPxMean, hRelDeltaPxRms, hRelDeltaPxSig);
 
-  TH1F* hDeltaPzMean = new TH1F("hDeltaPzMean",";p (GeV/c);<p_{z}^{rec}-p_{z}^{gen}> (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPzRms = new TH1F("hDeltaPzRms",";p (GeV/c);rms (p_{z}^{rec}-p_{z}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hDeltaPzSig = new TH1F("hDeltaPzSig",";p (GeV/c);#sigma(p_{z}^{rec}-p_{z}^{gen}) (GeV/c)",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPzMean = new TH1F("hRelDeltaPzMean",";p (GeV/c);<(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen}>",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPzRms = new TH1F("hRelDeltaPzRms",";p (GeV/c);rms (p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen}",nMomBins,0.,maxP);
-  TH1F* hRelDeltaPzSig = new TH1F("hRelDeltaPzSig",";p (GeV/c);#sigma(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen} (GeV/c)",nMomBins,0.,maxP);
-  FillMeanAndRms(hDeltaPzVsP,hDeltaPzMean,hDeltaPzRms,hDeltaPzSig);
-  FillMeanAndRms(hRelDeltaPzVsP,hRelDeltaPzMean,hRelDeltaPzRms,hRelDeltaPzSig);
-  
-  TCanvas* ct = new TCanvas("ct","",1000,800);
-  ct->Divide(2,2);
+  TH1F* hDeltaPyMean = new TH1F("hDeltaPyMean", ";p (GeV/c);<p_{y}^{rec}-p_{x}^{gen}> (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPyRms = new TH1F("hDeltaPyRms", ";p (GeV/c);rms (p_{y}^{rec}-p_{x}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPySig = new TH1F("hDeltaPySig", ";p (GeV/c);#sigma(p_{y}^{rec}-p_{x}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPyMean = new TH1F("hRelDeltaPyMean", ";p (GeV/c);<(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen}>", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPyRms = new TH1F("hRelDeltaPyRms", ";p (GeV/c);rms (p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen}", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPySig = new TH1F("hRelDeltaPySig", ";p (GeV/c);#sigma(p_{y}^{rec}-p_{y}^{gen})/p_{y}^{gen} (GeV/c)", nMomBins, 0., maxP);
+  FillMeanAndRms(hDeltaPyVsP, hDeltaPyMean, hDeltaPyRms, hDeltaPySig);
+  FillMeanAndRms(hRelDeltaPyVsP, hRelDeltaPyMean, hRelDeltaPyRms, hRelDeltaPySig);
+
+  TH1F* hDeltaPzMean = new TH1F("hDeltaPzMean", ";p (GeV/c);<p_{z}^{rec}-p_{z}^{gen}> (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPzRms = new TH1F("hDeltaPzRms", ";p (GeV/c);rms (p_{z}^{rec}-p_{z}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hDeltaPzSig = new TH1F("hDeltaPzSig", ";p (GeV/c);#sigma(p_{z}^{rec}-p_{z}^{gen}) (GeV/c)", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPzMean = new TH1F("hRelDeltaPzMean", ";p (GeV/c);<(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen}>", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPzRms = new TH1F("hRelDeltaPzRms", ";p (GeV/c);rms (p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen}", nMomBins, 0., maxP);
+  TH1F* hRelDeltaPzSig = new TH1F("hRelDeltaPzSig", ";p (GeV/c);#sigma(p_{z}^{rec}-p_{z}^{gen})/p_{z}^{gen} (GeV/c)", nMomBins, 0., maxP);
+  FillMeanAndRms(hDeltaPzVsP, hDeltaPzMean, hDeltaPzRms, hDeltaPzSig);
+  FillMeanAndRms(hRelDeltaPzVsP, hRelDeltaPzMean, hRelDeltaPzRms, hRelDeltaPzSig);
+
+  TCanvas* ct = new TCanvas("ct", "", 1000, 800);
+  ct->Divide(2, 2);
   ct->cd(1);
   hIsGood->Draw();
   ct->cd(2);
@@ -339,8 +353,8 @@ void runFastFitOnHits(int firstEv = 0,
   ct->cd(3);
   hChi2NDF->Draw();
 
-  TCanvas* cip = new TCanvas("cip","",1200,800);
-  cip->Divide(2,2);
+  TCanvas* cip = new TCanvas("cip", "", 1200, 800);
+  cip->Divide(2, 2);
   cip->cd(1);
   gPad->SetTickx();
   gPad->SetTicky();
@@ -378,8 +392,8 @@ void runFastFitOnHits(int firstEv = 0,
   hImpParYSig->SetMaximum(120);
   hImpParYSig->Draw("P");
 
-  TCanvas* cmom = new TCanvas("cmom","",1400,900);
-  cmom->Divide(3,3);
+  TCanvas* cmom = new TCanvas("cmom", "", 1400, 900);
+  cmom->Divide(3, 3);
   cmom->cd(1);
   gPad->SetTickx();
   gPad->SetTicky();
@@ -460,22 +474,22 @@ void runFastFitOnHits(int firstEv = 0,
   hRelDeltaPzSig->SetMaximum(0.05);
   hRelDeltaPzSig->Draw("P");
 
-  TCanvas* ce = new TCanvas("ce","",1200,600);
-  ce->Divide(2,1);
+  TCanvas* ce = new TCanvas("ce", "", 1200, 600);
+  ce->Divide(2, 1);
   ce->cd(1);
   hEtaGen->SetLineColor(kGray);
   hEtaGen->SetLineWidth(2);
   hEtaGen->Draw();
-  hEtaReco->SetLineColor(kGreen+1);
+  hEtaReco->SetLineColor(kGreen + 1);
   hEtaReco->SetLineWidth(2);
   hEtaReco->Draw("same");
   ce->cd(2);
   TH1F* hEffRec = (TH1F*)hEtaReco->Clone("hEffRec");
-  hEffRec->Divide(hEtaReco,hEtaGen,1.,1.,"B");
+  hEffRec->Divide(hEtaReco, hEtaGen, 1., 1., "B");
   hEffRec->SetMaximum(1.05);
   hEffRec->Draw("");
 
-  TFile* outFFit = new TFile("TrackingFastFit.root","recreate");
+  TFile* outFFit = new TFile("TrackingFastFit.root", "recreate");
   hImpParXVsP->Write();
   hImpParYVsP->Write();
   hDeltaPxVsP->Write();
@@ -489,5 +503,4 @@ void runFastFitOnHits(int firstEv = 0,
   hEtaGen->Write();
   hEtaReco->Write();
   outFFit->Close();
-
 }

--- a/test/runTrackFinderCA.C
+++ b/test/runTrackFinderCA.C
@@ -16,195 +16,196 @@
 const int maxIterationsCA = NA6PTrackerCA::kMaxIterationsCA;
 
 void runTrackFinderCA(int firstEv = 0,
-		      int lastEv = 9999,
-		      const char *dirSimu = "../testN6Proot/pions/latesttag",
-		      int nLayers = 5){
+                      int lastEv = 9999,
+                      const char* dirSimu = "../testN6Proot/pions/latesttag",
+                      int nLayers = 5)
+{
 
   auto magField = new MagneticField();
   magField->loadField();
   magField->setAsGlobalField();
 
-
   int nMomBins = 40;
-  TH1F* hMomGen = new TH1F("hMomGen",";p (GeV/c);counts",nMomBins,0.,10.);
-  TH1F* hEtaGen = new TH1F("hEtaGen",";#eta;counts",20,1.,5.);
-  TH1F* hMomReco = new TH1F("hMomReco",";p (GeV/c);counts",nMomBins,0.,10.);
-  TH1F* hEtaReco = new TH1F("hEtaReco",";#eta;counts",20,1.,5.);
-  TH1F* hMomGoodReco = new TH1F("hMomGoodReco",";p (GeV/c);counts",nMomBins,0.,10.);
-  TH1F* hEtaGoodReco = new TH1F("hEtaGoodReco",";#eta;counts",20,1.,5.);
+  TH1F* hMomGen = new TH1F("hMomGen", ";p (GeV/c);counts", nMomBins, 0., 10.);
+  TH1F* hEtaGen = new TH1F("hEtaGen", ";#eta;counts", 20, 1., 5.);
+  TH1F* hMomReco = new TH1F("hMomReco", ";p (GeV/c);counts", nMomBins, 0., 10.);
+  TH1F* hEtaReco = new TH1F("hEtaReco", ";#eta;counts", 20, 1., 5.);
+  TH1F* hMomGoodReco = new TH1F("hMomGoodReco", ";p (GeV/c);counts", nMomBins, 0., 10.);
+  TH1F* hEtaGoodReco = new TH1F("hEtaGoodReco", ";#eta;counts", 20, 1., 5.);
   TH1F** hMomRecoIterCA = new TH1F*[maxIterationsCA];
   TH1F** hEtaRecoIterCA = new TH1F*[maxIterationsCA];
-  int colors[maxIterationsCA] = {kMagenta+1, kBlue, kGreen+1, kOrange+1, kRed+1, kRed, kRed-9, kGray+2, kGray+1, kGray};
-  for (int jIteration = 0; jIteration < maxIterationsCA; ++jIteration){
-    hMomRecoIterCA[jIteration] = new TH1F(Form("hMomRecoIterCA%d",jIteration),";p (GeV/c);counts",nMomBins,0.,10.);
-    hEtaRecoIterCA[jIteration] = new TH1F(Form("hEtaRecoIterCA%d",jIteration),";#eta;counts",20,1.,5.);
+  int colors[maxIterationsCA] = {kMagenta + 1, kBlue, kGreen + 1, kOrange + 1, kRed + 1, kRed, kRed - 9, kGray + 2, kGray + 1, kGray};
+  for (int jIteration = 0; jIteration < maxIterationsCA; ++jIteration) {
+    hMomRecoIterCA[jIteration] = new TH1F(Form("hMomRecoIterCA%d", jIteration), ";p (GeV/c);counts", nMomBins, 0., 10.);
+    hEtaRecoIterCA[jIteration] = new TH1F(Form("hEtaRecoIterCA%d", jIteration), ";#eta;counts", 20, 1., 5.);
   }
 
-
   NA6PTrackerCA* tracker = new NA6PTrackerCA();
-  if (!tracker->loadGeometry(Form("%s/geometry.root",dirSimu))) return;
+  if (!tracker->loadGeometry(Form("%s/geometry.root", dirSimu)))
+    return;
   // pass here the configuration of the tracker via an ini file
   tracker->configureFromRecoParam(/* filename.ini */);
   // alternatively the configuration can be set calling setters for the iterations
   // tracker->setNumberOfIterations(3);
   // tracker->setIterationParams(0,0.04,0.1,4.,0.4,0.02,2e-3,5.,5.,5.,5);
   tracker->printConfiguration();
-  TFile* fk=new TFile(Form("%s/MCKine.root",dirSimu));
-  TTree* mcTree=(TTree*)fk->Get("mckine");
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
   std::vector<TParticle>* mcArr = nullptr;
   mcTree->SetBranchAddress("tracks", &mcArr);
 
-  TFile* fh=new TFile(Form("%s/HitsVerTel.root",dirSimu));
-  TTree* th=(TTree*)fh->Get("hitsVerTel");
+  TFile* fh = new TFile(Form("%s/HitsVerTel.root", dirSimu));
+  TTree* th = (TTree*)fh->Get("hitsVerTel");
   std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
   th->SetBranchAddress("VerTel", &vtHitsPtr);
 
-  TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
-  printf("Open cluster file: %s\n",fc->GetName());
-  TTree* tc=(TTree*)fc->Get("clustersVerTel");
+  TFile* fc = new TFile(Form("%s/ClustersVerTel.root", dirSimu));
+  printf("Open cluster file: %s\n", fc->GetName());
+  TTree* tc = (TTree*)fc->Get("clustersVerTel");
   std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
   tc->SetBranchAddress("VerTel", &vtClusPtr);
-  int nEv=tc->GetEntries();
-  if(lastEv>nEv || lastEv<0) lastEv=nEv;
-  if(firstEv<0) firstEv=0;
-  TVector3 primVert(0,0,0);
+  int nEv = tc->GetEntries();
+  if (lastEv > nEv || lastEv < 0)
+    lastEv = nEv;
+  if (firstEv < 0)
+    firstEv = 0;
+  TVector3 primVert(0, 0, 0);
 
   int nIterationsCA = tracker->getNIterations();
 
-  for(int jEv=firstEv;jEv<lastEv; jEv++){
+  for (int jEv = firstEv; jEv < lastEv; jEv++) {
     mcTree->GetEvent(jEv);
     th->GetEvent(jEv);
-    int nPart=mcArr->size();
+    int nPart = mcArr->size();
     double zvert = 0;
     // get primary vertex position from the Kine Tree
-    for(int jp=0; jp<nPart; jp++){
-      auto curPart=mcArr->at(jp);
-      if(curPart.IsPrimary()){
-	zvert =  curPart.Vz();
-	break;
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      if (curPart.IsPrimary()) {
+        zvert = curPart.Vz();
+        break;
       }
     }
     primVert.SetZ(zvert);
-    uint nHits=vtHits.size();
-    for(int jp=0; jp<nPart; jp++){
-      auto curPart=mcArr->at(jp);
+    uint nHits = vtHits.size();
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
       int maskHits = 0;
       for (size_t jHit = 0; jHit < nHits; ++jHit) {
-	const auto& hit = vtHits.at(jHit);
-	int idPart=hit.getTrackID();
-	if(idPart==jp){
-	  int nLay=hit.getDetectorID()/4;
-	  maskHits += (1<<nLay);
-	}
+        const auto& hit = vtHits.at(jHit);
+        int idPart = hit.getTrackID();
+        if (idPart == jp) {
+          int nLay = hit.getDetectorID() / 4;
+          maskHits += (1 << nLay);
+        }
       }
-      if(maskHits == (1<<nLayers)-1){
-	double pxPart=curPart.Px();
-	double pyPart=curPart.Py();
-	double pzPart=curPart.Pz();
-	double momPart=curPart.P();
-	double phiPart=curPart.Phi();
-	double thetaPart=std::acos(pzPart/momPart);
-	double etaPart=-std::log(std::tan(thetaPart/2.));
-	hMomGen->Fill(momPart);
-	hEtaGen->Fill(etaPart);
+      if (maskHits == (1 << nLayers) - 1) {
+        double pxPart = curPart.Px();
+        double pyPart = curPart.Py();
+        double pzPart = curPart.Pz();
+        double momPart = curPart.P();
+        double phiPart = curPart.Phi();
+        double thetaPart = std::acos(pzPart / momPart);
+        double etaPart = -std::log(std::tan(thetaPart / 2.));
+        hMomGen->Fill(momPart);
+        hEtaGen->Fill(etaPart);
       }
     }
     tc->GetEvent(jEv);
-    tracker->findTracks(vtClus,primVert);
+    tracker->findTracks(vtClus, primVert);
     std::vector<NA6PTrack> trks = tracker->getTracks();
     int nTrks = trks.size();
-    for(int jT =0; jT < nTrks; jT++){
+    for (int jT = 0; jT < nTrks; jT++) {
       NA6PTrack tr = trks[jT];
       int idPartTrack = tr.getParticleID();
       int jIteration = tr.getCAIteration();
       if (tr.getNHits() == 5) {
-	auto curPart=mcArr->at(std::abs(idPartTrack));
-	double pxPart=curPart.Px();
-	double pyPart=curPart.Py();
-	double pzPart=curPart.Pz();
-	double momPart=curPart.P();
-	double phiPart=curPart.Phi();
-	double thetaPart=std::acos(pzPart/momPart);
-	double etaPart=-std::log(std::tan(thetaPart/2.));
-	hMomReco->Fill(momPart);
-	hEtaReco->Fill(etaPart);
-	if(jIteration >=0 && jIteration<maxIterationsCA){
-	  hMomRecoIterCA[jIteration]->Fill(momPart);
-	  hEtaRecoIterCA[jIteration]->Fill(etaPart);
-	}
-	if(idPartTrack>0){
-	  hMomGoodReco->Fill(momPart);
-	  hEtaGoodReco->Fill(etaPart);
-	}
+        auto curPart = mcArr->at(std::abs(idPartTrack));
+        double pxPart = curPart.Px();
+        double pyPart = curPart.Py();
+        double pzPart = curPart.Pz();
+        double momPart = curPart.P();
+        double phiPart = curPart.Phi();
+        double thetaPart = std::acos(pzPart / momPart);
+        double etaPart = -std::log(std::tan(thetaPart / 2.));
+        hMomReco->Fill(momPart);
+        hEtaReco->Fill(etaPart);
+        if (jIteration >= 0 && jIteration < maxIterationsCA) {
+          hMomRecoIterCA[jIteration]->Fill(momPart);
+          hEtaRecoIterCA[jIteration]->Fill(etaPart);
+        }
+        if (idPartTrack > 0) {
+          hMomGoodReco->Fill(momPart);
+          hEtaGoodReco->Fill(etaPart);
+        }
       }
     }
   }
 
   TH1F* hPurityMom = (TH1F*)hMomGoodReco->Clone("hPurityMom");
   hPurityMom->GetYaxis()->SetTitle("purity");
-  for(int iBin=1; iBin <=hMomGoodReco->GetNbinsX(); iBin++){
+  for (int iBin = 1; iBin <= hMomGoodReco->GetNbinsX(); iBin++) {
     double cg = hMomGoodReco->GetBinContent(iBin);
     double ct = hMomReco->GetBinContent(iBin);
-    if(ct == 0){
-      hPurityMom->SetBinContent(iBin,0.);
-      hPurityMom->SetBinError(iBin,0.);
-    }else{
-      double p = cg/ct;
-      double ep = std::sqrt(p * (1-p) / ct);
-      hPurityMom->SetBinContent(iBin,p);
-      hPurityMom->SetBinError(iBin,ep);
+    if (ct == 0) {
+      hPurityMom->SetBinContent(iBin, 0.);
+      hPurityMom->SetBinError(iBin, 0.);
+    } else {
+      double p = cg / ct;
+      double ep = std::sqrt(p * (1 - p) / ct);
+      hPurityMom->SetBinContent(iBin, p);
+      hPurityMom->SetBinError(iBin, ep);
     }
   }
   TH1F* hPurityEta = (TH1F*)hEtaGoodReco->Clone("hPurityEta");
   hPurityEta->GetYaxis()->SetTitle("purity");
-  for(int iBin=1; iBin <=hEtaGoodReco->GetNbinsX(); iBin++){
+  for (int iBin = 1; iBin <= hEtaGoodReco->GetNbinsX(); iBin++) {
     double cg = hEtaGoodReco->GetBinContent(iBin);
     double ct = hEtaReco->GetBinContent(iBin);
-    if(ct == 0){
-      hPurityEta->SetBinContent(iBin,0.);
-      hPurityEta->SetBinError(iBin,0.);
-    }else{
-      double p = cg/ct;
-      double ep = std::sqrt(p * (1-p) / ct);
-      hPurityEta->SetBinContent(iBin,p);
-      hPurityEta->SetBinError(iBin,ep);
+    if (ct == 0) {
+      hPurityEta->SetBinContent(iBin, 0.);
+      hPurityEta->SetBinError(iBin, 0.);
+    } else {
+      double p = cg / ct;
+      double ep = std::sqrt(p * (1 - p) / ct);
+      hPurityEta->SetBinContent(iBin, p);
+      hPurityEta->SetBinError(iBin, ep);
     }
   }
 
-  
-  TCanvas* cef = new TCanvas("cef","",1400,800);
-  cef->Divide(2,2);
+  TCanvas* cef = new TCanvas("cef", "", 1400, 800);
+  cef->Divide(2, 2);
   cef->cd(1);
-  hMomGen->SetLineColor(kGray+1);
+  hMomGen->SetLineColor(kGray + 1);
   hMomGen->SetLineWidth(3);
   hMomGen->Draw();
   hMomReco->SetLineWidth(2);
   hMomReco->Draw("same");
-  TLegend* leg = new TLegend(0.5,0.6,0.89,0.8);
-  leg->AddEntry(hMomGen,"Generated, 5 hits in VT");
-  for (int jIteration = 0; jIteration < nIterationsCA; ++jIteration){
-    if(hMomRecoIterCA[jIteration]->GetEntries() > 0) {
+  TLegend* leg = new TLegend(0.5, 0.6, 0.89, 0.8);
+  leg->AddEntry(hMomGen, "Generated, 5 hits in VT");
+  for (int jIteration = 0; jIteration < nIterationsCA; ++jIteration) {
+    if (hMomRecoIterCA[jIteration]->GetEntries() > 0) {
       hMomRecoIterCA[jIteration]->SetLineColor(colors[jIteration]);
       hMomRecoIterCA[jIteration]->SetLineWidth(2);
       hMomRecoIterCA[jIteration]->Draw("same");
-      leg->AddEntry(hMomRecoIterCA[jIteration],Form("Reconstructed Interation %d, 5 hits in VT",jIteration));
+      leg->AddEntry(hMomRecoIterCA[jIteration], Form("Reconstructed Interation %d, 5 hits in VT", jIteration));
     }
   }
   leg->Draw();
   cef->cd(2);
   TH1F* hEffMom = (TH1F*)hMomReco->Clone("hEffMom");
-  hEffMom->Divide(hMomReco,hMomGen,1.,1.,"B");
+  hEffMom->Divide(hMomReco, hMomGen, 1., 1., "B");
   hEffMom->GetYaxis()->SetTitle("Efficiency");
   hEffMom->SetStats(0);
   hEffMom->Draw();
   cef->cd(3);
-  hEtaGen->SetLineColor(kGray+1);
+  hEtaGen->SetLineColor(kGray + 1);
   hEtaGen->SetLineWidth(3);
   hEtaGen->Draw();
   hEtaReco->SetLineWidth(2);
   hEtaReco->Draw("same");
-  for (int jIteration = 0; jIteration < nIterationsCA; ++jIteration){
-    if(hEtaRecoIterCA[jIteration]->GetEntries() > 0) {
+  for (int jIteration = 0; jIteration < nIterationsCA; ++jIteration) {
+    if (hEtaRecoIterCA[jIteration]->GetEntries() > 0) {
       hEtaRecoIterCA[jIteration]->SetLineColor(colors[jIteration]);
       hEtaRecoIterCA[jIteration]->SetLineWidth(2);
       hEtaRecoIterCA[jIteration]->Draw("same");
@@ -212,31 +213,35 @@ void runTrackFinderCA(int firstEv = 0,
   }
   cef->cd(4);
   TH1F* hEffEta = (TH1F*)hEtaReco->Clone("hEffEta");
-  hEffEta->Divide(hEtaReco,hEtaGen,1.,1.,"B");
+  hEffEta->Divide(hEtaReco, hEtaGen, 1., 1., "B");
   hEffEta->GetYaxis()->SetTitle("Efficiency");
   hEffEta->SetStats(0);
   hEffEta->Draw();
 
-  TCanvas* cpu = new TCanvas("cpu","",1400,800);
-  cpu->Divide(2,2);
+  TCanvas* cpu = new TCanvas("cpu", "", 1400, 800);
+  cpu->Divide(2, 2);
   cpu->cd(1);
   hMomReco->Draw();
-  hMomGoodReco->SetLineColor(kGreen+1);;
+  hMomGoodReco->SetLineColor(kGreen + 1);
+  ;
+  hMomGoodReco->SetLineWidth(2);
   hMomGoodReco->Draw("same");
   cpu->cd(2);
   hPurityMom->GetYaxis()->SetTitle("Purity");
   hPurityMom->SetMinimum(0.8);
   hPurityMom->SetStats(0);
+  hPurityMom->SetLineWidth(2);
   hPurityMom->Draw();
   cpu->cd(3);
   hEtaReco->Draw();
-  hEtaGoodReco->SetLineColor(kGreen+1);;
+  hEtaGoodReco->SetLineColor(kGreen + 1);
+  ;
+  hEtaGoodReco->SetLineWidth(2);
   hEtaGoodReco->Draw("same");
   cpu->cd(4);
   hPurityEta->GetYaxis()->SetTitle("Purity");
   hPurityEta->SetMinimum(0.8);
   hPurityEta->SetStats(0);
+  hPurityEta->SetLineWidth(2);
   hPurityEta->Draw();
-  
 }
-    

--- a/test/runVertexerTracklets.C
+++ b/test/runVertexerTracklets.C
@@ -24,40 +24,42 @@
 
 void runVertexerTracklets(int firstEv = 0,
                           int lastEv = 999999,
-                          const char *dirSimu = "../testN6Proot/pions/latesttag")
-//			const char *dirSimu = "Angantyr") 
+                          const char* dirSimu = "../testN6Proot/bkgNA49")
+//			const char *dirSimu = "Angantyr")
 {
-  TFile* fk=new TFile(Form("%s/MCKine.root",dirSimu));
-  TTree* mcTree=(TTree*)fk->Get("mckine");
-  int nEv=mcTree->GetEntries();
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  int nEv = mcTree->GetEntries();
   std::vector<TParticle>* mcArr = nullptr;
   mcTree->SetBranchAddress("tracks", &mcArr);
 
-  TFile* fc=new TFile(Form("%s/ClustersVerTel.root",dirSimu));
-  printf("Open cluster file: %s\n",fc->GetName());
-  TTree* tc=(TTree*)fc->Get("clustersVerTel");
+  TFile* fc = new TFile(Form("%s/ClustersVerTel.root", dirSimu));
+  printf("Open cluster file: %s\n", fc->GetName());
+  TTree* tc = (TTree*)fc->Get("clustersVerTel");
   std::vector<NA6PBaseCluster> vtClus, *vtClusPtr = &vtClus;
   tc->SetBranchAddress("VerTel", &vtClusPtr);
 
-  if(lastEv>nEv || lastEv<0) lastEv=nEv;
-  if(firstEv<0) firstEv=0;
+  if (lastEv > nEv || lastEv < 0)
+    lastEv = nEv;
+  if (firstEv < 0)
+    firstEv = 0;
 
-  TH1F* hdz = new TH1F("hdz","",100,-0.5,0.5);
-  TH1F* hncontr = new TH1F("hncontr","",100,-0.5,999.5);
-  TH1F* hnvert = new TH1F("hnvert","",11,-0.5,10.5);
+  TH1F* hdz = new TH1F("hdz", "; z_{rec} - z_{gen} (cm); counts", 100, -0.5, 0.5);
+  TH1F* hncontr = new TH1F("hncontr", "; N_{contributors}; counts", 100, -0.5, 999.5);
+  TH1F* hnvert = new TH1F("hnvert", "; N_{vertices}; counts", 11, -0.5, 10.5);
 
   NA6PVerTelReconstruction* vtrec = new NA6PVerTelReconstruction();
 
-  for(int jEv=firstEv;jEv<lastEv; jEv++){
+  for (int jEv = firstEv; jEv < lastEv; jEv++) {
     mcTree->GetEvent(jEv);
     tc->GetEvent(jEv);
-    int nPart=mcArr->size();
+    int nPart = mcArr->size();
     double zVertGen = 0;
     // get primary vertex position from the Kine Tree
-    for(int jp=0; jp<nPart; jp++){
-      auto curPart=mcArr->at(jp);
-      if(curPart.IsPrimary()){
-        zVertGen =  curPart.Vz();
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      if (curPart.IsPrimary()) {
+        zVertGen = curPart.Vz();
         break;
       }
     }
@@ -66,24 +68,27 @@ void runVertexerTracklets(int firstEv = 0,
     std::vector<NA6PVertex> zVertices = vtrec->getVertices();
     int nVertices = zVertices.size();
     hnvert->Fill(nVertices);
-    int jv=0;
+    int jv = 0;
     for (auto vert : zVertices) {
       double zRec = vert.getZ();
-      if(jv == 0){
-				hdz->Fill(zRec-zVertGen);
-				hncontr->Fill(vert.getNContributors());
-			}
-      printf("Vertex %d, z = %f contrib = %d\n",jv++,zRec,vert.getNContributors());
-		}
+      if (jv == 0) {
+        hdz->Fill(zRec - zVertGen);
+        hncontr->Fill(vert.getNContributors());
+      }
+      printf("Vertex %d, z = %f contrib = %d\n", jv++, zRec, vert.getNContributors());
+    }
   }
   vtrec->closeVerticesOutput();
 
-  TCanvas* coutp= new TCanvas("coutp","",1200,600);
-  coutp->Divide(3,1);
+  TCanvas* coutp = new TCanvas("coutp", "", 1200, 600);
+  coutp->Divide(3, 1);
   coutp->cd(1);
+  hnvert->SetLineWidth(2);
   hnvert->Draw();
-  coutp->cd(2);
-  hdz->Draw();
   coutp->cd(3);
+  hdz->SetLineWidth(2);
+  hdz->Draw();
+  coutp->cd(2);
+  hncontr->SetLineWidth(2);
   hncontr->Draw();
 }


### PR DESCRIPTION
This adds the parameters of the vertexer to the NA6PRecoParam.
In addition there are a number of minor modifications and fixes to properly deal with the cases of beam shifted in x and y.
clang format applied to the modified files.