### PR TITLE
Introduce cluster indices for proper track-to-cluster association

### DIFF
--- a/rec/include/NA6PBaseCluster.h
+++ b/rec/include/NA6PBaseCluster.h
@@ -23,7 +23,6 @@
 class NA6PBaseCluster
 {
  public:
-
   NA6PBaseCluster() = default;
   NA6PBaseCluster(float x, float y, float z, int clusiz, int layer);
   NA6PBaseCluster(const NA6PBaseCluster&) = default;
@@ -31,52 +30,61 @@ class NA6PBaseCluster
   virtual ~NA6PBaseCluster() {}
 
   int getLayer() const { return mLayer; }
-  int   getClusterSize() const { return mCluSiz; }
+  int getClusterSize() const { return mCluSiz; }
   // Lab frame coordinates
-  auto getXLab()       const {return mPos[0];}
-  auto getYLab()       const {return mPos[1];}
-  auto getZLab()       const {return mPos[2];}
+  auto getXLab() const { return mPos[0]; }
+  auto getYLab() const { return mPos[1]; }
+  auto getZLab() const { return mPos[2]; }
   // Tracking frame coordinates (right-handed):
   // X_tracking = Z_lab, Y_tracking = X_lab, Z_tracking = Y_lab
-  auto getXTF()        const {return mPos[2];}
-  auto getYTF()        const {return mPos[0];}
-  auto getZTF()        const {return mPos[1];}
-  auto getX()          const {return getXLab();}
-  auto getY()          const {return getYLab();}
-  auto getZ()          const {return getZLab();}
-  auto getSigYY()      const { return mSigYY; }
-  auto getSigYZ()      const { return mSigYZ; }
-  auto getSigZZ()      const { return mSigZZ; }
+  auto getXTF() const { return mPos[2]; }
+  auto getYTF() const { return mPos[0]; }
+  auto getZTF() const { return mPos[1]; }
+  auto getX() const { return getXLab(); }
+  auto getY() const { return getYLab(); }
+  auto getZ() const { return getZLab(); }
+  auto getSigYY() const { return mSigYY; }
+  auto getSigYZ() const { return mSigYZ; }
+  auto getSigZZ() const { return mSigZZ; }
   auto getDetectorID() const { return mDetectorID; }
   auto getParticleID() const { return mParticleID; }
-  auto getHitID()      const { return mHitID; }
+  auto getHitID() const { return mHitID; }
+  int getClusterIndex() const { return mClusterIndex; }
 
   void setDetectorID(int id) { mDetectorID = id; }
   void setParticleID(int id) { mParticleID = id; }
   void setHitID(int id) { mHitID = id; }
-  void setPos(float x, float y, float z){
-    mPos[0] = x; mPos[1] = y; mPos[2] = z;
+  void setPos(float x, float y, float z)
+  {
+    mPos[0] = x;
+    mPos[1] = y;
+    mPos[2] = z;
   }
-  void setX(float v)    {mPos[0] = v;}
-  void setY(float v)    {mPos[1] = v;}
-  void setZ(float v)    {mPos[2] = v;}
-  void setErr(float syy, float syz, float szz){
-    mSigYY = syy; mSigYZ = syz; mSigZZ = szz;
+  void setX(float v) { mPos[0] = v; }
+  void setY(float v) { mPos[1] = v; }
+  void setZ(float v) { mPos[2] = v; }
+  void setErr(float syy, float syz, float szz)
+  {
+    mSigYY = syy;
+    mSigYZ = syz;
+    mSigZZ = szz;
   }
+  void setClusterIndex(int idx) { mClusterIndex = idx; }
 
   virtual void print() const;
   std::string asString() const;
-  
+
  protected:
-  float mPos[3] = {};          // cartesian position of cluster in lab frame
-  float mSigYY = 0.f;          // covariance matrix elements
-  float mSigYZ = 0.f;          // covariance matrix elements
-  float mSigZZ = 0.f;          // covariance matrix elements
-  int   mCluSiz = 0;           // cluster size
-  int   mParticleID = 0;       // particle ID in Kine tree (MC truth)
-  int   mHitID = -1;           // hit ID (for test of hitsToRecPoints)
-  short mDetectorID = 0;       // the detector/sensor id
+  float mPos[3] = {};    // cartesian position of cluster in lab frame
+  float mSigYY = 0.f;    // covariance matrix elements
+  float mSigYZ = 0.f;    // covariance matrix elements
+  float mSigZZ = 0.f;    // covariance matrix elements
+  int mCluSiz = 0;       // cluster size
+  int mParticleID = 0;   // particle ID in Kine tree (MC truth)
+  int mHitID = -1;       // hit ID (for test of hitsToRecPoints)
+  short mDetectorID = 0; // the detector/sensor id
   int8_t mLayer = -1;
+  int mClusterIndex; //! Transient index for track-cluster association
 
   ClassDefNV(NA6PBaseCluster, 1);
 };

--- a/rec/include/NA6PMuonSpecReconstruction.h
+++ b/rec/include/NA6PMuonSpecReconstruction.h
@@ -56,10 +56,7 @@ class NA6PMuonSpecReconstruction : public NA6PReconstruction
     mPrimaryVertex.SetXYZ(x, y, z);
   }
   // methods to steer tracking
-  void setClusters(const std::vector<NA6PMuonSpecCluster>& clusters)
-  {
-    mClusters = clusters;
-  }
+  void setClusters(const std::vector<NA6PMuonSpecCluster>& clusters);
 
   void createTracksOutput() override;
   void clearTracks() override { mTracks.clear(); }
@@ -69,15 +66,15 @@ class NA6PMuonSpecReconstruction : public NA6PReconstruction
 
  private:
   std::vector<NA6PMuonSpecCluster> mClusters, *hClusPtr = &mClusters; // vector of clusters
-  TFile* mClusFile = nullptr;                                     // file with clusters
-  TTree* mClusTree = nullptr;                                     // tree of clusters
-  double mCluResX = 100.e-4;                                      // cluster resolution, cm (for fast simu)
-  double mCluResY = 500.e-4;                                      // cluster resolution, cm (for fast simu)
-  TVector3 mPrimaryVertex{0.0, 0.0, 0.0};                         // primary vertex position
-  std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;          // vector of tracks
-  TFile* mTrackFile = nullptr;                                    // file with tracks
-  TTree* mTrackTree = nullptr;                                    // tree of tracks
-  NA6PTrackerCA* mMSTracker = nullptr;                            // tracker
+  TFile* mClusFile = nullptr;                                         // file with clusters
+  TTree* mClusTree = nullptr;                                         // tree of clusters
+  double mCluResX = 100.e-4;                                          // cluster resolution, cm (for fast simu)
+  double mCluResY = 500.e-4;                                          // cluster resolution, cm (for fast simu)
+  TVector3 mPrimaryVertex{0.0, 0.0, 0.0};                             // primary vertex position
+  std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;              // vector of tracks
+  TFile* mTrackFile = nullptr;                                        // file with tracks
+  TTree* mTrackTree = nullptr;                                        // tree of tracks
+  NA6PTrackerCA* mMSTracker = nullptr;                                // tracker
 
   ClassDefNV(NA6PMuonSpecReconstruction, 1);
 };

