### PR TITLE
Feature/gdml magnets refactoring

### DIFF
--- a/NA6PSim.cxx
+++ b/NA6PSim.cxx
@@ -10,7 +10,6 @@
 #include "MagneticField.h"
 #include "StringUtils.h"
 #include "NA6PMC.h"
-#include "NA6PDetector.h"
 #include "TG4RunConfiguration.h"
 #include "TGeant4.h"
 
@@ -39,8 +38,6 @@ int main(int argc, char** argv)
     add_option("user-vertex,V", bpo::value<std::string>()->default_value(""), "root macro C macro with user method for vertex generation");
     add_option("rnd-seed,r", bpo::value<int64_t>()->default_value(-1), "random number seed, 0 - do not set, <0: generate from time");
     add_option("save-bfield,b", bpo::value<bool>()->default_value(false)->implicit_value(true), "Save magnetic field to file");
-    add_option("use-gdml-magnets", bpo::value<bool>()->default_value(false)->implicit_value(true),
-               "Use magnet geometry from GDML (BothMagnets.gdml) instead of analytic C++ magnets");
     opt_all.add(opt_general).add(opt_hidden);
     bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
 
@@ -66,11 +63,6 @@ int main(int argc, char** argv)
   }
   LOGP(info, "Printing all configs");
   na6p::conf::ConfigurableParam::printAllKeyValuePairs();
-
-  // Select geometry description for magnets BEFORE constructing the detector.
-  // By default (flag false) analytic C++ magnets (NA6PDipoleVT/MS) are used.
-  bool useGDMLMagnets = vm["use-gdml-magnets"].as<bool>();
-  NA6PDetector::setUseGDMLMagnets(useGDMLMagnets);
 
   auto mc = new NA6PMC("NA6PMCApp", "NA6P Virtual Monte Carlo Application");
   mc->setVerbosity(vm["verbosity"].as<int>());

--- a/NA6PSim.cxx
+++ b/NA6PSim.cxx
@@ -10,6 +10,7 @@
 #include "MagneticField.h"
 #include "StringUtils.h"
 #include "NA6PMC.h"
+#include "NA6PDetector.h"
 #include "TG4RunConfiguration.h"
 #include "TGeant4.h"
 
@@ -38,6 +39,8 @@ int main(int argc, char** argv)
     add_option("user-vertex,V", bpo::value<std::string>()->default_value(""), "root macro C macro with user method for vertex generation");
     add_option("rnd-seed,r", bpo::value<int64_t>()->default_value(-1), "random number seed, 0 - do not set, <0: generate from time");
     add_option("save-bfield,b", bpo::value<bool>()->default_value(false)->implicit_value(true), "Save magnetic field to file");
+    add_option("use-gdml-magnets", bpo::value<bool>()->default_value(false)->implicit_value(true),
+               "Use magnet geometry from GDML (BothMagnets.gdml) instead of analytic C++ magnets");
     opt_all.add(opt_general).add(opt_hidden);
     bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
 
@@ -63,6 +66,11 @@ int main(int argc, char** argv)
   }
   LOGP(info, "Printing all configs");
   na6p::conf::ConfigurableParam::printAllKeyValuePairs();
+
+  // Select geometry description for magnets BEFORE constructing the detector.
+  // By default (flag false) analytic C++ magnets (NA6PDipoleVT/MS) are used.
+  bool useGDMLMagnets = vm["use-gdml-magnets"].as<bool>();
+  NA6PDetector::setUseGDMLMagnets(useGDMLMagnets);
 
   auto mc = new NA6PMC("NA6PMCApp", "NA6P Virtual Monte Carlo Application");
   mc->setVerbosity(vm["verbosity"].as<int>());

--- a/base/include/NA6PLayoutParam.h
+++ b/base/include/NA6PLayoutParam.h
@@ -30,6 +30,10 @@ struct NA6PLayoutParam : public na6p::conf::ConfigurableParamHelper<NA6PLayoutPa
   float posDipMS[3] = {0.f, 0.f, 430.f}; // MS dipole position
   std::string fieldMapDipMS = "$(NA6PROOT_ROOT)/share/data/mnp33_fieldmap_5cm.dat";
 
+  // GDML-based magnet geometry
+  std::string gdmlMagPath = "$(NA6PROOT_ROOT)/share/data/BothMagnets.gdml";
+  bool use_gdml_magnets = false; // set to true to use GDML geometry instead of analytic C++ magnets
+
   // Target
   int nTargets = 5;
   float shiftTargets[3] = {0.f, 0.f, 0.f}; // Target box global shift, added to posTargetX,Y,Z

--- a/sim/include/NA6PDetector.h
+++ b/sim/include/NA6PDetector.h
@@ -21,11 +21,6 @@ class NA6PDetector
     return inst;
   }
 
-  // Switch between analytic (C++) and GDML-based magnet geometry.
-  // Must be called BEFORE the first call to instance(), i.e. before
-  // NA6PMC is constructed.
-  static void setUseGDMLMagnets(bool v);
-
   void createGeometry(const std::string& name = "NA6P");
   void createCommonMaterials();
 

--- a/sim/include/NA6PDetector.h
+++ b/sim/include/NA6PDetector.h
@@ -21,6 +21,11 @@ class NA6PDetector
     return inst;
   }
 
+  // Switch between analytic (C++) and GDML-based magnet geometry.
+  // Must be called BEFORE the first call to instance(), i.e. before
+  // NA6PMC is constructed.
+  static void setUseGDMLMagnets(bool v);
+
   void createGeometry(const std::string& name = "NA6P");
   void createCommonMaterials();
 

--- a/sim/include/NA6PMagnetsGDML.h
+++ b/sim/include/NA6PMagnetsGDML.h
@@ -1,0 +1,28 @@
+// NA6PCCopyright
+#ifndef NA6P_MAGNETS_GDML_H_
+#define NA6P_MAGNETS_GDML_H_
+
+#include "NA6PModule.h"
+#include <string>
+
+class TGeoVolume;
+
+/// Module for importing magnet geometry from an external GDML file
+/// (e.g. BothMagnets.gdml) and aligning it to layout positions.
+class NA6PMagnetsGDML : public NA6PModule
+{
+ public:
+  NA6PMagnetsGDML() : NA6PModule("MagnetsGDML") {}
+  ~NA6PMagnetsGDML() override = default;
+
+  void createMaterials() override;
+  void createGeometry(TGeoVolume* world) override;
+
+  // Public helper methods for GDML geometry processing
+  std::string getGDMLPath() const;
+  void alignMagnetsToLayout(TGeoVolume* world);
+  void assignMediaToGDMLVolumes();
+  void harmoniseVolumeNames();
+};
+
+#endif

