### PR TITLE
Add outward fit in the CA tracker fr VT and in the VT track

### DIFF
--- a/rec/include/NA6PTrack.h
+++ b/rec/include/NA6PTrack.h
@@ -26,108 +26,132 @@ class NA6PBaseCluster;
 class NA6PTrack
 {
  public:
-  
-  enum {kNDOF=5, kMaxLr=16};
-  enum {kY2=0,kZ2=2,kSnp2=5,kTgl2=9,kPtI2=14};
-  enum {kY,kZ,kSnp,kTgl,kPtI};
+  enum { kNDOF = 5,
+         kMaxLr = 16 };
+  enum { kY2 = 0,
+         kZ2 = 2,
+         kSnp2 = 5,
+         kTgl2 = 9,
+         kPtI2 = 14 };
+  enum { kY,
+         kZ,
+         kSnp,
+         kTgl,
+         kPtI };
 
   NA6PTrack();
-  NA6PTrack(const double *xyz, const double *pxyz, int sign, double errLoose=-1);
+  NA6PTrack(const double* xyz, const double* pxyz, int sign, double errLoose = -1);
   NA6PTrack(const NA6PTrack&) = default;
   NA6PTrack& operator=(const NA6PTrack&) = default;
   virtual ~NA6PTrack() {}
 
-  bool    init(const double *xyz, const double *pxyz, int sign, double errLoose=-1);
-  void    imposeKinematics(const double* xyzLab,const double* cosinesLab, double en, double mass, int charge);
-  void    reset(); 
-  void    resetCovariance(float err=-1.);
+  bool init(const double* xyz, const double* pxyz, int sign, double errLoose = -1);
+  void imposeKinematics(const double* xyzLab, const double* cosinesLab, double en, double mass, int charge);
+  void reset();
+  void resetCovariance(float err = -1.);
+  void setOuterParam(const ExtTrackPar& p) { mOuter = p; }
 
-  double        getMass()                  const {return mMass;}
-  double        getChi2()                  const {return mChi2;}
-  double        getChi2VT()                const { return mChi2VT; }
-  double        getChi2MS()                const { return mChi2MS; }
-  const ExtTrackPar& getTrackExtParam()    const {return mExtTrack; }
-  const double* getCovariance()            const {return mExtTrack.getCovariance(); }
-  int          getNVTHits()                const {return mNClustersVT;}
-  int          getNMSHits()                const {return mNClustersMS;}
-  int          getNTRHits()                const {return mNClustersTR;}
-  int          getNHits()                  const {return mNClusters;}
-  uint32_t     getClusterMap()             const {return mClusterMap;}
-  int          getClusterIndex(int lr)   const {return lr < kMaxLr ? mClusterIndices[lr] : -1; }
-  int          getParticleLabel(int lr)    const {return lr < kMaxLr ? mClusterPartID[lr] : -2; }
-  int          getParticleID()             const {return mParticleID;}
-  int          getCAIteration()            const {return mCAIteration;}
-  
-  double       getAlpha()                  const {return mExtTrack.getAlpha();}
-  double       getCharge()                 const {return mExtTrack.Charge();}
-  bool         negDir()                    const {return std::abs(mExtTrack.getAlpha()) > M_PI/2.;}
-  double       getXLab()                   const {return mExtTrack.getY();} 
-  double       getYLab()                   const {return mExtTrack.getZ();} 
-  double       getZLab()                   const {return negDir() ? -mExtTrack.getX():mExtTrack.getX();}
-  double       getR()                      const {double x=getXLab(),y=getYLab(),r=x*x+y*y; return r>0? std::sqrt(r):0;}
-  double       getXTF()                    const {return mExtTrack.getX();}
-  double       getYTF()                    const {return mExtTrack.getY();}
-  double       getZTF()                    const {return mExtTrack.getZ();}
-  void         getXYZ(double *xyz)         const;
-  void         getPXYZ(double *pxyz)       const;  
-  double       getP()                      const {return mExtTrack.getP();}
-  double       getSigmaX2()                const {return mExtTrack.getSigmaY2();}
-  double       getSigmaY2()                const {return mExtTrack.getSigmaZ2();}
-  double       getSigmaXY()                const {return mExtTrack.getSigmaZY();}  
-  double       getSigmaP2()                const;
-  double       getSigmaPX2()               const;
-  double       getSigmaPY2()               const;
-  double       getSigmaPZ2()               const;
-  double       getNormChi2()               const {return mNClusters<3 ? 0 :  mChi2 / ( (mNClusters<<1)-kNDOF);}
-  double       getPredictedChi2(double* p, double* cov) const {return mExtTrack.getPredictedChi2(p,cov);}
-  
-  void   setMass(double m)         {mMass = m;}
-  void   setChi2(double chi2)      {mChi2 = chi2;}
-  void   setChi2VT(double chi2)    {mChi2VT = chi2;}
-  void   setChi2MS(double chi2)    {mChi2MS = chi2;}
-  void   setParticleLabel(int idx, int lr)  { if (lr < kMaxLr) mClusterPartID[lr] = idx;}
-  void   setClusterIndex(int idx, int lr) { if (lr < kMaxLr) mClusterIndices[lr] = idx;}
-  void   setParticleID(int idx)    {mParticleID = idx;}
-  void   setCAIteration(int iter)  {mCAIteration = iter;}
+  double getMass() const { return mMass; }
+  double getChi2() const { return mChi2; }
+  double getChi2VT() const { return mChi2VT; }
+  double getChi2MS() const { return mChi2MS; }
+  const ExtTrackPar& getTrackExtParam() const { return mExtTrack; }
+  const double* getCovariance() const { return mExtTrack.getCovariance(); }
+  const ExtTrackPar& getOuterParam() const { return mOuter; }
+  ExtTrackPar& getOuterParam() { return mOuter; }
+  int getNVTHits() const { return mNClustersVT; }
+  int getNMSHits() const { return mNClustersMS; }
+  int getNTRHits() const { return mNClustersTR; }
+  int getNHits() const { return mNClusters; }
+  uint32_t getClusterMap() const { return mClusterMap; }
+  int getClusterIndex(int lr) const { return lr < kMaxLr ? mClusterIndices[lr] : -1; }
+  int getParticleLabel(int lr) const { return lr < kMaxLr ? mClusterPartID[lr] : -2; }
+  int getParticleID() const { return mParticleID; }
+  int getCAIteration() const { return mCAIteration; }
 
-  static void lab2trk(const double *vLab, double *vTrk); 
-  static void trk2lab(const double *vTrk, double *vLab); 
+  double getAlpha() const { return mExtTrack.getAlpha(); }
+  double getCharge() const { return mExtTrack.Charge(); }
+  bool negDir() const { return std::abs(mExtTrack.getAlpha()) > M_PI / 2.; }
+  double getXLab() const { return mExtTrack.getY(); }
+  double getYLab() const { return mExtTrack.getZ(); }
+  double getZLab() const { return negDir() ? -mExtTrack.getX() : mExtTrack.getX(); }
+  double getR() const
+  {
+    double x = getXLab(), y = getYLab(), r = x * x + y * y;
+    return r > 0 ? std::sqrt(r) : 0;
+  }
+  double getXTF() const { return mExtTrack.getX(); }
+  double getYTF() const { return mExtTrack.getY(); }
+  double getZTF() const { return mExtTrack.getZ(); }
+  void getXYZ(double* xyz) const;
+  void getPXYZ(double* pxyz) const;
+  double getP() const { return mExtTrack.getP(); }
+  double getSigmaX2() const { return mExtTrack.getSigmaY2(); }
+  double getSigmaY2() const { return mExtTrack.getSigmaZ2(); }
+  double getSigmaXY() const { return mExtTrack.getSigmaZY(); }
+  double getSigmaP2() const;
+  double getSigmaPX2() const;
+  double getSigmaPY2() const;
+  double getSigmaPZ2() const;
+  double getNormChi2() const { return mNClusters < 3 ? 0 : mChi2 / ((mNClusters << 1) - kNDOF); }
+  double getPredictedChi2(double* p, double* cov) const { return mExtTrack.getPredictedChi2(p, cov); }
+
+  void setMass(double m) { mMass = m; }
+  void setChi2(double chi2) { mChi2 = chi2; }
+  void setChi2VT(double chi2) { mChi2VT = chi2; }
+  void setChi2MS(double chi2) { mChi2MS = chi2; }
+  void setParticleLabel(int idx, int lr)
+  {
+    if (lr < kMaxLr)
+      mClusterPartID[lr] = idx;
+  }
+  void setClusterIndex(int idx, int lr)
+  {
+    if (lr < kMaxLr)
+      mClusterIndices[lr] = idx;
+  }
+  void setParticleID(int idx) { mParticleID = idx; }
+  void setCAIteration(int iter) { mCAIteration = iter; }
+
+  static void lab2trk(const double* vLab, double* vTrk);
+  static void trk2lab(const double* vTrk, double* vLab);
 
   template <typename ClusterType>
-  void   addCluster(const ClusterType* clu, int cluIndex, double chi2);
-  bool   correctForMeanMaterial(double xOverX0, double xTimesRho, bool anglecorr = false){
+  void addCluster(const ClusterType* clu, int cluIndex, double chi2);
+  bool correctForMeanMaterial(double xOverX0, double xTimesRho, bool anglecorr = false)
+  {
     return mExtTrack.correctForMeanMaterial(xOverX0, xTimesRho, mMass, anglecorr);
   }
-  bool   propagateToZBxByBz(double z, double maxDZ=1.0, double xOverX0=0., double xTimesRho=0.);
-  bool   propagateToZBxByBz(double z, const double *bxyz){return mExtTrack.propagateToBxByBz(z,bxyz);}
-  bool   propagateToDCA(NA6PTrack* partner);
-  bool   update(double p[2],double cov[3]) {return mExtTrack.Update(p,cov);}
+  bool propagateToZBxByBz(double z, double maxDZ = 1.0, double xOverX0 = 0., double xTimesRho = 0.);
+  bool propagateToZBxByBz(double z, const double* bxyz) { return mExtTrack.propagateToBxByBz(z, bxyz); }
+  bool propagateToDCA(NA6PTrack* partner);
+  bool update(double p[2], double cov[3]) { return mExtTrack.Update(p, cov); }
 
-  virtual void  print() const;
+  virtual void print() const;
   std::string asString() const;
 
-  
  protected:
-  double   mMass = 0.140;                        // particle mass
-  double   mChi2 = 0.f;                          // total chi2
-  double   mChi2VT = 0.f;                        // total chi2 VT
-  double   mChi2MS = 0.f;                        // total chi2 MS
-  uint32_t mClusterMap = 0;                      // pattern of clusters per layer
-  int      mNClusters = 0;                       // total hits
-  int      mNClustersVT = 0;                     // total VT hits
-  int      mNClustersMS = 0;                     // total MS hits
-  int      mNClustersTR = 0;                     // total TR hits
-  std::array<int, kMaxLr> mClusterIndices{};   // cluster indices
-  std::array<int, kMaxLr> mClusterPartID{};    // particle ID (per cluster)
-  int      mParticleID = -1;                     // particle ID (MC truth)
-  int      mCAIteration = -1;                    //! CA iteration (for debug)
-  ExtTrackPar mExtTrack;                         // track params
-  
-  ClassDefNV(NA6PTrack,1)
+  double mMass = 0.140;                      // particle mass
+  double mChi2 = 0.f;                        // total chi2
+  double mChi2VT = 0.f;                      // total chi2 VT
+  double mChi2MS = 0.f;                      // total chi2 MS
+  uint32_t mClusterMap = 0;                  // pattern of clusters per layer
+  int mNClusters = 0;                        // total hits
+  int mNClustersVT = 0;                      // total VT hits
+  int mNClustersMS = 0;                      // total MS hits
+  int mNClustersTR = 0;                      // total TR hits
+  std::array<int, kMaxLr> mClusterIndices{}; // cluster indices
+  std::array<int, kMaxLr> mClusterPartID{};  // particle ID (per cluster)
+  int mParticleID = -1;                      // particle ID (MC truth)
+  int mCAIteration = -1;                     //! CA iteration (for debug)
+  ExtTrackPar mExtTrack;                     // track params
+  ExtTrackPar mOuter{};                      // parametrization for outward fit
+
+  ClassDefNV(NA6PTrack, 1)
 };
 
 //_______________________________________________________________________
-inline void  NA6PTrack::lab2trk(const double *vLab, double *vTrk)
+inline void NA6PTrack::lab2trk(const double* vLab, double* vTrk)
 {
   // convert alice coordinates to modified
   vTrk[0] = vLab[2];
@@ -136,7 +160,7 @@ inline void  NA6PTrack::lab2trk(const double *vLab, double *vTrk)
 }
 
 //_______________________________________________________________________
-inline void  NA6PTrack::trk2lab(const double *vTrk, double *vLab)
+inline void NA6PTrack::trk2lab(const double* vTrk, double* vLab)
 {
   // convert modified coordinates to Lab ones
   vLab[0] = vTrk[1];
@@ -145,7 +169,7 @@ inline void  NA6PTrack::trk2lab(const double *vTrk, double *vLab)
 }
 
 //_______________________________________________________________________
-inline void NA6PTrack::getXYZ(double *xyz) const
+inline void NA6PTrack::getXYZ(double* xyz) const
 {
   // track position in Lab coordinates
   double xyzTrk[3];
@@ -154,7 +178,7 @@ inline void NA6PTrack::getXYZ(double *xyz) const
 }
 
 //_______________________________________________________________________
-inline void NA6PTrack::getPXYZ(double *pxyz) const
+inline void NA6PTrack::getPXYZ(double* pxyz) const
 {
   // track position in Lab coordinates
   double pxyzTrk[3];
@@ -162,6 +186,4 @@ inline void NA6PTrack::getPXYZ(double *pxyz) const
   trk2lab(pxyzTrk, pxyz);
 }
 
-
 #endif
-

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -29,10 +29,10 @@ struct TrackletCandidate {
   int startingLayer;
   int firstClusterIndex;
   int secondClusterIndex;
-  double tanL;
-  double phi;
-  double pxpz;
-  double pypz;
+  float tanL;
+  float phi;
+  float pxpz;
+  float pypz;
 };
 
 struct CellCandidate {
@@ -59,7 +59,7 @@ struct TrackFitted {
   std::vector<int> cluIDs;
   NA6PTrack trackFitFast;
   //    genfit::Track trackFit;
-  double chi2ndf;
+  float chi2ndf;
 };
 
 enum class ExtendDirection { kInward,
@@ -82,15 +82,15 @@ class NA6PTrackerCA
   void setZForOutwardPropagation(float zout) { mZOutProp = zout; }
   void setNumberOfIterations(int nIter);
   void setIterationParams(int iter,
-                          double maxDeltaThetaTracklets,
-                          double maxDeltaPhiTracklets,
-                          double maxDeltaTanLCells,
-                          double maxDeltaPhiCells,
-                          double maxDeltaPxPzCells,
-                          double maxDeltaPyPzCells,
-                          double maxChi2TrClCells,
-                          double maxChi2ndfCells,
-                          double maxChi2ndfTracks,
+                          float maxDeltaThetaTracklets,
+                          float maxDeltaPhiTracklets,
+                          float maxDeltaTanLCells,
+                          float maxDeltaPhiCells,
+                          float maxDeltaPxPzCells,
+                          float maxDeltaPyPzCells,
+                          float maxChi2TrClCells,
+                          float maxChi2ndfCells,
+                          float maxChi2ndfTracks,
                           int minNClusTracks);
   void configureFromRecoParam(const std::string& filename = "");
   void setVerbosity(bool opt = true) { mVerbose = opt; }
@@ -121,43 +121,43 @@ class NA6PTrackerCA
                              const std::vector<int>& firstIndex,
                              const std::vector<int>& lastIndex,
                              std::vector<TrackletCandidate>& tracklets,
-                             double deltaThetaMax,
-                             double deltaPhiMax);
+                             float deltaThetaMax,
+                             float deltaPhiMax);
   template <typename ClusterType>
   void computeLayerCells(const std::vector<TrackletCandidate>& tracklets,
                          const std::vector<int>& firstIndex,
                          const std::vector<int>& lastIndex,
                          const std::vector<ClusterType>& cluArr,
                          std::vector<CellCandidate>& cells,
-                         double deltaTanLMax,
-                         double deltaPhiMax,
-                         double deltaPxPzMax,
-                         double deltaPyPzMax,
-                         double maxChi2TrClu,
-                         double maxChi2NDF);
+                         float deltaTanLMax,
+                         float deltaPhiMax,
+                         float deltaPxPzMax,
+                         float deltaPyPzMax,
+                         float maxChi2TrClu,
+                         float maxChi2NDF);
   template <typename ClusterType>