--- a/rec/include/NA6PVerTelReconstruction.h
+++ b/rec/include/NA6PVerTelReconstruction.h
@@ -63,10 +63,7 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
     mPrimaryVertex.SetXYZ(x, y, z);
   }
   // methods to steer tracking
-  void setClusters(const std::vector<NA6PVerTelCluster>& clusters)
-  {
-    mClusters = clusters;
-  }
+  void setClusters(const std::vector<NA6PVerTelCluster>& clusters);
   void createVerticesOutput() override;
   void clearVertices() override { mVertices.clear(); }
   void writeVertices() override;
@@ -82,21 +79,21 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
 
  private:
   std::vector<NA6PVerTelCluster> mClusters, *hClusPtr = &mClusters; // vector of clusters
-  std::string mGeoFilName{};                                      // name of geometry file
-  std::string mGeoObjName{};                                      // name of geometry object
-  std::string mRecoParFilName{};                                  // name of reco param file
-  TFile* mClusFile = nullptr;                                     // file with clusters
-  TTree* mClusTree = nullptr;                                     // tree of clusters
-  double mCluRes = 5.e-4;                                         // cluster resolution, cm (for fast simu)
-  std::vector<NA6PVertex> mVertices, *hVerticesPtr = &mVertices;  // vector of vertices
-  TFile* mVertexFile = nullptr;                                   // file with vertices
-  TTree* mVertexTree = nullptr;                                   // tree of vertices
-  NA6PVertexerTracklets* mVTTrackletVertexer = nullptr;           // vertexer
-  TVector3 mPrimaryVertex{0.0, 0.0, 0.0};                         // primary vertex position
-  std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;          // vector of tracks
-  TFile* mTrackFile = nullptr;                                    // file with tracks
-  TTree* mTrackTree = nullptr;                                    // tree of tracks
-  NA6PTrackerCA* mVTTracker = nullptr;                            // tracker
+  std::string mGeoFilName{};                                        // name of geometry file
+  std::string mGeoObjName{};                                        // name of geometry object
+  std::string mRecoParFilName{};                                    // name of reco param file
+  TFile* mClusFile = nullptr;                                       // file with clusters
+  TTree* mClusTree = nullptr;                                       // tree of clusters
+  double mCluRes = 5.e-4;                                           // cluster resolution, cm (for fast simu)
+  std::vector<NA6PVertex> mVertices, *hVerticesPtr = &mVertices;    // vector of vertices
+  TFile* mVertexFile = nullptr;                                     // file with vertices
+  TTree* mVertexTree = nullptr;                                     // tree of vertices
+  NA6PVertexerTracklets* mVTTrackletVertexer = nullptr;             // vertexer
+  TVector3 mPrimaryVertex{0.0, 0.0, 0.0};                           // primary vertex position
+  std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;            // vector of tracks
+  TFile* mTrackFile = nullptr;                                      // file with tracks
+  TTree* mTrackTree = nullptr;                                      // tree of tracks
+  NA6PTrackerCA* mVTTracker = nullptr;                              // tracker
 
   ClassDefNV(NA6PVerTelReconstruction, 1);
 };

