### PR TITLE
Add VT MS matching

### DIFF
--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -33,6 +33,7 @@ set(DICTIONARY_HEADERS
   NA6PVertexerTracklets.h
   NA6PTrackerCA.h
   NA6PFastTrackFitter.h
+  NA6PMatching.h
   ) # Add all class headers requiring dictionary
   
 set(DICTIONARY_LINKDEF ${THIS_SRC_DIR}/${MOD_NAME}LinkDef.h)

--- a/rec/include/NA6PFastTrackFitter.h
+++ b/rec/include/NA6PFastTrackFitter.h
@@ -36,7 +36,7 @@ class NA6PFastTrackFitter
   static constexpr int kMaxLayers = 20;
 
   NA6PFastTrackFitter();
-  ~NA6PFastTrackFitter(){};
+  ~NA6PFastTrackFitter() {};
 
   // setters for configurable parameters
   void setMaxChi2Cl(double v = 10) { mMaxChi2Cl = v; }
@@ -94,8 +94,13 @@ class NA6PFastTrackFitter
   NA6PTrack* fitTrackPointsInward() { return fitTrackPoints(-1); }
   NA6PTrack* fitTrackPointsOutward(NA6PTrack* seed = nullptr) { return fitTrackPoints(1, seed); }
   bool updateTrack(NA6PTrack* trc, const NA6PBaseCluster* cl) const;
-  int propagateToZ(NA6PTrack* trc, double zFrom, double zTo, int dir) const;
+
   int propagateToZ(NA6PTrack* trc, double zTo) const;
+  int propagateToZ(NA6PTrack* trc, double zFrom, double zTo, int dir) const;
+  int propagateToZOuter(NA6PTrack* trc, double zTo) const;
+  int propagateToZOuter(NA6PTrack* trc, double zFrom, double zTo, int dir) const;
+  int propagateToZImpl(NA6PTrack* trc, double zFrom, double zTo, int dir, bool outer) const;
+
   void getMeanMaterialBudgetFromGeom(double* start, double* end, double* mparam) const;
 
   static const Double_t kMassP;

--- a/rec/include/NA6PMatching.h
+++ b/rec/include/NA6PMatching.h
@@ -52,25 +52,21 @@ class NA6PMatching : public NA6PReconstruction
   void setVerTelTracks(const std::vector<NA6PTrack>& tracks)
   {
     mVerTelTracks = tracks;
-    hVerTelTrackPtr = &mVerTelTracks;
   }
 
   void setMuonSpecTracks(const std::vector<NA6PTrack>& tracks)
   {
     mMuonSpecTracks = tracks;
-    hMuonSpecTrackPtr = &mMuonSpecTracks;
   }
 
   void setVerTelClusters(const std::vector<NA6PVerTelCluster>& clusters)
   {
     mVerTelClusters = clusters;
-    hVerTelClusPtr = &mVerTelClusters;
   }
 
   void setMuonSpecClusters(const std::vector<NA6PMuonSpecCluster>& clusters)
   {
     mMuonSpecClusters = clusters;
-    hMuonSpecClusPtr = &mMuonSpecClusters;
   }
 
   bool init(const char* filename, const char* geoname = "NA6P") override;

