### PR TITLE
Set particle hypothesis to muon and fix hit counting bug

### DIFF
--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -93,6 +93,7 @@ class NA6PTrackerCA
                           float maxChi2ndfCells,
                           float maxChi2ndfTracks,
                           int minNClusTracks);
+  void setParticleHypothesis(int pdg);
   void configureFromRecoParamVT(const std::string& filename = "");
   void configureFromRecoParamMS(const std::string& filename = "");
   void setVerbosity(bool opt = true) { mVerbose = opt; }

--- a/rec/src/NA6PMuonSpecReconstruction.cxx
+++ b/rec/src/NA6PMuonSpecReconstruction.cxx
@@ -21,8 +21,7 @@ bool NA6PMuonSpecReconstruction::init(const char* filename, const char* geoname)
   NA6PReconstruction::init(filename, geoname);
   mMSTracker = new NA6PTrackerCA();
   mMSTracker->configureFromRecoParamMS();
-  mMSTracker->setNLayers(6); 
-  mMSTracker->setStartLayer(5);
+  mMSTracker->setParticleHypothesis(13); // muon mass hypothesis
   createTracksOutput();
   return true;
 }

--- a/rec/src/NA6PTrack.cxx
+++ b/rec/src/NA6PTrack.cxx
@@ -279,11 +279,11 @@ void NA6PTrack::addCluster(const ClusterType* clu, int cluIndex, double chi2) {
     mChi2VT += chi2;
   }
   else if (nLay >= NA6PLayoutParam::Instance().nVerTelPlanes + NA6PLayoutParam::Instance().nMSPlanes - 2) {
-    mNClustersMS++;
+    mNClustersTR++;
     mChi2MS += chi2;
   }
   else {
-    mNClustersTR++;
+    mNClustersMS++;
     mChi2MS += chi2;
   }
 }

--- a/rec/src/NA6PTrackerCA.cxx
+++ b/rec/src/NA6PTrackerCA.cxx
@@ -86,6 +86,13 @@ void NA6PTrackerCA::setIterationParams(int iter,
   mMinNClusTracksCA[iter] = minNClusTracks;
 }
 
+void NA6PTrackerCA::setParticleHypothesis(int pdg)
+{
+  if (mTrackFitter) {
+    mTrackFitter->setParticleHypothesis(pdg);
+  }
+}
+
 void NA6PTrackerCA::configureFromRecoParamVT(const std::string& filename)
 {
   if (filename != "") {
@@ -122,6 +129,7 @@ void NA6PTrackerCA::configureFromRecoParamMS(const std::string& filename)
   const auto& param = NA6PRecoParam::Instance();
   setNumberOfIterations(param.msNIterationsTrackerCA);
   setNLayers(param.msNLayers);
+  setStartLayer(param.vtNLayers);
   for (int jIter = 0; jIter < mNIterationsCA; ++jIter) {
     setIterationParams(jIter,
                        param.msMaxDeltaThetaTrackletsCA[jIter],


### PR DESCRIPTION
Add a method in NA6PTrackerCA to set the track fitter mass hypothesis and set the hypothesis to muon for the MS reconstruction.
Fix the counting logic for hits in the muon spectrometer.