--- a/rec/src/NA6PMuonSpecReconstruction.cxx
+++ b/rec/src/NA6PMuonSpecReconstruction.cxx
@@ -57,6 +57,16 @@ void NA6PMuonSpecReconstruction::closeClustersOutput()
   }
 }
 
+void NA6PMuonSpecReconstruction::setClusters(const std::vector<NA6PMuonSpecCluster>& clusters)
+{
+  mClusters = clusters;
+  // Assign a transient index based on position in the vector
+  // to be used for storing the cluster indices in the track
+  for (size_t i = 0; i < mClusters.size(); ++i) {
+    mClusters[i].setClusterIndex(static_cast<int>(i));
+  }
+}
+
 void NA6PMuonSpecReconstruction::hitsToRecPoints(const std::vector<NA6PMuonSpecModularHit>& hits)
 {
   int nHits = hits.size();
@@ -82,10 +92,10 @@ void NA6PMuonSpecReconstruction::hitsToRecPoints(const std::vector<NA6PMuonSpecM
     int nDet = hit.getDetectorID();
     int idPart = hit.getTrackID();
     // Set layer based on Z position - find closest plane
-        
+
     float minDist = std::abs(z - layout.posMSPlaneZ[0]);
     int layer = layout.nVerTelPlanes;
-    
+
     for (int i = 1; i < layout.nMSPlanes; ++i) {
       float dist = std::abs(z - layout.posMSPlaneZ[i]);
       if (dist < minDist) {

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -94,6 +94,16 @@ void NA6PVerTelReconstruction::closeClustersOutput()
   }
 }
 
+void NA6PVerTelReconstruction::setClusters(const std::vector<NA6PVerTelCluster>& clusters)
+{
+  mClusters = clusters;
+  // Assign a transient index based on position in the vector
+  // to be used for storing the cluster indices in the track
+  for (size_t i = 0; i < mClusters.size(); ++i) {
+    mClusters[i].setClusterIndex(static_cast<int>(i));
+  }
+}
+
 void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>& hits)
 {
   int nHits = hits.size();


### PR DESCRIPTION
Note that the large differences in NA6BaseCluster are due to the application of clang-format.
The actual changes in that class are just the addition of the transient data member mClusterIndex with its setter and getter