-  double computeTrackToClusterChi2(const NA6PTrack& track,
-                                   const ClusterType& clu);
+  float computeTrackToClusterChi2(const NA6PTrack& track,
+                                  const ClusterType& clu);
   template <typename ClusterType>
   bool fitTrackPointsFast(const std::vector<int>& cluIDs,
                           const std::vector<ClusterType>& cluArr,
                           NA6PTrack& fitTrack,
-                          double maxChi2TrClu,
-                          double maxChi2NDF);
+                          float maxChi2TrClu,
+                          float maxChi2NDF);
   template <typename ClusterType>
   void findCellsNeighbours(const std::vector<CellCandidate>& cells,
                            const std::vector<int>& firstIndex,
                            const std::vector<int>& lastIndex,
                            std::vector<std::pair<int, int>>& cneigh,
                            const std::vector<ClusterType>& cluArr,
-                           double maxChi2TrClu);
+                           float maxChi2TrClu);
   template <typename ClusterType>
   std::vector<TrackCandidate> prolongSeed(const TrackCandidate& seed,
                                           const std::vector<CellCandidate>& cells,
                                           const std::vector<int>& firstIndex,
                                           const std::vector<int>& lastIndex,
                                           const std::vector<ClusterType>& cluArr,
-                                          double maxChi2TrClu,
+                                          float maxChi2TrClu,
                                           ExtendDirection dir);
   template <typename ClusterType>
   void findRoads(const std::vector<std::pair<int, int>>& cneigh,
@@ -167,14 +167,14 @@ class NA6PTrackerCA
                  const std::vector<TrackletCandidate>& tracklets,
                  const std::vector<ClusterType>& cluArr,
                  std::vector<TrackCandidate>& trackCands,
-                 double maxChi2TrClu);
+                 float maxChi2TrClu);
   template <typename ClusterType>
   void fitAndSelectTracks(const std::vector<TrackCandidate>& trackCands,
                           const std::vector<ClusterType>& cluArr,
                           std::vector<TrackFitted>& tracks,
-                          double maxChi2TrClu,
+                          float maxChi2TrClu,
                           int minNClu,
-                          double maxChi2NDF);
+                          float maxChi2NDF);
   template <typename T, typename ClusterType>
   void printStats(const std::vector<T>& candidates,
                   const std::vector<ClusterType>& cluArr,
@@ -185,7 +185,7 @@ class NA6PTrackerCA
  private:
   int mNLayers = 5;
   int mLayerStart = 0;
-  double mPrimVertPos[3] = {};
+  float mPrimVertPos[3] = {};
   NA6PFastTrackFitter* mTrackFitter = nullptr;
   std::vector<bool> mIsClusterUsed = {};
   std::vector<TrackFitted> mFinalTracks = {};
@@ -195,15 +195,15 @@ class NA6PTrackerCA
   bool mDoOutwardPropagation = false;
   float mZOutProp = 40.;
   int mNIterationsCA = 2;
-  double mMaxDeltaThetaTrackletsCA[kMaxIterationsCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxDeltaPhiTrackletsCA[kMaxIterationsCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxDeltaTanLCellsCA[kMaxIterationsCA] = {4., 9., 18., 40., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxDeltaPhiCellsCA[kMaxIterationsCA] = {0.4, 0.6, 1.2, 2.4, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxDeltaPxPzCellsCA[kMaxIterationsCA] = {0.02, 0.05, 0.1, 0.2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxDeltaPyPzCellsCA[kMaxIterationsCA] = {2e-3, 7.5e-3, 1.5e-2, 3.e-2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxChi2TrClCellsCA[kMaxIterationsCA] = {100., 500., 999., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxChi2ndfCellsCA[kMaxIterationsCA] = {100., 500., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
-  double mMaxChi2ndfTracksCA[kMaxIterationsCA] = {100., 500., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float mMaxDeltaThetaTrackletsCA[kMaxIterationsCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float mMaxDeltaPhiTrackletsCA[kMaxIterationsCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float mMaxDeltaTanLCellsCA[kMaxIterationsCA] = {4., 9., 18., 40., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float mMaxDeltaPhiCellsCA[kMaxIterationsCA] = {0.4, 0.6, 1.2, 2.4, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float mMaxDeltaPxPzCellsCA[kMaxIterationsCA] = {0.02, 0.05, 0.1, 0.2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float mMaxDeltaPyPzCellsCA[kMaxIterationsCA] = {2e-3, 7.5e-3, 1.5e-2, 3.e-2, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float mMaxChi2TrClCellsCA[kMaxIterationsCA] = {100., 500., 999., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float mMaxChi2ndfCellsCA[kMaxIterationsCA] = {100., 500., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
+  float mMaxChi2ndfTracksCA[kMaxIterationsCA] = {100., 500., 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   int mMinNClusTracksCA[kMaxIterationsCA] = {5, 3, 0, 0, 0, 0, 0, 0, 0, 0};
 
   ClassDefNV(NA6PTrackerCA, 1);

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -78,6 +78,8 @@ class NA6PTrackerCA
   void setStartLayer(int start) { mLayerStart = start; }
   void setMaxNumberOfSharedClusters(int n) { mMaxSharedClusters = n; }
   void setPropagateTracksToPrimaryVertex(bool opt = true) { mPropagateTracksToPrimaryVertex = opt; }
+  void setDoOutwardPropagation(bool opt = true) { mDoOutwardPropagation = opt; }
+  void setZForOutwardPropagation(float zout) { mZOutProp = zout; }
   void setNumberOfIterations(int nIter);
   void setIterationParams(int iter,
                           double maxDeltaThetaTracklets,
@@ -190,6 +192,8 @@ class NA6PTrackerCA
   int mMaxSharedClusters = 0;
   bool mVerbose = false;
   bool mPropagateTracksToPrimaryVertex = false;
+  bool mDoOutwardPropagation = false;
+  float mZOutProp = 40.;
   int mNIterationsCA = 2;
   double mMaxDeltaThetaTrackletsCA[kMaxIterationsCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   double mMaxDeltaPhiTrackletsCA[kMaxIterationsCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};

--- a/rec/src/NA6PFastTrackFitter.cxx
+++ b/rec/src/NA6PFastTrackFitter.cxx
@@ -499,6 +499,7 @@ NA6PTrack* NA6PFastTrackFitter::fitTrackPoints(int dir, NA6PTrack* seed)
   }
   NA6PTrack* currTr = nullptr;
   if (seed) {
+    // Seed provided as a track from previous pass
     currTr = new NA6PTrack(*seed);
     mIsSeedSet = true;
   } else {

--- a/rec/src/NA6PTrackerCA.cxx
+++ b/rec/src/NA6PTrackerCA.cxx
@@ -58,15 +58,15 @@ void NA6PTrackerCA::setNumberOfIterations(int nIter)
     LOGP(error, "Number of iterations should be <= {}", kMaxIterationsCA);
 }
 void NA6PTrackerCA::setIterationParams(int iter,
-                                       double maxDeltaThetaTracklets,
-                                       double maxDeltaPhiTracklets,
-                                       double maxDeltaTanLCells,
-                                       double maxDeltaPhiCells,
-                                       double maxDeltaPxPzCells,
-                                       double maxDeltaPyPzCells,
-                                       double maxChi2TrClCells,
-                                       double maxChi2ndfCells,
-                                       double maxChi2ndfTracks,
+                                       float maxDeltaThetaTracklets,
+                                       float maxDeltaPhiTracklets,
+                                       float maxDeltaTanLCells,
+                                       float maxDeltaPhiCells,
+                                       float maxDeltaPxPzCells,
+                                       float maxDeltaPyPzCells,
+                                       float maxChi2TrClCells,
+                                       float maxChi2ndfCells,
+                                       float maxChi2ndfTracks,
                                        int minNClusTracks)
 {
   if (iter < 0 || iter >= mNIterationsCA) {
@@ -191,21 +191,21 @@ void NA6PTrackerCA::sortClustersByLayerAndEta(std::vector<ClusterType>& cluArr,
   }
   cluArr = std::move(reordered);
   // sort by theta within each layer (use z^2/r^2 as a proxy of theta to avoid sqrt and atan)
-  const double pvx = mPrimVertPos[0];
-  const double pvy = mPrimVertPos[1];
-  const double pvz = mPrimVertPos[2];
+  const float pvx = mPrimVertPos[0];
+  const float pvy = mPrimVertPos[1];
+  const float pvz = mPrimVertPos[2];
   for (int jLay = 0; jLay < mNLayers; jLay++) {
     auto first = cluArr.begin() + firstIndex[jLay];
     auto last = cluArr.begin() + lastIndex[jLay];
     std::sort(first, last, [pvx, pvy, pvz](const ClusterType& a, const ClusterType& b) {
-      double xa = a.getX() - pvx;
-      double ya = a.getY() - pvy;
-      double za = a.getZ() - pvz;
-      double xb = b.getX() - pvx;
-      double yb = b.getY() - pvy;
-      double zb = b.getZ() - pvz;
-      double r2a = xa * xa + ya * ya;
-      double r2b = xb * xb + yb * yb;
+      float xa = a.getX() - pvx;
+      float ya = a.getY() - pvy;
+      float za = a.getZ() - pvz;
+      float xb = b.getX() - pvx;
+      float yb = b.getY() - pvy;
+      float zb = b.getZ() - pvz;
+      float r2a = xa * xa + ya * ya;
+      float r2b = xb * xb + yb * yb;
       return za * za * r2b < zb * zb * r2a;
     });
   }
@@ -304,14 +304,14 @@ void NA6PTrackerCA::computeLayerTracklets(const std::vector<ClusterType>& cluArr
                                           const std::vector<int>& firstIndex,
                                           const std::vector<int>& lastIndex,
                                           std::vector<TrackletCandidate>& tracklets,
-                                          double deltaThetaMax,
-                                          double deltaPhiMax)
+                                          float deltaThetaMax,
+                                          float deltaPhiMax)
 {
 
   tracklets.clear();
-  const double pvx = mPrimVertPos[0];
-  const double pvy = mPrimVertPos[1];
-  const double pvz = mPrimVertPos[2];
+  const float pvx = mPrimVertPos[0];
+  const float pvy = mPrimVertPos[1];
+  const float pvz = mPrimVertPos[2];
 
   for (int iLayer = 0; iLayer < mNLayers - 1; ++iLayer) {
     auto layerBegin = cluArr.begin() + firstIndex[iLayer + 1];
@@ -320,31 +320,31 @@ void NA6PTrackerCA::computeLayerTracklets(const std::vector<ClusterType>& cluArr
       if (mIsClusterUsed[jClu1])
         continue;
       const ClusterType& clu1 = cluArr[jClu1];
-      double x1 = clu1.getX() - pvx;
-      double y1 = clu1.getY() - pvy;
-      double z1 = clu1.getZ() - pvz;
-      double r1 = std::sqrt(x1 * x1 + y1 * y1);
-      double theta1 = std::atan2(z1, r1);
-      double phi1 = std::atan2(y1, x1);
-      double tanth2Min = std::max(0., std::tan(theta1 - 1.2 * deltaThetaMax)); // 1.2 is a safety margin, the tan(theta) range is limited at zero to protect for the case in which theta1 - 1.2 * deltaThetaMax is <0, which would give a negative tangent. The minimum acceptable value for theta is 0
-      double tanth2Max = std::tan(theta1 + 1.2 * deltaThetaMax);
+      float x1 = clu1.getX() - pvx;
+      float y1 = clu1.getY() - pvy;
+      float z1 = clu1.getZ() - pvz;
+      float r1 = std::sqrt(x1 * x1 + y1 * y1);
+      float theta1 = std::atan2(z1, r1);
+      float phi1 = std::atan2(y1, x1);
+      float tanth2Min = std::max(0.f, std::tan(theta1 - 1.2f * deltaThetaMax)); // 1.2 is a safety margin, the tan(theta) range is limited at zero to protect for the case in which theta1 - 1.2 * deltaThetaMax is <0, which would give a negative tangent. The minimum acceptable value for theta is 0
+      float tanth2Max = std::tan(theta1 + 1.2f * deltaThetaMax);
       auto lower = std::partition_point(layerBegin, layerEnd,
                                         [pvx, pvy, pvz, tanth2Min](const ClusterType& clu) {
-                                          double x = clu.getX() - pvx;
-                                          double y = clu.getY() - pvy;
-                                          double z = clu.getZ() - pvz;
-                                          double r2 = x * x + y * y;
-                                          double tan2 = z * z / r2;
+                                          float x = clu.getX() - pvx;
+                                          float y = clu.getY() - pvy;
+                                          float z = clu.getZ() - pvz;
+                                          float r2 = x * x + y * y;
+                                          float tan2 = z * z / r2;
                                           return tan2 < tanth2Min * tanth2Min;
                                         });
 
       auto upper = std::partition_point(layerBegin, layerEnd,
                                         [pvx, pvy, pvz, tanth2Max](const ClusterType& clu) {
-                                          double x = clu.getX() - pvx;
-                                          double y = clu.getY() - pvy;
-                                          double z = clu.getZ() - pvz;
-                                          double r2 = x * x + y * y;
-                                          double tan2 = z * z / r2;
+                                          float x = clu.getX() - pvx;
+                                          float y = clu.getY() - pvy;
+                                          float z = clu.getZ() - pvz;
+                                          float r2 = x * x + y * y;
+                                          float tan2 = z * z / r2;
                                           return tan2 <= tanth2Max * tanth2Max;
                                         });
       int lowerIdx = std::distance(cluArr.begin(), lower);
@@ -353,22 +353,22 @@ void NA6PTrackerCA::computeLayerTracklets(const std::vector<ClusterType>& cluArr
         if (mIsClusterUsed[jClu2])
           continue;
         const ClusterType& clu2 = cluArr[jClu2];
-        double x2 = clu2.getX() - pvx;
-        double y2 = clu2.getY() - pvy;
-        double z2 = clu2.getZ() - pvz;
-        double r2 = std::sqrt(x2 * x2 + y2 * y2);
-        double theta2 = std::atan2(z2, r2);
-        double phi2 = std::atan2(y2, x2);
-        double dphi = phi2 - phi1;
+        float x2 = clu2.getX() - pvx;
+        float y2 = clu2.getY() - pvy;
+        float z2 = clu2.getZ() - pvz;
+        float r2 = std::sqrt(x2 * x2 + y2 * y2);
+        float theta2 = std::atan2(z2, r2);
+        float phi2 = std::atan2(y2, x2);
+        float dphi = phi2 - phi1;
         if (dphi > M_PI)
           dphi -= 2 * M_PI;
         else if (dphi < -M_PI)
           dphi += 2 * M_PI;
         if (std::abs(theta2 - theta1) < deltaThetaMax && std::abs(dphi) < deltaPhiMax) {
-          double phi = std::atan2(y2 - y1, x2 - x1);
-          double tanL = (z2 - z1) / (r2 - r1);
-          double pxpz = (x2 - x1) / (z2 - z1);
-          double pypz = (y2 - y1) / (z2 - z1);
+          float phi = std::atan2(y2 - y1, x2 - x1);
+          float tanL = (z2 - z1) / (r2 - r1);
+          float pxpz = (x2 - x1) / (z2 - z1);
+          float pypz = (y2 - y1) / (z2 - z1);
           tracklets.emplace_back(iLayer, jClu1, jClu2, tanL, phi, pxpz, pypz);
           // do not assign the clusters as used, it will be done when the tracklets are used into tracks
           // mIsClusterUsed[jClu1] = true;
@@ -387,12 +387,12 @@ void NA6PTrackerCA::computeLayerCells(const std::vector<TrackletCandidate>& trac
                                       const std::vector<int>& lastIndex,
                                       const std::vector<ClusterType>& cluArr,
                                       std::vector<CellCandidate>& cells,
-                                      double deltaTanLMax,
-                                      double deltaPhiMax,
-                                      double deltaPxPzMax,
-                                      double deltaPyPzMax,
-                                      double maxChi2TrClu,
-                                      double maxChi2NDF)
+                                      float deltaTanLMax,
+                                      float deltaPhiMax,
+                                      float deltaPxPzMax,
+                                      float deltaPyPzMax,
+                                      float maxChi2TrClu,
+                                      float maxChi2NDF)
 {
 
   cells.clear();
@@ -415,14 +415,14 @@ void NA6PTrackerCA::computeLayerCells(const std::vector<TrackletCandidate>& trac
         const TrackletCandidate& trkl2 = *it;
         if (trkl2.firstClusterIndex != nextLayerClusterIndex)
           continue;
-        const double deltaTanLambda = std::abs(trkl2.tanL - trkl1.tanL);
-        double dphi = trkl2.phi - trkl1.phi;
+        const float deltaTanLambda = std::abs(trkl2.tanL - trkl1.tanL);
+        float dphi = trkl2.phi - trkl1.phi;
         if (dphi > M_PI)
           dphi -= 2 * M_PI;
         else if (dphi < -M_PI)
           dphi += 2 * M_PI;
-        double deltapxpz = std::abs(trkl2.pxpz - trkl1.pxpz);
-        double deltapypz = std::abs(trkl2.pypz - trkl1.pypz);
+        float deltapxpz = std::abs(trkl2.pxpz - trkl1.pxpz);
+        float deltapypz = std::abs(trkl2.pypz - trkl1.pypz);
         if (deltapypz < deltaPyPzMax && deltapxpz < deltaPxPzMax && deltaTanLambda < deltaTanLMax && std::abs(dphi) < deltaPhiMax) {
           std::array<int, 3> cluIDs = {trkl1.firstClusterIndex, trkl2.firstClusterIndex, trkl2.secondClusterIndex};
           NA6PTrack fitTrackFast;
@@ -439,15 +439,15 @@ void NA6PTrackerCA::computeLayerCells(const std::vector<TrackletCandidate>& trac
 //______________________________________________________________________
 
 template <typename ClusterType>
-double NA6PTrackerCA::computeTrackToClusterChi2(const NA6PTrack& track,
-                                                const ClusterType& clu)
+float NA6PTrackerCA::computeTrackToClusterChi2(const NA6PTrack& track,
+                                               const ClusterType& clu)
 {
 
   double meas[2] = {clu.getYTF(), clu.getZTF()}; // ideal cluster coordinate, tracking (AliExtTrParam frame)
   double measErr2[3] = {clu.getSigYY(), clu.getSigYZ(), clu.getSigZZ()};
   NA6PTrack copyToProp = track;
   copyToProp.propagateToZBxByBz(clu.getZ()); // no material correction temporarily
-  double cluchi2 = copyToProp.getTrackExtParam().getPredictedChi2(meas, measErr2);
+  float cluchi2 = copyToProp.getTrackExtParam().getPredictedChi2(meas, measErr2);
   return cluchi2;
 }
 
@@ -457,8 +457,8 @@ template <typename ClusterType>
 bool NA6PTrackerCA::fitTrackPointsFast(const std::vector<int>& cluIDs,
                                        const std::vector<ClusterType>& cluArr,
                                        NA6PTrack& fitTrack,
-                                       double maxChi2TrClu,
-                                       double maxChi2NDF)
+                                       float maxChi2TrClu,
+                                       float maxChi2NDF)
 {
 
   int nClus = cluIDs.size();
@@ -478,7 +478,7 @@ bool NA6PTrackerCA::fitTrackPointsFast(const std::vector<int>& cluIDs,
   if (!fitTrackPtr)
     return false;
 
-  double chi2ndf = fitTrackPtr->getNormChi2();
+  float chi2ndf = fitTrackPtr->getNormChi2();
   if (chi2ndf > maxChi2NDF)
     return false;
 
@@ -494,7 +494,7 @@ void NA6PTrackerCA::findCellsNeighbours(const std::vector<CellCandidate>& cells,
                                         const std::vector<int>& lastIndex,
                                         std::vector<std::pair<int, int>>& cneigh,
                                         const std::vector<ClusterType>& cluArr,
-                                        double maxChi2TrClu)
+                                        float maxChi2TrClu)
 {
 
   cneigh.clear();
@@ -524,13 +524,13 @@ void NA6PTrackerCA::findCellsNeighbours(const std::vector<CellCandidate>& cells,
         //   because we have the track parameterization at the innermost point of each cell
         // int jClu2 = cell2.cluIDs[2];
         // const auto& clu2 = cluArr[jClu2];
-        // double cluchi2a = computeTrackToClusterChi2(cell1.trackFitFast, clu2);
+        // float cluchi2a = computeTrackToClusterChi2(cell1.trackFitFast, clu2);
         // if (cluchi2a > maxChi2TrClu)
         //   continue;
 
         int jClu0 = cell1.cluIDs[0];
         const auto& clu0 = cluArr[jClu0];
-        double cluchi2b = computeTrackToClusterChi2(cell2.trackFitFast, clu0);
+        float cluchi2b = computeTrackToClusterChi2(cell2.trackFitFast, clu0);
         if (cluchi2b > maxChi2TrClu)
           continue;
 
@@ -548,7 +548,7 @@ std::vector<TrackCandidate> NA6PTrackerCA::prolongSeed(const TrackCandidate& see
                                                        const std::vector<int>& firstIndex,
                                                        const std::vector<int>& lastIndex,
                                                        const std::vector<ClusterType>& cluArr,
-                                                       double maxChi2TrClu,
+                                                       float maxChi2TrClu,
                                                        ExtendDirection dir)
 {
 
@@ -594,7 +594,7 @@ std::vector<TrackCandidate> NA6PTrackerCA::prolongSeed(const TrackCandidate& see
         // Compute chi2 only for the innermost cluster of the cells to be connected
         const auto& fitCurr = (dir == ExtendDirection::kInward) ? refCell.trackFitFast : ccNext.trackFitFast;
         const auto& cluToAdd = (dir == ExtendDirection::kInward) ? cluArr[ccNext.cluIDs[0]] : cluArr[refCell.cluIDs[0]];
-        double chi2 = computeTrackToClusterChi2(fitCurr, cluToAdd);
+        float chi2 = computeTrackToClusterChi2(fitCurr, cluToAdd);
         if (chi2 > maxChi2TrClu)
           continue;
 
@@ -635,7 +635,7 @@ void NA6PTrackerCA::findRoads(const std::vector<std::pair<int, int>>& cneigh,
                               const std::vector<TrackletCandidate>& tracklets,
                               const std::vector<ClusterType>& cluArr,
                               std::vector<TrackCandidate>& trackCands,
-                              double maxChi2TrClu)
+                              float maxChi2TrClu)
 {
 
   trackCands.clear();
@@ -710,9 +710,9 @@ template <typename ClusterType>
 void NA6PTrackerCA::fitAndSelectTracks(const std::vector<TrackCandidate>& trackCands,
                                        const std::vector<ClusterType>& cluArr,
                                        std::vector<TrackFitted>& tracks,
-                                       double maxChi2TrClu,
+                                       float maxChi2TrClu,
                                        int minNClu,
-                                       double maxChi2NDF)
+                                       float maxChi2NDF)
 {
 
   std::vector<TrackFitted> fittedTracks;
@@ -739,10 +739,10 @@ void NA6PTrackerCA::fitAndSelectTracks(const std::vector<TrackCandidate>& trackC
     if (nClus < minNClu)
       continue;
     // const genfit::AbsTrackRep* rep = fitTrack.getTrackRep(0);
-    // double chi2 = fitTrack.getFitStatus(rep)->getChi2();
-    // double ndf = fitTrack.getFitStatus(rep)->getNdf();
-    // double chi2ndf = (ndf > 0) ? chi2 / ndf : 9999.0;
-    double chi2ndf = fitTrackFast.getNormChi2();
+    // float chi2 = fitTrack.getFitStatus(rep)->getChi2();
+    // float ndf = fitTrack.getFitStatus(rep)->getNdf();
+    // float chi2ndf = (ndf > 0) ? chi2 / ndf : 9999.0;
+    float chi2ndf = fitTrackFast.getNormChi2();
     if (mDoOutwardPropagation) {
       // outward fit (needed in VT for matching to Muon Spectrometer)
       std::unique_ptr<NA6PTrack> outwRefitPtr(mTrackFitter->fitTrackPointsOutward(&fitTrackFast));
@@ -902,7 +902,7 @@ void NA6PTrackerCA::printStats(const std::vector<T>& candidates,
     LOGP(info, "Number of {} = {}", label.c_str(), nFound);
   int nGood = 0;
   int nSelected = 0;
-  double aveClus = 0;
+  float aveClus = 0;
   for (int j = 0; j < nFound; ++j) {
     const auto& tr = candidates[j];
     int nClus = -1;
@@ -964,14 +964,18 @@ void NA6PTrackerCA::printStats(const std::vector<T>& candidates,
   if (requiredClus > 0) {
     if (nSelected > 0) {
       LOGP(info, "{} with {} clus: Fraction of good = {} / {} = {}  --- average clus = {}",
-           label.c_str(), requiredClus, nGood, nSelected, (double)nGood / (double)nSelected, aveClus / (double)nSelected);
+           label.c_str(), requiredClus, nGood, nSelected,
+           static_cast<float>(nGood) / static_cast<float>(nSelected),
+           aveClus / static_cast<float>(nSelected));
     } else {
       LOGP(info, "No {} having {} clus", label.c_str(), requiredClus);
     }
   } else {
     if (nFound > 0)
       LOGP(info, "Fraction of good {} = {} / {} = {}  --- average clus = {}",
-           label.c_str(), nGood, nFound, (double)nGood / (double)nFound, aveClus / (double)nFound);
+           label.c_str(), nGood, nFound,
+           static_cast<float>(nGood) / static_cast<float>(nFound),
+           aveClus / static_cast<float>(nFound));
   }
 }
 

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -205,17 +205,16 @@ void NA6PVerTelReconstruction::closeTracksOutput()
 
 void NA6PVerTelReconstruction::runTracking()
 {
-  if (!mIsInitialized)
-  {
+  if (!mIsInitialized) {
     LOGP(error, "Magnetic field and geometry not initialized");
     return;
   }
-  if (!mVTTracker)
-  {
+  if (!mVTTracker) {
     LOGP(info, "Tracker not initialized, will call default initialization");
     initTracker();
   }
   clearTracks();
+  mVTTracker->setDoOutwardPropagation(true);
   mVTTracker->setPropagateTracksToPrimaryVertex(true);
   mVTTracker->findTracks(mClusters, mPrimaryVertex);
   mTracks = mVTTracker->getTracks();


### PR DESCRIPTION
Note the diff is large because I have also:
- applied clang format to NA6PTrack
- changes from double to float in the trackerCA, as done in the recNative branch