--- a/rec/include/NA6PMatching.h
+++ b/rec/include/NA6PMatching.h
@@ -1,0 +1,130 @@
+// NA6PCCopyright
+
+// Minimal matching reconstruction driver
+
+#ifndef NA6P_MATCHING_H
+#define NA6P_MATCHING_H
+
+#include <string>
+#include <Rtypes.h>
+#include <TVector3.h>
+
+#include "NA6PReconstruction.h"
+#include "NA6PVerTelCluster.h"
+#include "NA6PMuonSpecCluster.h"
+#include "NA6PFastTrackFitter.h"
+
+#include "NA6PTrack.h"
+#include "NA6PVertex.h"
+class TH1D;
+class TH2D;
+
+class TFile;
+class TTree;
+class NA6PFastTrackFitter;
+
+class NA6PMatching : public NA6PReconstruction
+{
+ public:
+  NA6PMatching();
+  ~NA6PMatching() override = default;
+
+  void useMCMatching() { mMCMatching = true; }
+  void useChi2Matching() { mMCMatching = false; }
+
+  void setMaxChi2Match(double v) { mMaxChi2Match = v; }
+  void setMaxChi2Refit(double v) { mMaxChi2Refit = v; }
+  void setMinTrackP(double p) { mMinTrackP = p; }
+  void setMinVTHits(int n) { mMinVTHits = n; }
+  void setMinMSHits(int n) { mMinMSHits = n; }
+  void setPMatchWindow(double w) { mPMatchWindow = w; }
+  void setZMatching(double z)
+  {
+    mZMatching = z;
+    mIsZMatchingSet = true;
+  }
+
+  void setPrimaryVertexPosition(double x, double y, double z)
+  {
+    mPrimaryVertex.SetXYZ(x, y, z);
+  }
+
+  void setVerTelTracks(const std::vector<NA6PTrack>& tracks)
+  {
+    mVerTelTracks = tracks;
+    hVerTelTrackPtr = &mVerTelTracks;
+  }
+
+  void setMuonSpecTracks(const std::vector<NA6PTrack>& tracks)
+  {
+    mMuonSpecTracks = tracks;
+    hMuonSpecTrackPtr = &mMuonSpecTracks;
+  }
+
+  void setVerTelClusters(const std::vector<NA6PVerTelCluster>& clusters)
+  {
+    mVerTelClusters = clusters;
+    hVerTelClusPtr = &mVerTelClusters;
+  }
+
+  void setMuonSpecClusters(const std::vector<NA6PMuonSpecCluster>& clusters)
+  {
+    mMuonSpecClusters = clusters;
+    hMuonSpecClusPtr = &mMuonSpecClusters;
+  }
+
+  bool init(const char* filename, const char* geoname = "NA6P") override;
+
+  void createTracksOutput() override;
+  void clearTracks() override
+  {
+    mMatchedTracks.clear();
+  }
+  void writeTracks() override;
+  void closeTracksOutput() override;
+  void sortVTTracksByP(std::vector<NA6PTrack>& tracks);
+  double computeChi2(const double* par1, const double* cov1,
+                     const double* par2, const double* cov2);
+  void propToZMatching(std::vector<NA6PTrack>& tracks, double z, bool outer = false);
+  void runMatching();
+  
+  bool fitAndStoreMatchedTrack(const NA6PTrack& vtTrk, const NA6PTrack& msTrk, int particleId, double matchChi2);
+
+ private:
+  void addClustersToFitter(const NA6PTrack& trk, const auto* clusPtr);
+  void runMCMatching();
+  void runDataMatching();
+  std::unordered_map<int, int> buildMCMatchingIndex();
+
+  std::tuple<int, bool, double> findBestChi2Match(
+      const NA6PTrack& msTrack,
+      const std::vector<size_t>& validVerTelIndices);
+
+  std::vector<size_t> prefilterVerTelTracks();
+
+  std::vector<NA6PVerTelCluster> mVerTelClusters, *hVerTelClusPtr = &mVerTelClusters;         // vector of clusters
+  std::vector<NA6PMuonSpecCluster> mMuonSpecClusters, *hMuonSpecClusPtr = &mMuonSpecClusters; // vector of clusters                                                     // cluster resolution, cm (for fast simu)
+  TVector3 mPrimaryVertex{0.0, 0.0, 0.0};                                                     // primary vertex position
+  double mZMatching = 38.1175;
+  bool mIsZMatchingSet = false;
+  bool mMCMatching = true;
+  int mMinVTHits = 5;
+  int mMinMSHits = 6;
+  double mMinTrackP = 2.0;
+  double mMaxChi2Match = std::numeric_limits<double>::max();
+  double mMaxChi2Refit = std::numeric_limits<double>::max();
+  double mPMatchWindow = 3; // GeV/c
+
+  NA6PFastTrackFitter* mTrackFitter = nullptr;
+  std::vector<NA6PTrack> mVerTelTracks, *hVerTelTrackPtr = &mVerTelTracks;       // Vertex telescope tracks
+  std::vector<NA6PTrack> mMuonSpecTracks, *hMuonSpecTrackPtr = &mMuonSpecTracks; // Muon spectrometer tracks
+
+  std::vector<NA6PTrack> mMatchedTracks, *hMatchedTrackPtr = &mMatchedTracks; // Matched tracks
+
+  TFile* mMatchedTrackFile = nullptr; // file with Matched tracks
+  TTree* mMatchedTrackTree = nullptr; // tree of Matched tracks
+
+  ClassDefNV(NA6PMatching, 1);
+};
+
+#endif

--- a/rec/include/NA6PMuonSpecReconstruction.h
+++ b/rec/include/NA6PMuonSpecReconstruction.h
@@ -59,7 +59,6 @@ class NA6PMuonSpecReconstruction : public NA6PReconstruction
   void setClusters(const std::vector<NA6PMuonSpecCluster>& clusters)
   {
     mClusters = clusters;
-    hClusPtr = &mClusters;
   }
 
   void createTracksOutput() override;

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -193,7 +193,7 @@ class NA6PTrackerCA
   bool mVerbose = false;
   bool mPropagateTracksToPrimaryVertex = false;
   bool mDoOutwardPropagation = false;