--- a/sim/include/NA6PMagnetsGDML.h
+++ b/sim/include/NA6PMagnetsGDML.h
@@ -19,7 +19,6 @@ class NA6PMagnetsGDML : public NA6PModule
   void createGeometry(TGeoVolume* world) override;
 
   // Public helper methods for GDML geometry processing
-  std::string getGDMLPath() const;
   void alignMagnetsToLayout(TGeoVolume* world);
   void assignMediaToGDMLVolumes();
   void harmoniseVolumeNames();

--- a/sim/src/NA6PDetector.cxx
+++ b/sim/src/NA6PDetector.cxx
@@ -4,6 +4,7 @@
 #include "NA6PTGeoHelper.h"
 #include "NA6PDipoleVT.h"
 #include "NA6PDipoleMS.h"
+#include "NA6PMagnetsGDML.h"
 #include "NA6PTarget.h"
 #include "NA6PVerTel.h"
 #include "NA6PAbsorber.h"
@@ -30,10 +31,13 @@ void NA6PDetector::setUseGDMLMagnets(bool v)
 
 NA6PDetector::NA6PDetector()
 {
-  // just declare modules
+  // Declare modules
   if (!gUseGDMLMagnets) {
     // Analytic magnets from C++ (original behaviour)
     addModule(new NA6PDipoleVT());
+  } else {
+    // GDML-based magnets: add the GDML magnet module
+    addModule(new NA6PMagnetsGDML());
   }
 
   addModule(new NA6PTarget());
@@ -85,282 +89,58 @@ void NA6PDetector::addModule(NA6PModule* m)
 
 void NA6PDetector::createGeometry(const std::string& name)
 {
+  TGeoManager* geom = nullptr;
+  TGeoVolume* world = nullptr;
+
   if (!gUseGDMLMagnets) {
-    // === Analytic geometry: build magnets in C++ (NA6PDipoleVT/MS) ===
-    TGeoManager* geom =
-      new TGeoManager(name.c_str(), (name + " TGeometry").c_str());
-
-    // Make sure common materials (e.g. Air) exist
+    // === Analytic geometry (original): build from C++ code ===
+    geom = new TGeoManager(name.c_str(), (name + " TGeometry").c_str());
     createCommonMaterials();
-
-    // World box in cm (half-sizes 1000x1000x1000)
-    TGeoVolume* world =
-      geom->MakeBox("World",
-                    NA6PTGeoHelper::instance().getMedium("Air"),
-                    1000., 1000., 1000.);
+    world = geom->MakeBox("World",
+                          NA6PTGeoHelper::instance().getMedium("Air"),
+                          1000., 1000., 1000.);
     geom->SetTopVolume(world);
-
-    // build modules (including NA6PDipoleVT/MS if they were added)
+  } else {
+    // === GDML-based magnets: import BothMagnets.gdml ===
+    // Get GDML module (it was added in constructor)
+    NA6PMagnetsGDML* gdmlMagnetModule = nullptr;
     for (auto m : mModulesVec) {
-      m->createMaterials();
-      m->createGeometry(world);
-    }
-
-    // Recolour volumes: all Iron* media blue, all Copper* media yellow.
-    {
-      auto* vols = geom->GetListOfVolumes();
-      if (vols) {
-        for (int i = 0; i < vols->GetEntriesFast(); ++i) {
-          auto* v = static_cast<TGeoVolume*>(vols->At(i));
-          if (!v) {
-            continue;
-          }
-          auto* med = v->GetMedium();
-          if (!med) {
-            continue;
-          }
-          const TGeoMaterial* mat = med->GetMaterial();
-          const char* mname = nullptr;
-          if (mat && mat->GetName()) {
-            mname = mat->GetName();
-          } else if (med->GetName()) {
-            mname = med->GetName();
-          }
-          if (!mname) {
-            continue;
-          }
-          std::string nm = mname;
-          if (nm.find("Iron") != std::string::npos || nm.find("Fe") != std::string::npos) {
-            v->SetLineColor(kGray);
-          } else if (nm.find("Copper") != std::string::npos || nm.find("Cu") != std::string::npos) {
-            v->SetLineColor(kRed);
-          }
-        }
-      }
-    }
-
-    // Close the geometry
-    geom->CloseGeometry();
-    for (auto m : mModulesVec) {
-      m->setAlignableEntries();
-    }
-    // Export to file
-    geom->Export("geometry.root");
-    return;
-  }
-
-  // === GDML-based magnets: import BothMagnets.gdml and attach remaining modules ===
-
-  // Path to the GDML file can be overridden via NA6P_BOTHMAGNETS_GDML.
-  const char* gdmlPathEnv = std::getenv("NA6P_BOTHMAGNETS_GDML");
-  std::string gdmlPath = gdmlPathEnv ? gdmlPathEnv : "/home/access/Alice/NA6PRoot/data/BothMagnets.gdml";
-
-  LOGP(info, "Importing geometry from GDML file: {}", gdmlPath);
-  TGeoManager::Import(gdmlPath.c_str());
-
-  TGeoManager* geom = gGeoManager;
-  if (!geom) {
-    LOGP(fatal, "Failed to create TGeoManager from GDML file {}", gdmlPath);
-  }
-
-  // Ensure common materials (e.g. Air) exist for modules that use NA6PTGeoHelper.
-  createCommonMaterials();
-
-  TGeoVolume* world = geom->GetTopVolume();
-  if (!world) {
-    LOGP(fatal, "No top volume found after importing GDML file {}", gdmlPath);
-  }
-
-  {
-    const auto& param = NA6PLayoutParam::Instance();
-    const double shiftX = param.posDipIP[0];
-    const double shiftY = param.posDipIP[1];
-    const double shiftZ = param.posDipIP[2];
-
-    TGeoIterator it(world);
-    TGeoNode* node = nullptr;
-    TGeoNode* mep48Node = nullptr;
-
-    while ((node = it())) {
-      const char* nname = node->GetName();
-      const char* vname = node->GetVolume()->GetName();
-      if ((strcmp(nname, "PV_MEP48") == 0) || (strcmp(vname, "MEP48") == 0)) {
-        mep48Node = node;
+      if (auto* gdmlMod = dynamic_cast<NA6PMagnetsGDML*>(m)) {
+        gdmlMagnetModule = gdmlMod;
         break;
       }
     }
-
-    if (mep48Node) {
-      const Double_t* tr = it.GetCurrentMatrix()->GetTranslation();
-      // Apply layout shift relative to the baseline GDML placement.
-      Double_t newTr[3] = {tr[0] + shiftX, tr[1] + shiftY, tr[2] + shiftZ};
-
-      auto* origMat = mep48Node->GetMatrix();
-      auto* newMat = new TGeoHMatrix(*origMat);
-      newMat->SetTranslation(newTr);
-
-      if (auto* nodeMat = dynamic_cast<TGeoNodeMatrix*>(mep48Node)) {
-        nodeMat->SetMatrix(newMat);
-        LOGP(info, "Shifted first magnet (PV_MEP48) by d(posDipIP) = (%g,%g,%g) cm",
-             shiftX, shiftY, shiftZ);
-      } else {
-        LOGP(warn, "Found PV_MEP48 / MEP48, but it is not a TGeoNodeMatrix; cannot reset matrix");
-        delete newMat;
-      }
-    } else {
-      LOGP(warn, "Could not find PV_MEP48 / MEP48 node to align first magnet to posDipIP");
+    if (!gdmlMagnetModule) {
+      LOGP(fatal, "GDML magnet mode is enabled, but NA6PMagnetsGDML module not found");
     }
+
+    std::string gdmlPath = gdmlMagnetModule->getGDMLPath();
+    LOGP(info, "Importing geometry from GDML file: {}", gdmlPath);
+    TGeoManager::Import(gdmlPath.c_str());
+    geom = gGeoManager;
+    if (!geom) {
+      LOGP(fatal, "Failed to create TGeoManager from GDML file {}", gdmlPath);
+    }
+
+    createCommonMaterials();
+    world = geom->GetTopVolume();
+    if (!world) {
+      LOGP(fatal, "No top volume found after importing GDML file {}", gdmlPath);
+    }
+
+    // Let the GDML module do magnet-specific setup
+    gdmlMagnetModule->assignMediaToGDMLVolumes();
+    gdmlMagnetModule->alignMagnetsToLayout(world);
+    gdmlMagnetModule->harmoniseVolumeNames();
   }
 
-  // --- Second magnet (MNP33) : PV_MNP33 / MNP33 ---
-  {
-    const auto& param = NA6PLayoutParam::Instance();
-    const double targetX = param.posDipMS[0];
-    const double targetY = param.posDipMS[1];
-    const double targetZ = param.posDipMS[2];
-
-    TGeoIterator it(world);
-    TGeoNode* node = nullptr;
-    TGeoNode* mnp33Node = nullptr;
-
-    while ((node = it())) {
-      // Heuristics: either node name "PV_MNP33" (from GDML physvol),
-      // or volume name "MNP33" (local world of the second magnet).
-      const char* nname = node->GetName();
-      const char* vname = node->GetVolume()->GetName();
-      if ((strcmp(nname, "PV_MNP33") == 0) || (strcmp(vname, "MNP33") == 0)) {
-        mnp33Node = node;
-        break;
-      }
-    }
-
-    if (mnp33Node) {
-      const Double_t* tr = it.GetCurrentMatrix()->GetTranslation();
-      double dx = targetX - tr[0];
-      double dy = targetY - tr[1];
-      double dz = targetZ - tr[2];
-
-      // Create a new matrix with updated translation and attach it to the node,
-      // if it is a TGeoNodeMatrix (only that subclass owns a mutable matrix).
-      auto* origMat = mnp33Node->GetMatrix();
-      auto* newMat = new TGeoHMatrix(*origMat);
-      Double_t newTr[3] = {tr[0] + dx, tr[1] + dy, tr[2] + dz};
-      newMat->SetTranslation(newTr);
-
-      if (auto* nodeMat = dynamic_cast<TGeoNodeMatrix*>(mnp33Node)) {
-        nodeMat->SetMatrix(newMat);
-        LOGP(info, "Shifted second magnet (PV_MNP33) by dx=%g dy=%g dz=%g cm to align with posDipMS",
-             dx, dy, dz);
-      } else {
-        LOGP(warn, "Found PV_MNP33 / MNP33, but it is not a TGeoNodeMatrix; cannot reset matrix");
-        delete newMat;
-      }
-    } else {
-      LOGP(warn, "Could not find PV_MNP33 / MNP33 node to align second magnet to posDipMS");
-    }
-  }
-
-  {
-    auto& helper = NA6PTGeoHelper::instance();
-    TGeoMedium* airMed = helper.getMedium("Air", /*fatalIfMissing=*/true);
-    if (airMed) {
-      if (world->GetMedium() != airMed) {
-        LOGP(info, "Assigning Air medium to top volume {}", world->GetName());
-        world->SetMedium(airMed);
-      }
-      if (auto v = geom->FindVolumeFast("World")) {
-        if (v->GetMedium() != airMed) {
-          LOGP(info, "Assigning Air medium to volume {}", v->GetName());
-          v->SetMedium(airMed);
-        }
-      }
-
-      if (auto v = geom->FindVolumeFast("MNP33")) {
-        if (v->GetMedium() != airMed) {
-          LOGP(info, "Assigning Air medium to volume {}", v->GetName());
-          v->SetMedium(airMed);
-        }
-      }
-      // First magnet local world (assembly MEP48) in GDML
-      if (auto v = geom->FindVolumeFast("MEP48")) {
-        if (v->GetMedium() != airMed) {
-          LOGP(info, "Assigning Air medium to volume {}", v->GetName());
-          v->SetMedium(airMed);
-        }
-      }
-    }
-
-    // Try to reuse media created from GDML materials for iron and copper.
-    auto getMedIfExists = [geom](const char* name) -> TGeoMedium* {
-      auto* m = geom->GetMedium(name);
-      return m;
-    };
-
-    TGeoMedium* feMed = getMedIfExists("G4_Fe");
-    if (!feMed) {
-      feMed = getMedIfExists("G4_Fe0x39eca690");
-    }
-    TGeoMedium* cuMed = getMedIfExists("G4_Cu");
-    if (!cuMed) {
-      cuMed = getMedIfExists("G4_Cu0x39e8a110");
-    }
-
-    // assign names Iron_DipoleVT / Copper_DipoleVT / Iron_DipoleMS /
-    // Copper_DipoleMS to GDML magnet parts.
-    {
-      NA6PDipoleVT vtDummy;
-      vtDummy.createMaterials();
-      NA6PDipoleMS msDummy;
-      msDummy.createMaterials();
-    }
-
-    TGeoMedium* feVT = helper.getMedium("Iron_DipoleVT", /*fatalIfMissing=*/false);
-    TGeoMedium* cuVT = helper.getMedium("Copper_DipoleVT", /*fatalIfMissing=*/false);
-    TGeoMedium* feMS = helper.getMedium("Iron_DipoleMS", /*fatalIfMissing=*/false);
-    TGeoMedium* cuMS = helper.getMedium("Copper_DipoleMS", /*fatalIfMissing=*/false);
-
-    auto assignMediumIfFound = [&](const char* volName, TGeoMedium* med) {
-      if (!med) {
-        return;
-      }
-      if (auto* v = geom->FindVolumeFast(volName)) {
-        LOGP(info, "Assigning medium {} to volume {}", med->GetName(), v->GetName());
-        v->SetMedium(med);
-      }
-    };
-
-    // Magnet volumes in BothMagnets.gdml
-
-    assignMediumIfFound("gap",      feVT ? feVT : feMed);
-    assignMediumIfFound("yokeUp",   feVT ? feVT : feMed);
-    assignMediumIfFound("yokeDown", feVT ? feVT : feMed);
-    assignMediumIfFound("poleUp",   feVT ? feVT : feMed);
-    assignMediumIfFound("poleDown", feVT ? feVT : feMed);
-    assignMediumIfFound("coilUp",   cuVT ? cuVT : cuMed);
-    assignMediumIfFound("coilDown", cuVT ? cuVT : cuMed);
-    assignMediumIfFound("yoke",       feMS ? feMS : feMed);
-    assignMediumIfFound("coil_big",   cuMS ? cuMS : cuMed);
-    assignMediumIfFound("coil_small", cuMS ? cuMS : cuMed);
-  }
-
-  {
-    if (auto* v = geom->FindVolumeFast("MEP48")) {
-      LOGP(info, "Renaming GDML volume MEP48 to DipoleVT for consistency with analytic geometry");
-      v->SetName("DipoleVT");
-    }
-    if (auto* v = geom->FindVolumeFast("MNP33")) {
-      LOGP(info, "Renaming GDML volume MNP33 to DipoleMS for consistency with analytic geometry");
-      v->SetName("DipoleMS");
-    }
-  }
-
-  // build remaining modules (magnets are already in the GDML)
+  // Build modules (analytic magnets or other detectors)
   for (auto m : mModulesVec) {
     m->createMaterials();
     m->createGeometry(world);
   }
 
-  // Recolour volumes: all Iron* media blue, all Copper* media yellow.
+  // Apply consistent coloring: Iron/Fe → blue, Copper/Cu → yellow
   {
     auto* vols = geom->GetListOfVolumes();
     if (vols) {
@@ -385,20 +165,19 @@ void NA6PDetector::createGeometry(const std::string& name)
         }
         std::string nm = mname;
         if (nm.find("Iron") != std::string::npos || nm.find("Fe") != std::string::npos) {
-          v->SetLineColor(kGray);
+          v->SetLineColor(kBlue);
         } else if (nm.find("Copper") != std::string::npos || nm.find("Cu") != std::string::npos) {
-          v->SetLineColor(kRed);
+          v->SetLineColor(kYellow);
         }
       }
     }
   }
 
-  // Close the geometry
+  // Finalize
   geom->CloseGeometry();
   for (auto m : mModulesVec) {
     m->setAlignableEntries();
   }
-  // Export to file
   geom->Export("geometry.root");
 }
 

--- a/sim/src/NA6PDetector.cxx
+++ b/sim/src/NA6PDetector.cxx
@@ -153,7 +153,7 @@ void NA6PDetector::createGeometry(const std::string& name)
 
   // Path to the GDML file can be overridden via NA6P_BOTHMAGNETS_GDML.
   const char* gdmlPathEnv = std::getenv("NA6P_BOTHMAGNETS_GDML");
-  std::string gdmlPath = gdmlPathEnv ? gdmlPathEnv : "/home/access/Alice/BothMagnets.gdml";
+  std::string gdmlPath = gdmlPathEnv ? gdmlPathEnv : "/home/access/Alice/NA6PRoot/data/BothMagnets.gdml";
 
   LOGP(info, "Importing geometry from GDML file: {}", gdmlPath);
   TGeoManager::Import(gdmlPath.c_str());

--- a/sim/src/NA6PDetector.cxx
+++ b/sim/src/NA6PDetector.cxx
@@ -12,16 +12,37 @@
 #include "NA6PLayoutParam.h"
 #include "StringUtils.h"
 #include <TGeoManager.h>
+#include <TColor.h>
 #include <fairlogger/Logger.h>
+#include <cstdlib>
+
+namespace
+{
+// Global switch: false = analytic C++ magnets (NA6PDipoleVT/MS),
+// true = import magnets from GDML (BothMagnets.gdml).
+bool gUseGDMLMagnets = false;
+} // namespace
+
+void NA6PDetector::setUseGDMLMagnets(bool v)
+{
+  gUseGDMLMagnets = v;
+}
 
 NA6PDetector::NA6PDetector()
 {
   // just declare modules
-  addModule(new NA6PDipoleVT());
+  if (!gUseGDMLMagnets) {
+    // Analytic magnets from C++ (original behaviour)
+    addModule(new NA6PDipoleVT());
+  }
+
   addModule(new NA6PTarget());
   addModule(new NA6PVerTel());
   addModule(new NA6PAbsorber());
-  addModule(new NA6PDipoleMS());
+
+  if (!gUseGDMLMagnets) {
+    addModule(new NA6PDipoleMS());
+  }
   //addModule(new NA6PMuonSpec());
   addModule(new NA6PMuonSpecModular());
 }
@@ -64,15 +85,312 @@ void NA6PDetector::addModule(NA6PModule* m)
 
 void NA6PDetector::createGeometry(const std::string& name)
 {
-  TGeoManager* geom = new TGeoManager(name.c_str(), (name + " TGeometry").c_str());
+  if (!gUseGDMLMagnets) {
+    // === Analytic geometry: build magnets in C++ (NA6PDipoleVT/MS) ===
+    TGeoManager* geom =
+      new TGeoManager(name.c_str(), (name + " TGeometry").c_str());
+
+    // Make sure common materials (e.g. Air) exist
+    createCommonMaterials();
+
+    // World box in cm (half-sizes 1000x1000x1000)
+    TGeoVolume* world =
+      geom->MakeBox("World",
+                    NA6PTGeoHelper::instance().getMedium("Air"),
+                    1000., 1000., 1000.);
+    geom->SetTopVolume(world);
+
+    // build modules (including NA6PDipoleVT/MS if they were added)
+    for (auto m : mModulesVec) {
+      m->createMaterials();
+      m->createGeometry(world);
+    }
+
+    // Recolour volumes: all Iron* media blue, all Copper* media yellow.
+    {
+      auto* vols = geom->GetListOfVolumes();
+      if (vols) {
+        for (int i = 0; i < vols->GetEntriesFast(); ++i) {
+          auto* v = static_cast<TGeoVolume*>(vols->At(i));
+          if (!v) {
+            continue;
+          }
+          auto* med = v->GetMedium();
+          if (!med) {
+            continue;
+          }
+          const TGeoMaterial* mat = med->GetMaterial();
+          const char* mname = nullptr;
+          if (mat && mat->GetName()) {
+            mname = mat->GetName();
+          } else if (med->GetName()) {
+            mname = med->GetName();
+          }
+          if (!mname) {
+            continue;
+          }
+          std::string nm = mname;
+          if (nm.find("Iron") != std::string::npos || nm.find("Fe") != std::string::npos) {
+            v->SetLineColor(kGray);
+          } else if (nm.find("Copper") != std::string::npos || nm.find("Cu") != std::string::npos) {
+            v->SetLineColor(kRed);
+          }
+        }
+      }
+    }
+
+    // Close the geometry
+    geom->CloseGeometry();
+    for (auto m : mModulesVec) {
+      m->setAlignableEntries();
+    }
+    // Export to file
+    geom->Export("geometry.root");
+    return;
+  }
+
+  // === GDML-based magnets: import BothMagnets.gdml and attach remaining modules ===
+
+  // Path to the GDML file can be overridden via NA6P_BOTHMAGNETS_GDML.
+  const char* gdmlPathEnv = std::getenv("NA6P_BOTHMAGNETS_GDML");
+  std::string gdmlPath = gdmlPathEnv ? gdmlPathEnv : "/home/access/Alice/BothMagnets.gdml";
+
+  LOGP(info, "Importing geometry from GDML file: {}", gdmlPath);
+  TGeoManager::Import(gdmlPath.c_str());
+
+  TGeoManager* geom = gGeoManager;
+  if (!geom) {
+    LOGP(fatal, "Failed to create TGeoManager from GDML file {}", gdmlPath);
+  }
+
+  // Ensure common materials (e.g. Air) exist for modules that use NA6PTGeoHelper.
   createCommonMaterials();
-  TGeoVolume* world = geom->MakeBox("World", NA6PTGeoHelper::instance().getMedium("Air"), 1000, 1000, 1000);
-  geom->SetTopVolume(world);
-  //
-  // build modules
+
+  TGeoVolume* world = geom->GetTopVolume();
+  if (!world) {
+    LOGP(fatal, "No top volume found after importing GDML file {}", gdmlPath);
+  }
+
+  {
+    const auto& param = NA6PLayoutParam::Instance();
+    const double shiftX = param.posDipIP[0];
+    const double shiftY = param.posDipIP[1];
+    const double shiftZ = param.posDipIP[2];
+
+    TGeoIterator it(world);
+    TGeoNode* node = nullptr;
+    TGeoNode* mep48Node = nullptr;
+
+    while ((node = it())) {
+      const char* nname = node->GetName();
+      const char* vname = node->GetVolume()->GetName();
+      if ((strcmp(nname, "PV_MEP48") == 0) || (strcmp(vname, "MEP48") == 0)) {
+        mep48Node = node;
+        break;
+      }
+    }
+
+    if (mep48Node) {
+      const Double_t* tr = it.GetCurrentMatrix()->GetTranslation();
+      // Apply layout shift relative to the baseline GDML placement.
+      Double_t newTr[3] = {tr[0] + shiftX, tr[1] + shiftY, tr[2] + shiftZ};
+
+      auto* origMat = mep48Node->GetMatrix();
+      auto* newMat = new TGeoHMatrix(*origMat);
+      newMat->SetTranslation(newTr);
+
+      if (auto* nodeMat = dynamic_cast<TGeoNodeMatrix*>(mep48Node)) {
+        nodeMat->SetMatrix(newMat);
+        LOGP(info, "Shifted first magnet (PV_MEP48) by d(posDipIP) = (%g,%g,%g) cm",
+             shiftX, shiftY, shiftZ);
+      } else {
+        LOGP(warn, "Found PV_MEP48 / MEP48, but it is not a TGeoNodeMatrix; cannot reset matrix");
+        delete newMat;
+      }
+    } else {
+      LOGP(warn, "Could not find PV_MEP48 / MEP48 node to align first magnet to posDipIP");
+    }
+  }
+
+  // --- Second magnet (MNP33) : PV_MNP33 / MNP33 ---
+  {
+    const auto& param = NA6PLayoutParam::Instance();
+    const double targetX = param.posDipMS[0];
+    const double targetY = param.posDipMS[1];
+    const double targetZ = param.posDipMS[2];
+
+    TGeoIterator it(world);
+    TGeoNode* node = nullptr;
+    TGeoNode* mnp33Node = nullptr;
+
+    while ((node = it())) {
+      // Heuristics: either node name "PV_MNP33" (from GDML physvol),
+      // or volume name "MNP33" (local world of the second magnet).
+      const char* nname = node->GetName();
+      const char* vname = node->GetVolume()->GetName();
+      if ((strcmp(nname, "PV_MNP33") == 0) || (strcmp(vname, "MNP33") == 0)) {
+        mnp33Node = node;
+        break;
+      }
+    }
+
+    if (mnp33Node) {
+      const Double_t* tr = it.GetCurrentMatrix()->GetTranslation();
+      double dx = targetX - tr[0];
+      double dy = targetY - tr[1];
+      double dz = targetZ - tr[2];
+
+      // Create a new matrix with updated translation and attach it to the node,
+      // if it is a TGeoNodeMatrix (only that subclass owns a mutable matrix).
+      auto* origMat = mnp33Node->GetMatrix();
+      auto* newMat = new TGeoHMatrix(*origMat);
+      Double_t newTr[3] = {tr[0] + dx, tr[1] + dy, tr[2] + dz};
+      newMat->SetTranslation(newTr);
+
+      if (auto* nodeMat = dynamic_cast<TGeoNodeMatrix*>(mnp33Node)) {
+        nodeMat->SetMatrix(newMat);
+        LOGP(info, "Shifted second magnet (PV_MNP33) by dx=%g dy=%g dz=%g cm to align with posDipMS",
+             dx, dy, dz);
+      } else {
+        LOGP(warn, "Found PV_MNP33 / MNP33, but it is not a TGeoNodeMatrix; cannot reset matrix");
+        delete newMat;
+      }
+    } else {
+      LOGP(warn, "Could not find PV_MNP33 / MNP33 node to align second magnet to posDipMS");
+    }
+  }
+
+  {
+    auto& helper = NA6PTGeoHelper::instance();
+    TGeoMedium* airMed = helper.getMedium("Air", /*fatalIfMissing=*/true);
+    if (airMed) {
+      if (world->GetMedium() != airMed) {
+        LOGP(info, "Assigning Air medium to top volume {}", world->GetName());
+        world->SetMedium(airMed);
+      }
+      if (auto v = geom->FindVolumeFast("World")) {
+        if (v->GetMedium() != airMed) {
+          LOGP(info, "Assigning Air medium to volume {}", v->GetName());
+          v->SetMedium(airMed);
+        }
+      }
+
+      if (auto v = geom->FindVolumeFast("MNP33")) {
+        if (v->GetMedium() != airMed) {
+          LOGP(info, "Assigning Air medium to volume {}", v->GetName());
+          v->SetMedium(airMed);
+        }
+      }
+      // First magnet local world (assembly MEP48) in GDML
+      if (auto v = geom->FindVolumeFast("MEP48")) {
+        if (v->GetMedium() != airMed) {
+          LOGP(info, "Assigning Air medium to volume {}", v->GetName());
+          v->SetMedium(airMed);
+        }
+      }
+    }
+
+    // Try to reuse media created from GDML materials for iron and copper.
+    auto getMedIfExists = [geom](const char* name) -> TGeoMedium* {
+      auto* m = geom->GetMedium(name);
+      return m;
+    };
+
+    TGeoMedium* feMed = getMedIfExists("G4_Fe");
+    if (!feMed) {
+      feMed = getMedIfExists("G4_Fe0x39eca690");
+    }
+    TGeoMedium* cuMed = getMedIfExists("G4_Cu");
+    if (!cuMed) {
+      cuMed = getMedIfExists("G4_Cu0x39e8a110");
+    }
+
+    // assign names Iron_DipoleVT / Copper_DipoleVT / Iron_DipoleMS /
+    // Copper_DipoleMS to GDML magnet parts.
+    {
+      NA6PDipoleVT vtDummy;
+      vtDummy.createMaterials();
+      NA6PDipoleMS msDummy;
+      msDummy.createMaterials();
+    }
+
+    TGeoMedium* feVT = helper.getMedium("Iron_DipoleVT", /*fatalIfMissing=*/false);
+    TGeoMedium* cuVT = helper.getMedium("Copper_DipoleVT", /*fatalIfMissing=*/false);
+    TGeoMedium* feMS = helper.getMedium("Iron_DipoleMS", /*fatalIfMissing=*/false);
+    TGeoMedium* cuMS = helper.getMedium("Copper_DipoleMS", /*fatalIfMissing=*/false);
+
+    auto assignMediumIfFound = [&](const char* volName, TGeoMedium* med) {
+      if (!med) {
+        return;
+      }
+      if (auto* v = geom->FindVolumeFast(volName)) {
+        LOGP(info, "Assigning medium {} to volume {}", med->GetName(), v->GetName());
+        v->SetMedium(med);
+      }
+    };
+
+    // Magnet volumes in BothMagnets.gdml
+
+    assignMediumIfFound("gap",      feVT ? feVT : feMed);
+    assignMediumIfFound("yokeUp",   feVT ? feVT : feMed);
+    assignMediumIfFound("yokeDown", feVT ? feVT : feMed);
+    assignMediumIfFound("poleUp",   feVT ? feVT : feMed);
+    assignMediumIfFound("poleDown", feVT ? feVT : feMed);
+    assignMediumIfFound("coilUp",   cuVT ? cuVT : cuMed);
+    assignMediumIfFound("coilDown", cuVT ? cuVT : cuMed);
+    assignMediumIfFound("yoke",       feMS ? feMS : feMed);
+    assignMediumIfFound("coil_big",   cuMS ? cuMS : cuMed);
+    assignMediumIfFound("coil_small", cuMS ? cuMS : cuMed);
+  }
+
+  {
+    if (auto* v = geom->FindVolumeFast("MEP48")) {
+      LOGP(info, "Renaming GDML volume MEP48 to DipoleVT for consistency with analytic geometry");
+      v->SetName("DipoleVT");
+    }
+    if (auto* v = geom->FindVolumeFast("MNP33")) {
+      LOGP(info, "Renaming GDML volume MNP33 to DipoleMS for consistency with analytic geometry");
+      v->SetName("DipoleMS");
+    }
+  }
+
+  // build remaining modules (magnets are already in the GDML)
   for (auto m : mModulesVec) {
     m->createMaterials();
     m->createGeometry(world);
+  }
+
+  // Recolour volumes: all Iron* media blue, all Copper* media yellow.
+  {
+    auto* vols = geom->GetListOfVolumes();
+    if (vols) {
+      for (int i = 0; i < vols->GetEntriesFast(); ++i) {
+        auto* v = static_cast<TGeoVolume*>(vols->At(i));
+        if (!v) {
+          continue;
+        }
+        auto* med = v->GetMedium();
+        if (!med) {
+          continue;
+        }
+        const TGeoMaterial* mat = med->GetMaterial();
+        const char* mname = nullptr;
+        if (mat && mat->GetName()) {
+          mname = mat->GetName();
+        } else if (med->GetName()) {
+          mname = med->GetName();
+        }
+        if (!mname) {
+          continue;
+        }
+        std::string nm = mname;
+        if (nm.find("Iron") != std::string::npos || nm.find("Fe") != std::string::npos) {
+          v->SetLineColor(kGray);
+        } else if (nm.find("Copper") != std::string::npos || nm.find("Cu") != std::string::npos) {
+          v->SetLineColor(kRed);
+        }
+      }
+    }
   }
 
   // Close the geometry

--- a/sim/src/NA6PMagnetsGDML.cxx
+++ b/sim/src/NA6PMagnetsGDML.cxx
@@ -1,0 +1,217 @@
+// NA6PCCopyright
+#include "NA6PMagnetsGDML.h"
+#include "NA6PDetector.h"
+#include "NA6PTGeoHelper.h"
+#include "NA6PLayoutParam.h"
+#include "NA6PDipoleVT.h"
+#include "NA6PDipoleMS.h"
+
+#include <TGeoManager.h>
+#include <TGeoVolume.h>
+#include <TGeoNode.h>
+#include <TGeoMatrix.h>
+#include <TColor.h>
+#include <fairlogger/Logger.h>
+#include <cstdlib>
+
+std::string NA6PMagnetsGDML::getGDMLPath() const
+{
+  const char* gdmlPathEnv = std::getenv("NA6P_BOTHMAGNETS_GDML");
+  // Default to BothMagnets.gdml in user's Alice directory
+  // TODO: should be moved to NA6PRoot/data/ directory for production
+  return gdmlPathEnv ? gdmlPathEnv : "/home/access/Alice/NA6PRoot/data/BothMagnets.gdml";
+}
+
+void NA6PMagnetsGDML::createMaterials()
+{
+  // For GDML-based magnets we need to ensure that the analytic magnet
+  // materials (Iron_DipoleVT, Copper_DipoleVT, Iron_DipoleMS, Copper_DipoleMS)
+  // exist so we can map GDML volumes to them for consistency.
+  {
+    NA6PDipoleVT vtDummy;
+    vtDummy.createMaterials();
+    NA6PDipoleMS msDummy;
+    msDummy.createMaterials();
+  }
+}
+
+void NA6PMagnetsGDML::createGeometry(TGeoVolume* world)
+{
+  // The GDML import and magnet setup is handled by NA6PDetector::createGeometry
+  // which calls the helper methods (assignMediaToGDMLVolumes, alignMagnetsToLayout,
+  // harmoniseVolumeNames) directly. This method is left empty because the GDML
+  // file already contains the magnet geometry.
+}
+
+void NA6PMagnetsGDML::assignMediaToGDMLVolumes()
+{
+  // Assign proper TGeoMedium to volumes imported from GDML, which initially
+  // have no medium or dummy medium. This is needed for Geant4 VMC to work.
+  auto& helper = NA6PTGeoHelper::instance();
+  auto* geom = gGeoManager;
+
+  TGeoMedium* airMed = helper.getMedium("Air", /*fatalIfMissing=*/false);
+  if (airMed) {
+    auto assignAirIfNeeded = [&](const char* vname) {
+      if (auto* v = geom->FindVolumeFast(vname)) {
+        if (v->GetMedium() != airMed) {
+          LOGP(info, "Assigning Air medium to volume {}", v->GetName());
+          v->SetMedium(airMed);
+        }
+      }
+    };
+    assignAirIfNeeded("worldVOL");
+    assignAirIfNeeded("World");
+    assignAirIfNeeded("MNP33");
+    assignAirIfNeeded("MEP48");
+  }
+
+  // Get GDML materials (fallback if analytic ones are not available)
+  auto getMedIfExists = [geom](const char* name) -> TGeoMedium* {
+    return geom->GetMedium(name);
+  };
+
+  TGeoMedium* feMed = getMedIfExists("G4_Fe");
+  if (!feMed) {
+    feMed = getMedIfExists("G4_Fe0x39eca690");
+  }
+  TGeoMedium* cuMed = getMedIfExists("G4_Cu");
+  if (!cuMed) {
+    cuMed = getMedIfExists("G4_Cu0x39e8a110");
+  }
+
+  // Prefer analytic magnet media for consistency
+  TGeoMedium* feVT = helper.getMedium("Iron_DipoleVT", /*fatalIfMissing=*/false);
+  TGeoMedium* cuVT = helper.getMedium("Copper_DipoleVT", /*fatalIfMissing=*/false);
+  TGeoMedium* feMS = helper.getMedium("Iron_DipoleMS", /*fatalIfMissing=*/false);
+  TGeoMedium* cuMS = helper.getMedium("Copper_DipoleMS", /*fatalIfMissing=*/false);
+
+  auto assignMediumIfFound = [&](const char* volName, TGeoMedium* med) {
+    if (!med) {
+      return;
+    }
+    if (auto* v = geom->FindVolumeFast(volName)) {
+      LOGP(info, "Assigning medium {} to volume {}", med->GetName(), v->GetName());
+      v->SetMedium(med);
+    }
+  };
+
+  // First magnet (DipoleVT / MEP48): gap, yokes, poles, coils
+  assignMediumIfFound("gap",      feVT ? feVT : feMed);
+  assignMediumIfFound("yokeUp",   feVT ? feVT : feMed);
+  assignMediumIfFound("yokeDown", feVT ? feVT : feMed);
+  assignMediumIfFound("poleUp",   feVT ? feVT : feMed);
+  assignMediumIfFound("poleDown", feVT ? feVT : feMed);
+  assignMediumIfFound("coilUp",   cuVT ? cuVT : cuMed);
+  assignMediumIfFound("coilDown", cuVT ? cuVT : cuMed);
+
+  // Second magnet (DipoleMS / MNP33): yoke, coils
+  assignMediumIfFound("yoke",       feMS ? feMS : feMed);
+  assignMediumIfFound("coil_big",   cuMS ? cuMS : cuMed);
+  assignMediumIfFound("coil_small", cuMS ? cuMS : cuMed);
+}
+
+void NA6PMagnetsGDML::alignMagnetsToLayout(TGeoVolume* world)
+{
+  const auto& param = NA6PLayoutParam::Instance();
+  auto* geom = gGeoManager;
+
+  // --- First magnet (MEP48) : align to posDipIP[...] ---
+  {
+    const double shiftX = param.posDipIP[0];
+    const double shiftY = param.posDipIP[1];
+    const double shiftZ = param.posDipIP[2];
+
+    TGeoIterator it(world);
+    TGeoNode* node = nullptr;
+    TGeoNode* mep48Node = nullptr;
+
+    while ((node = it())) {
+      const char* nname = node->GetName();
+      const char* vname = node->GetVolume()->GetName();
+      if ((strcmp(nname, "PV_MEP48") == 0) || (strcmp(vname, "MEP48") == 0)) {
+        mep48Node = node;
+        break;
+      }
+    }
+
+    if (mep48Node) {
+      const Double_t* tr = it.GetCurrentMatrix()->GetTranslation();
+      Double_t newTr[3] = {tr[0] + shiftX, tr[1] + shiftY, tr[2] + shiftZ};
+
+      auto* origMat = mep48Node->GetMatrix();
+      auto* newMat = new TGeoHMatrix(*origMat);
+      newMat->SetTranslation(newTr);
+
+      if (auto* nodeMat = dynamic_cast<TGeoNodeMatrix*>(mep48Node)) {
+        nodeMat->SetMatrix(newMat);
+        LOGP(info, "Shifted first magnet (PV_MEP48) by d(posDipIP) = (%g,%g,%g) cm",
+             shiftX, shiftY, shiftZ);
+      } else {
+        LOGP(warn, "Found PV_MEP48 / MEP48, but it is not a TGeoNodeMatrix; cannot reset matrix");
+        delete newMat;
+      }
+    } else {
+      LOGP(warn, "Could not find PV_MEP48 / MEP48 node to align first magnet to posDipIP");
+    }
+  }
+
+  // --- Second magnet (MNP33) : align to posDipMS[...] ---
+  {
+    const double targetX = param.posDipMS[0];
+    const double targetY = param.posDipMS[1];
+    const double targetZ = param.posDipMS[2];
+
+    TGeoIterator it(world);
+    TGeoNode* node = nullptr;
+    TGeoNode* mnp33Node = nullptr;
+
+    while ((node = it())) {
+      const char* nname = node->GetName();
+      const char* vname = node->GetVolume()->GetName();
+      if ((strcmp(nname, "PV_MNP33") == 0) || (strcmp(vname, "MNP33") == 0)) {
+        mnp33Node = node;
+        break;
+      }
+    }
+
+    if (mnp33Node) {
+      const Double_t* tr = it.GetCurrentMatrix()->GetTranslation();
+      double dx = targetX - tr[0];
+      double dy = targetY - tr[1];
+      double dz = targetZ - tr[2];
+
+      auto* origMat = mnp33Node->GetMatrix();
+      auto* newMat = new TGeoHMatrix(*origMat);
+      Double_t newTr[3] = {tr[0] + dx, tr[1] + dy, tr[2] + dz};
+      newMat->SetTranslation(newTr);
+
+      if (auto* nodeMat = dynamic_cast<TGeoNodeMatrix*>(mnp33Node)) {
+        nodeMat->SetMatrix(newMat);
+        LOGP(info, "Shifted second magnet (PV_MNP33) by dx=%g dy=%g dz=%g cm to align with posDipMS",
+             dx, dy, dz);
+      } else {
+        LOGP(warn, "Found PV_MNP33 / MNP33, but it is not a TGeoNodeMatrix; cannot reset matrix");
+        delete newMat;
+      }
+    } else {
+      LOGP(warn, "Could not find PV_MNP33 / MNP33 node to align second magnet to posDipMS");
+    }
+  }
+}
+
+void NA6PMagnetsGDML::harmoniseVolumeNames()
+{
+  // Rename GDML volumes to match analytic magnet names:
+  //   MEP48 (first magnet) -> DipoleVT
+  //   MNP33 (second magnet) -> DipoleMS
+  auto* geom = gGeoManager;
+  if (auto* v = geom->FindVolumeFast("MEP48")) {
+    LOGP(info, "Renaming GDML volume MEP48 to DipoleVT for consistency with analytic geometry");
+    v->SetName("DipoleVT");
+  }
+  if (auto* v = geom->FindVolumeFast("MNP33")) {
+    LOGP(info, "Renaming GDML volume MNP33 to DipoleMS for consistency with analytic geometry");
+    v->SetName("DipoleMS");
+  }
+}


### PR DESCRIPTION
This PR implements GDML-based magnet geometry integration into the NA6PRoot project while maintaining compatibility with the existing magnets geometry description.

External magnet geometry from `.gdml` files can now be imported into the simulation
Toggle between existing magnets geometry (C++) and GDML geometries using the `--use-gdml-magnets` flag
Magnet positions are automatically aligned to values from `na6pLayout.ini` configuration file
Preserved magnet volume names: `DipoleVT` (first magnet) and `DipoleMS` (second magnet) for both geometry variants
Maintained separate material definitions for each magnet:
  - `Iron_DipoleVT` / `Copper_DipoleVT` for the first magnet
  - `Iron_DipoleMS` / `Copper_DipoleMS` for the second magnet
Note: Copper_DipoleMS is currently a copy of Copper_DipoleVT; its material properties should be updated.