-  float mZOutProp = 40.;
+  float mZOutProp = 38.1175;
   int mNIterationsCA = 2;
   float mMaxDeltaThetaTrackletsCA[kMaxIterationsCA] = {0.04, 0.1, 0.15, 0.3, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};
   float mMaxDeltaPhiTrackletsCA[kMaxIterationsCA] = {0.1, 0.2, 0.25, 0.5, 999.0, 999.0, 999.0, 999.0, 999.0, 999.0};

--- a/rec/include/NA6PVerTelReconstruction.h
+++ b/rec/include/NA6PVerTelReconstruction.h
@@ -66,7 +66,6 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   void setClusters(const std::vector<NA6PVerTelCluster>& clusters)
   {
     mClusters = clusters;
-    hClusPtr = &mClusters;
   }
   void createVerticesOutput() override;
   void clearVertices() override { mVertices.clear(); }

--- a/rec/src/NA6PFastTrackFitter.cxx
+++ b/rec/src/NA6PFastTrackFitter.cxx
@@ -220,36 +220,74 @@ int NA6PFastTrackFitter::propagateToZ(NA6PTrack* trc, double zTo) const
   return propagateToZ(trc, zCurr, zTo, dir);
 }
 
-int NA6PFastTrackFitter::propagateToZ(NA6PTrack* trc, double zFrom, double zTo, int dir) const
-{
+int NA6PFastTrackFitter::propagateToZOuter(NA6PTrack* trc, double zTo) const
+{  
+  double zCurr = trc->getZLabOuter();
+  int dir = (zTo - zCurr) > 0 ? 1 : -1;
+  return propagateToZOuter(trc, zCurr, zTo, dir);
+}
 
-  if (trc->getTrackExtParam().getAlpha() < 0)
-    return -1;
-  if (std::abs(trc->getZLab() - zFrom) > 1.e-4) {
-    LOGP(fatal, "Track is not in the expected z position: {} vs {}", zFrom, trc->getZLab());
+int NA6PFastTrackFitter::propagateToZImpl(NA6PTrack* trc, double zFrom, double zTo, int dir, bool outer) const
+{
+  // Validate track state
+  if (trc->getTrackExtParam().getAlpha() < 0) {
     return -1;
   }
+  
+  // Select appropriate methods based on parametrization
+  auto getPosition = outer ? &NA6PTrack::getXYZOuter : &NA6PTrack::getXYZ;
+  auto getZ = outer ? &NA6PTrack::getZLabOuter : &NA6PTrack::getZLab;
+  
+  double currentZ = (trc->*getZ)();
+  if (std::abs(currentZ - zFrom) > 1.e-4) {
+    LOGP(fatal, "Track is not in the expected z position: {} vs {}", zFrom, currentZ);
+    return -1;
+  }
+  
   if (dir * (zTo - zFrom) < 0) {
     LOGP(fatal, "Wrong coordinates: Dir:{} Zstart:{} Zend:{}", dir, zFrom, zTo);
     return -1;
   }
-  double start[3], end[3];
-  trc->getXYZ(start);
+
+  // Get starting position
+  double start[3];
+  (trc->*getPosition)(start);
+  
+  // Create temporary track and propagate without material to get endpoint
   NA6PTrack tmpTrc = *trc;
-  tmpTrc.propagateToZBxByBz(zTo);
-  tmpTrc.getXYZ(end);
-  double p1[3], p2[3];
-  trc->getXYZ(p1);
-  tmpTrc.getXYZ(p2);
-  double mparam[7] = {0.};
-  if (mCorrectForMaterial)
-    getMeanMaterialBudgetFromGeom(start, end, mparam);
-  double xrho = mparam[0] * mparam[4];
-  double x2x0 = mparam[1];
-  double corrELoss = 1;
-  if (!trc->propagateToZBxByBz(zTo, 1., x2x0, -dir * xrho * corrELoss))
+  if (!tmpTrc.propagateToZBxByBz(zTo, 1., 0., 0., outer)) {
     return 0;
+  }
+  
+  double end[3];
+  (tmpTrc.*getPosition)(end);
+  
+  // Calculate material budget along path
+  double mparam[7] = {0.};
+  if (mCorrectForMaterial) {
+    getMeanMaterialBudgetFromGeom(start, end, mparam);
+  }
+  
+  double xrho = mparam[0] * mparam[4];  // length * density
+  double x2x0 = mparam[1];               // X/X0
+  double corrELoss = 1.0;
+  
+  // Propagate with material corrections
+  if (!trc->propagateToZBxByBz(zTo, 1., x2x0, -dir * xrho * corrELoss, outer)) {
+    return 0;
+  }
+  
   return 1;
+}
+
+int NA6PFastTrackFitter::propagateToZ(NA6PTrack* trc, double zFrom, double zTo, int dir) const
+{
+  return propagateToZImpl(trc, zFrom, zTo, dir, false);
+}
+
+int NA6PFastTrackFitter::propagateToZOuter(NA6PTrack* trc, double zFrom, double zTo, int dir) const
+{
+  return propagateToZImpl(trc, zFrom, zTo, dir, true);
 }
 
 bool NA6PFastTrackFitter::updateTrack(NA6PTrack* trc, const NA6PBaseCluster* cl) const

--- a/rec/src/NA6PMatching.cxx
+++ b/rec/src/NA6PMatching.cxx
@@ -1,0 +1,279 @@
+// NA6PCCopyright
+
+#include "NA6PMatching.h"
+#include <TFile.h>
+#include <TTree.h>
+#include <TH1D.h>
+#include <TH2D.h>
+#include <unordered_map>
+#include <fairlogger/Logger.h>
+
+#include <TMatrixD.h>
+#include <TVectorD.h>
+
+ClassImp(NA6PMatching)
+
+  NA6PMatching::NA6PMatching() : NA6PReconstruction("Matching")
+{
+}
+
+bool NA6PMatching::init(const char* filename, const char* geoname)
+{
+  NA6PReconstruction::init(filename, geoname);
+  mTrackFitter = new NA6PFastTrackFitter();
+  mTrackFitter->loadGeometry(filename, geoname);
+  mTrackFitter->enableMaterialCorrections();
+  mTrackFitter->setPropagateToPrimaryVertex(true);
+  mTrackFitter->setNLayers(11);
+  mTrackFitter->setParticleHypothesis(13); // muon mass hypothesis
+  mTrackFitter->setMaxChi2Cl(mMaxChi2Refit);
+  return true;
+}
+
+void NA6PMatching::createTracksOutput()
+{
+  auto nm = fmt::format("Tracks{}.root", getName());
+  mMatchedTrackFile = TFile::Open(nm.c_str(), "recreate");
+  mMatchedTrackTree = new TTree(fmt::format("tracks{}", getName()).c_str(), fmt::format("{} Tracks", getName()).c_str());
+  mMatchedTrackTree->Branch(getName().c_str(), &hMatchedTrackPtr);
+  LOGP(info, "Will store {} tracks in {}", getName(), nm);
+}
+
+void NA6PMatching::writeTracks()
+{
+  if (mMatchedTrackTree) {
+    mMatchedTrackTree->Fill();
+    LOGP(info, "Saved {} tracks in tree with {} entries", mMatchedTracks.size(), mMatchedTrackTree->GetEntries());
+  }
+}
+
+void NA6PMatching::closeTracksOutput()
+{
+  if (mMatchedTrackTree && mMatchedTrackFile) {
+    mMatchedTrackFile->cd();
+    mMatchedTrackTree->Write();
+    delete mMatchedTrackTree;
+    mMatchedTrackTree = nullptr;
+    mMatchedTrackFile->Close();
+    delete mMatchedTrackFile;
+    mMatchedTrackFile = nullptr;
+  }
+}
+
+void NA6PMatching::sortVTTracksByP(std::vector<NA6PTrack>& tracks)
+{
+  std::sort(tracks.begin(), tracks.end(),
+            [](const NA6PTrack& a, const NA6PTrack& b) {
+              return a.getP() > b.getP();
+            });
+}
+
+double NA6PMatching::computeChi2(const double* par1, const double* cov1,
+                                 const double* par2, const double* cov2)
+{
+  TVectorD delta(5);
+  for (int i = 0; i < 5; ++i) {
+    delta[i] = par1[i] - par2[i];
+  }
+
+  TMatrixDSym V(5);
+  int idx = 0;
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j <= i; ++j) {
+      V(i, j) = cov1[idx] + cov2[idx];
+      ++idx;
+    }
+  }
+
+  TMatrixDSym Vinv = V.Invert();
+  if (!V.IsValid())
+    return 1e9;
+
+  return Vinv.Similarity(delta);
+}
+
+void NA6PMatching::propToZMatching(std::vector<NA6PTrack>& tracks, double z, bool outer)
+{
+  for (auto& track : tracks) {
+    if (abs(track.getZLabOuter() - z) < 1e-6)
+      continue;
+    if (outer) {
+      mTrackFitter->propagateToZOuter(&track, z);
+    } else
+      mTrackFitter->propagateToZ(&track, z);
+  }
+};
+
+void NA6PMatching::addClustersToFitter(const NA6PTrack& trk, const auto* clusPtr)
+{
+  uint32_t cmap = trk.getClusterMap();
+  for (int lr = 0; lr < NA6PTrack::kMaxLr; ++lr) {
+    if (cmap & (1u << lr)) {
+      mTrackFitter->addCluster(lr, (*clusPtr)[trk.getClusterIndex(lr)]);
+    }
+  }
+}
+
+
+std::tuple<int, bool, double> NA6PMatching::findBestChi2Match(
+  const NA6PTrack& msTrack,
+  const std::vector<size_t>& validVerTelIndices)
+{
+  const auto msPar = msTrack.getTrackExtParam().getParameter();
+  const auto msCov = msTrack.getTrackExtParam().getCovariance();
+  const int msCharge = msTrack.getCharge();
+  const float msP = msTrack.getP();
+  const int msPartId = msTrack.getParticleID();
+
+  auto lower = std::partition_point(validVerTelIndices.begin(), validVerTelIndices.end(),
+    [&](size_t vIdx) { return mVerTelTracks[vIdx].getPOuter() > msP + mPMatchWindow; });
+  
+  auto upper = std::partition_point(lower, validVerTelIndices.end(),
+    [&](size_t vIdx) { return mVerTelTracks[vIdx].getPOuter() >= msP - mPMatchWindow; });
+  
+
+  float bestChi2 = mMaxChi2Match;
+  int bestIdx = -1;
+  bool isTrueMatch = false;
+
+  for (auto it = lower; it != upper; ++it) {
+    size_t vIdx = *it;
+    const auto& vtTrack = mVerTelTracks[vIdx];
+
+    if (vtTrack.getCharge() * msCharge < 0)
+      continue;
+
+    const auto vtPar = vtTrack.getOuterParam().getParameter();
+    const auto vtCov = vtTrack.getOuterParam().getCovariance();
+    const double chi2 = computeChi2(msPar, msCov, vtPar, vtCov);
+
+    if (chi2 < bestChi2) {
+      bestChi2 = chi2;
+      bestIdx = vIdx;
+      isTrueMatch = (msPartId > 0 && vtTrack.getParticleID() == msPartId);
+    }
+  }
+
+  return {bestIdx, isTrueMatch, bestChi2};
+}
+
+std::unordered_map<int, int> NA6PMatching::buildMCMatchingIndex()
+{
+  std::unordered_map<int, int> vtByPid;
+  vtByPid.reserve(mVerTelTracks.size());
+
+  for (size_t i = 0; i < mVerTelTracks.size(); ++i) {
+    const auto& vt = mVerTelTracks[i];
+    int pid = vt.getParticleID();
+    if (pid <= 0)
+      continue;
+
+    // Prefer track with more hits if there are duplicates with same particle ID
+    auto it = vtByPid.find(pid);
+    if (it == vtByPid.end() || vt.getNHits() > mVerTelTracks[it->second].getNHits()) {
+      vtByPid[pid] = static_cast<int>(i);
+    }
+  }
+  return vtByPid;
+}
+
+std::vector<size_t> NA6PMatching::prefilterVerTelTracks()
+{
+  std::vector<size_t> validIndices;
+  validIndices.reserve(mVerTelTracks.size());
+  sortVTTracksByP(mVerTelTracks);
+
+  for (size_t vIdx = 0; vIdx < mVerTelTracks.size(); ++vIdx) {
+    const auto& track = mVerTelTracks[vIdx];
+    if (track.getNHits() >= mMinVTHits && track.getP() >= mMinTrackP) {
+      validIndices.push_back(vIdx);
+    }
+  }
+  return validIndices;
+}
+
+bool NA6PMatching::fitAndStoreMatchedTrack(const NA6PTrack& vtTrk, const NA6PTrack& msTrk, int particleId, double matchChi2)
+{
+  mTrackFitter->cleanupAndStartFit();
+
+  addClustersToFitter(vtTrk, &mVerTelClusters);
+  addClustersToFitter(msTrk, hMuonSpecClusPtr);
+
+  std::unique_ptr<NA6PTrack> matchedTrack(mTrackFitter->fitTrackPoints());
+  if (!matchedTrack) {
+    LOGP(warn, "Refit of matched track failed, skipping");
+    return false;
+  }
+
+  matchedTrack->setParticleID(particleId);
+  matchedTrack->setMatchChi2(matchChi2);
+  mTrackFitter->propagateToZ(matchedTrack.get(), mPrimaryVertex.Z());
+  mMatchedTracks.push_back(*matchedTrack);
+
+  return true;
+}
+
+
+void NA6PMatching::runMCMatching()
+{
+  auto vtByPid = buildMCMatchingIndex();
+
+  for (const auto& msTrack : mMuonSpecTracks) {
+    if (msTrack.getNHits() < mMinMSHits)
+      continue;
+
+    int msPartId = msTrack.getParticleID();
+    if (msPartId <= 0)
+      continue;
+
+    auto it = vtByPid.find(msPartId);
+    if (it == vtByPid.end())
+      continue;
+
+    int vtIdx = it->second;
+    const auto& vtTrack = mVerTelTracks[vtIdx];
+    fitAndStoreMatchedTrack(vtTrack, msTrack, msPartId, 0.0);
+  }
+}
+
+void NA6PMatching::runDataMatching()
+{
+  if (mIsZMatchingSet) {
+    propToZMatching(mVerTelTracks, mZMatching, true);
+    propToZMatching(mMuonSpecTracks, mZMatching);
+  }
+
+  auto validVerTelIndices = prefilterVerTelTracks();
+
+  for (const auto& msTrack : mMuonSpecTracks) {
+    if (msTrack.getNHits() < mMinMSHits)
+      continue;
+
+    auto [vtIdx, isTrueMatch, bestChi2] = findBestChi2Match(msTrack, validVerTelIndices);
+    if (vtIdx < 0)
+      continue;
+
+    const auto& vtTrack = mVerTelTracks[vtIdx];
+    int matchedPartID = isTrueMatch ? msTrack.getParticleID() : -std::abs(msTrack.getParticleID());
+
+    fitAndStoreMatchedTrack(vtTrack, msTrack, matchedPartID, bestChi2);
+  }
+}
+
+void NA6PMatching::runMatching()
+{
+  if (!mIsInitialized) {
+    LOGP(error, "Magnetic field and geometry not initialized");
+    return;
+  }
+  clearTracks();
+  mMatchedTracks.reserve(mMuonSpecTracks.size());
+
+  if (mMCMatching) {
+    runMCMatching();
+  } else {
+    runDataMatching();
+  }
+
+  writeTracks();
+}

--- a/rec/src/NA6PTrack.cxx
+++ b/rec/src/NA6PTrack.cxx
@@ -13,7 +13,9 @@ ClassImp(NA6PTrack)
 //_______________________________________________________________________
 NA6PTrack::NA6PTrack() :
   mMass{0.140},
-  mChi2{0.0},
+  mMatchChi2{0.0},
+  mChi2VT{0.0},
+  mChi2MS{0.0},
   mClusterMap{0},
   mNClusters{0},
   mNClustersVT{0},
@@ -31,7 +33,9 @@ NA6PTrack::NA6PTrack() :
 //_______________________________________________________________________
 NA6PTrack::NA6PTrack(const double* xyz, const double* pxyz, int sign, double errLoose) :
   mMass{0.140},
-  mChi2{0.0},
+  mMatchChi2{0.0},
+  mChi2VT{0.0},
+  mChi2MS{0.0},
   mClusterMap{0},
   mNClusters{0},
   mNClustersVT{0},
@@ -53,7 +57,9 @@ NA6PTrack::NA6PTrack(const double* xyz, const double* pxyz, int sign, double err
 void NA6PTrack::reset() 
 {
   mMass = 0.14; 
-  mChi2 = 0; 
+  mMatchChi2 = 0; 
+  mChi2VT = 0;
+  mChi2MS = 0;
   mClusterMap = 0;
   mExtTrack.Reset();
   resetCovariance();
@@ -85,27 +91,45 @@ Bool_t NA6PTrack::init(const double *xyz, const double *pxyz, int sign, double e
 }
 
 //_______________________________________________________________________
-Bool_t NA6PTrack::propagateToZBxByBz(double z, double maxDZ, double xOverX0, double xTimesRho)
+Bool_t NA6PTrack::propagateToZBxByBz(double z, double maxDZ, double xOverX0, double xTimesRho, bool outward)
 {
-  // propagate the track to position Z in uniform material with xOverX0 rad lgt and xTimesRho lgt*density
-  //
-  double zCurr = getZLab();
+  // Propagate track to position z in uniform material with xOverX0 rad length and xTimesRho length*density
+  
+  // Select methods based on parametrization
+  auto getZ = outward ? &NA6PTrack::getZLabOuter : &NA6PTrack::getZLab;
+  auto getPos = outward ? &NA6PTrack::getXYZOuter : &NA6PTrack::getXYZ;
+  using PropagateFunc = Bool_t (NA6PTrack::*)(double, const double*);
+  PropagateFunc propagateStep = outward ? 
+    static_cast<PropagateFunc>(&NA6PTrack::propagateToZBxByBzOuter) : 
+    static_cast<PropagateFunc>(&NA6PTrack::propagateToZBxByBz);
+  
+  double zCurr = (this->*getZ)();
   double dz = z - zCurr;
-  if (TMath::Abs(dz)<kAlmost0) return true;
-  int nz = TMath::Abs(dz)/maxDZ + 1;
-  double zstep = dz/nz;
-  double xyz[3],bxyz[3],bxyzFwd[3];
-  for (int iz=0;iz<nz;iz++) {
-    getXYZ(xyz);              // coordinates in Lab frame
-    TGeoGlobalMagField::Instance()->Field(xyz,bxyz);
-    lab2trk(bxyz,bxyzFwd);  // field in Fwd frame
+  
+  if (TMath::Abs(dz) < kAlmost0) {
+    return true;
+  }
+  
+  int nz = TMath::Abs(dz) / maxDZ + 1;
+  double zstep = dz / nz;
+  double xyz[3], bxyz[3], bxyzFwd[3];
+  
+  for (int iz = 0; iz < nz; iz++) {
+    (this->*getPos)(xyz);  // coordinates in Lab frame
+    TGeoGlobalMagField::Instance()->Field(xyz, bxyz);
+    lab2trk(bxyz, bxyzFwd);  // field in Fwd frame
+    
     zCurr += zstep;
-    if (!propagateToZBxByBz(zCurr,bxyzFwd)) return false;
-    if (TMath::Abs(xTimesRho)>1e-6 && 
-	!correctForMeanMaterial(xOverX0/nz, xTimesRho/nz)) return false;
+    if (!(this->*propagateStep)(zCurr, bxyzFwd)) {
+      return false;
+    }
+    
+    if (TMath::Abs(xTimesRho) > 1e-6 && 
+        !correctForMeanMaterial(xOverX0 / nz, xTimesRho / nz)) {
+      return false;
+    }
   }
   return true;
-  //
 }
 
 //_______________________________________________________________________
@@ -225,8 +249,8 @@ std::string NA6PTrack::asString() const
 {
   double pxyz[3];
   getPXYZ(pxyz);
-  return fmt::format("Track: Nclusters:{} NVTclusters:{} NMSclusters:{} NTRclusters:{} chi2:{} chi2VT:{} chi2MS:{} pos:{:.4f},{:.4f},{:.4f} mom:{:.3f},{:.3f},{:.3f}",
-                     mNClusters,mNClustersVT,mNClustersMS,mNClustersTR,mChi2,mChi2VT,mChi2MS,getXLab(),getYLab(),getZLab(),pxyz[0],pxyz[1],pxyz[2]);
+  return fmt::format("Track: Nclusters:{} NVTclusters:{} NMSclusters:{} NTRclusters:{} match chi2:{} chi2VT:{} chi2MS:{} pos:{:.4f},{:.4f},{:.4f} mom:{:.3f},{:.3f},{:.3f}",
+                     mNClusters,mNClustersVT,mNClustersMS,mNClustersTR,mMatchChi2,mChi2VT,mChi2MS,getXLab(),getYLab(),getZLab(),pxyz[0],pxyz[1],pxyz[2]);
 }
 
 //_______________________________________________________________________
@@ -240,7 +264,6 @@ template <typename ClusterType>
 void NA6PTrack::addCluster(const ClusterType* clu, int cluIndex, double chi2) {
 
   mNClusters++;
-  mChi2 += chi2;
   int trackID = clu->getParticleID();
   
   int nLay = clu->getLayer();

--- a/rec/src/recLinkDef.h
+++ b/rec/src/recLinkDef.h
@@ -21,6 +21,7 @@
 #pragma link C++ class NA6PReconstruction + ;
 #pragma link C++ class NA6PVerTelReconstruction + ;
 #pragma link C++ class NA6PMuonSpecReconstruction + ;
+#pragma link C++ class NA6PMatching + ;
 #pragma link C++ class ExtTrackPar + ;
 #pragma link C++ class NA6PVertexerTracklets + ;
 #pragma link C++ class NA6PTrackerCA + ;

--- a/test/runMatching.C
+++ b/test/runMatching.C
@@ -1,0 +1,101 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <TTree.h>
+#include <TFile.h>
+#include <TParticle.h>
+#include <TStopwatch.h>
+#include "NA6PVerTelCluster.h"
+#include "NA6PMuonSpecCluster.h"
+#include "NA6PMatching.h"
+#include "ConfigurableParam.h"
+#endif
+
+void runMatching(
+                 bool useMC = false,
+                 double zprop = 38.1175,
+                 int firstEv = 0,
+                 int lastEv = 99999,
+                 const char* dirSimu = "../tst",
+                 const char* dirRec = ".")
+{
+  // kine file needed to get the primary vertex position (temporary)
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+
+  // io cluster file for VerTel
+  TFile* fvertelc = new TFile(Form("%s/ClustersVerTel.root", dirSimu), "READ");
+  printf("Open cluster file: %s\n", fvertelc->GetName());
+  TTree* tvertelc = (TTree*)fvertelc->Get("clustersVerTel");
+  std::vector<NA6PVerTelCluster> vtClus, *vtClusPtr = &vtClus;
+  tvertelc->SetBranchAddress("VerTel", &vtClusPtr);
+
+  // io cluster file for MuonSpec
+  TFile* fmuonspec = new TFile(Form("%s/ClustersMuonSpec.root", dirSimu), "READ");
+  printf("Open cluster file: %s\n", fmuonspec->GetName());
+  TTree* tmuonspec = (TTree*)fmuonspec->Get("clustersMuonSpec");
+  std::vector<NA6PMuonSpecCluster> msClus, *msClusPtr = &msClus;
+  tmuonspec->SetBranchAddress("MuonSpec", &msClusPtr);
+
+  // io track file for VerTel
+  TFile* fvttracks = new TFile(Form("%s/TracksVerTel.root", dirRec), "READ");
+  printf("Open track file: %s\n", fvttracks->GetName());
+  TTree* tvttracks = (TTree*)fvttracks->Get("tracksVerTel");
+  std::vector<NA6PTrack> vtTracks, *vtTrackPtr = &vtTracks;
+  tvttracks->SetBranchAddress("VerTel", &vtTrackPtr);
+  // io track file for MuonSpec
+  TFile* fmstracks = new TFile(Form("%s/TracksMuonSpec.root", dirRec), "READ");
+  printf("Open track file: %s\n", fmstracks->GetName());
+  TTree* tmstracks = (TTree*)fmstracks->Get("tracksMuonSpec");
+  std::vector<NA6PTrack> msTracks, *msTrackPtr = &msTracks;
+  tmstracks->SetBranchAddress("MuonSpec", &msTrackPtr);
+
+  NA6PMatching* matching = new NA6PMatching();
+  na6p::conf::ConfigurableParam::updateFromFile(Form("%s/na6pLayout.ini",dirSimu), "", true);
+  matching->init(Form("%s/geometry.root", dirSimu));
+  matching->setZMatching(zprop);
+  matching->useChi2Matching();
+  matching->setPMatchWindow(3.0);
+  if (useMC)
+    matching->useMCMatching();
+  
+  int nEv = tvertelc->GetEntries();
+  if (lastEv > nEv || lastEv < 0)
+    lastEv = nEv;
+  if (firstEv < 0)
+    firstEv = 0;
+
+  TStopwatch timer;
+  timer.Start();
+
+  matching->createTracksOutput();
+  for (int jEv = firstEv; jEv < lastEv; jEv++) {
+    mcTree->GetEvent(jEv);
+    int nPart = mcArr->size();
+    double zvert = 0;
+    // get primary vertex position from the Kine Tree
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      if (curPart.IsPrimary()) {
+        zvert = curPart.Vz();
+        break;
+      }
+    }
+    tvertelc->GetEvent(jEv);
+    tmuonspec->GetEvent(jEv);
+    tvttracks->GetEvent(jEv);
+    tmstracks->GetEvent(jEv);
+    matching->setPrimaryVertexPosition(0., 0., zvert);
+
+    matching->setVerTelClusters(vtClus);
+    matching->setMuonSpecClusters(msClus);
+    matching->setVerTelTracks(vtTracks);
+    matching->setMuonSpecTracks(msTracks);
+
+    matching->runMatching();
+  }
+  matching->closeTracksOutput();
+
+  timer.Stop();
+  timer.Print();
+}


### PR DESCRIPTION
This PR adds a class for the VT MS matching, and test/runMatching.C provides an example of its use.
The matching chi2 is computed using the mOuter parametrization of VT tracks. To propagate VT and MS tracks to a common z position, the propagation logic in both the track fitter and the track classes has been updated.
The generic chi2 variable in NA6PTrack has been removed, as it was ambiguous with respect to chi2VT and chi2MS, and replaced by mMatchChi2.