### PR TITLE
Add MS and Matching in NA6PRec

### DIFF
--- a/NA6PRec.cxx
+++ b/NA6PRec.cxx
@@ -15,10 +15,26 @@
 #include "MagneticField.h"
 #include "StringUtils.h"
 #include "NA6PVerTelReconstruction.h"
+#include "NA6PMuonSpecReconstruction.h"
+#include "NA6PMatching.h"
+
+double getPrimaryVertexZ(TTree* mcTree, std::vector<TParticle>* mcArr, int eventID)
+{
+  if (!mcTree || !mcArr) {
+    return 0.0;
+  }
+  mcTree->GetEvent(eventID);
+  for (const auto& part : *mcArr) {
+    if (part.IsPrimary()) {
+      return part.Vz();
+    }
+  }
+  return 0.0;
+}
 
 int main(int argc, char** argv)
 {
-  const std::string layoutIni = "na6pLayout.ini";
+  const std::string paramsIni = "na6pRecoParam.ini";
   fair::Logger::OnFatal([]() { throw std::runtime_error("Fatal error"); });
 
   namespace bpo = boost::program_options;
@@ -35,11 +51,14 @@ int main(int argc, char** argv)
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");
     add_option("load-ini", bpo::value<std::string>()->default_value(""), "load configurables from ini file (if defined), overridden by configKeyValues");
     add_option("load-recoparam", bpo::value<std::string>()->default_value(""), "load reco parameters from ini file (if defined), overridden by configKeyValues");
+    add_option("disable-write-ini", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not write reco parameters ini file");
     add_option("firstevent,f", bpo::value<int32_t>()->default_value(0), "first event");
     add_option("lastevent,l", bpo::value<int32_t>()->default_value(-1), "last event");
     add_option("doHitsToRecPoints,cl", bpo::value<bool>()->default_value(true), "run hits->clusters");
     add_option("doTrackletVertex,vert", bpo::value<bool>()->default_value(true), "run tracklet vertexer");
     add_option("doVTTracking,vt", bpo::value<bool>()->default_value(true), "run VT tracker");
+    add_option("doMSTracking,ms", bpo::value<bool>()->default_value(true), "run MS tracker");
+    add_option("doMatching,mt", bpo::value<bool>()->default_value(true), "run matching between VT and MS");
     opt_all.add(opt_general).add(opt_hidden);
     bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
 
@@ -58,6 +77,7 @@ int main(int argc, char** argv)
     std::cerr << e.what() << ", application will now exit" << std::endl;
     exit(2);
   }
+
   auto flini = vm["load-ini"].as<std::string>();
   na6p::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
   if (!flini.empty()) {
@@ -69,19 +89,26 @@ int main(int argc, char** argv)
   }
   LOGP(info, "Printing all configs");
   na6p::conf::ConfigurableParam::printAllKeyValuePairs();
+
+  const bool doHitsToRecPoints = vm["doHitsToRecPoints"].as<bool>();
+  const bool doTrackletVertex = vm["doTrackletVertex"].as<bool>();
+  const bool doVTTracking = vm["doVTTracking"].as<bool>();
+  const bool doMSTracking = vm["doMSTracking"].as<bool>();
+  const bool doMatching = vm["doMatching"].as<bool>();
+
   int firstEv = vm["firstevent"].as<int32_t>();
   int lastEv = vm["lastevent"].as<int32_t>();
 
-  // mag field definition
   auto magField = new MagneticField();
   magField->loadField();
   magField->setAsGlobalField();
 
   NA6PVerTelReconstruction* vtrec = new NA6PVerTelReconstruction();
   vtrec->setGeometryFile("geometry.root");
+  NA6PMuonSpecReconstruction* msrec = new NA6PMuonSpecReconstruction();
+  NA6PMatching* matching = new NA6PMatching();
 
-  if (vm["doHitsToRecPoints"].as<bool>()) {
-
+  if (doHitsToRecPoints) {
     TFile* fhVT = TFile::Open("HitsVerTel.root");
     if (!fhVT || fhVT->IsZombie()) {
       LOGP(error, "Cannot open HitsVerTel.root");
@@ -116,92 +143,288 @@ int main(int argc, char** argv)
     LOGP(info, "Hits -> Recpoints disabled from input options");
   }
 
-  if (vm["doVTTracking"].as<bool>() || vm["doTrackletVertex"].as<bool>()) {
-
-    TFile* fk = TFile::Open("MCKine.root");
+  const bool needsMCKine = doTrackletVertex || doVTTracking || doMSTracking || doMatching;
+  TFile* fk = nullptr;
+  TTree* mcTree = nullptr;
+  std::vector<TParticle>* mcArr = nullptr;
+  if (needsMCKine) {
+    fk = TFile::Open("MCKine.root");
     if (!fk || fk->IsZombie()) {
       LOGP(error, "Cannot open MCKine.root");
       if (fk)
         delete fk;
       return -1;
     }
-    TTree* mcTree = (TTree*)fk->Get("mckine");
+    mcTree = (TTree*)fk->Get("mckine");
     if (!mcTree) {
       LOGP(error, "Cannot find tree 'mckine' in MCKine.root");
       fk->Close();
       delete fk;
       return -1;
     }
-    std::vector<TParticle>* mcArr = nullptr;
     mcTree->SetBranchAddress("tracks", &mcArr);
+  }
 
-    TFile* fc = TFile::Open("ClustersVerTel.root");
-    if (!fc || fc->IsZombie()) {
+  TFile* fcVT = nullptr;
+  TTree* tcVT = nullptr;
+  std::vector<NA6PVerTelCluster> vtClus, *vtClusPtr = &vtClus;
+
+  if (doTrackletVertex || doVTTracking) {
+    fcVT = TFile::Open("ClustersVerTel.root");
+    if (!fcVT || fcVT->IsZombie()) {
       LOGP(error, "Cannot open ClustersVerTel.root");
-      if (fc)
-        delete fc;
+      if (fcVT)
+        delete fcVT;
       return -1;
     }
-    TTree* tc = (TTree*)fc->Get("clustersVerTel");
-    if (!tc) {
+    tcVT = (TTree*)fcVT->Get("clustersVerTel");
+    if (!tcVT) {
       LOGP(error, "Cannot find tree 'clustersVerTel' in ClustersVerTel.root");
-      fc->Close();
-      delete fc;
+      fcVT->Close();
+      delete fcVT;
       return -1;
     }
-    std::vector<NA6PVerTelCluster> vtClus, *vtClusPtr = &vtClus;
-    tc->SetBranchAddress("VerTel", &vtClusPtr);
+    tcVT->SetBranchAddress("VerTel", &vtClusPtr);
+  }
 
-    int nEv = tc->GetEntries();
+  TFile* fcMS = nullptr;
+  TTree* tcMS = nullptr;
+  std::vector<NA6PMuonSpecCluster> msClus, *msClusPtr = &msClus;
+
+  if (doMSTracking) {
+    fcMS = TFile::Open("ClustersMuonSpec.root");
+    if (!fcMS || fcMS->IsZombie()) {
+      LOGP(error, "Cannot open ClustersMuonSpec.root");
+      if (fcMS)
+        delete fcMS;
+      return -1;
+    }
+    tcMS = (TTree*)fcMS->Get("clustersMuonSpec");
+    if (!tcMS) {
+      LOGP(error, "Cannot find tree 'clustersMuonSpec' in ClustersMuonSpec.root");
+      fcMS->Close();
+      delete fcMS;
+      return -1;
+    }
+    tcMS->SetBranchAddress("MuonSpec", &msClusPtr);
+  }
+
+  if (doTrackletVertex || doVTTracking || doMSTracking) {
+    int nEv = -1;
+    if (tcVT) {
+      nEv = tcVT->GetEntries();
+    }
+    if (tcMS) {
+      int nEvMS = tcMS->GetEntries();
+      nEv = (nEv < 0) ? nEvMS : std::min(nEv, nEvMS);
+    }
+    if (nEv < 0) {
+      LOGP(error, "No input trees for tracking stage");
+      return -1;
+    }
     if (lastEv > nEv || lastEv < 0)
       lastEv = nEv;
     if (firstEv < 0)
       firstEv = 0;
 
-    if (vm["doTrackletVertex"].as<bool>())
+    if (doTrackletVertex)
       vtrec->initVertexer();
-    if (vm["doVTTracking"].as<bool>())
+    if (doVTTracking)
       vtrec->initTracker();
+    if (doMSTracking) {
+      msrec->initTracker();
+    }
+    TStopwatch timer;
+    timer.Start();
+
+    NA6PVertex pvert;
+    for (int jEv = firstEv; jEv < lastEv; jEv++) {
+      LOGP(info, "Process event {}", jEv);
+      const double zvert = getPrimaryVertexZ(mcTree, mcArr, jEv);
+      pvert.setXYZ(0.f, 0.f, zvert);
+
+      if (doTrackletVertex || doVTTracking) {
+        LOGP(info, "VT reconstruction");
+        vtrec->clearEvent();
+        tcVT->GetEvent(jEv);
+        vtrec->setPrimaryVertex(&pvert);
+        vtrec->setClusters(vtClus);
+        if (doTrackletVertex)
+          vtrec->runVertexerTracklets();
+        if (doVTTracking)
+          vtrec->runTracking();
+      }
+
+      if (doMSTracking) {
+        LOGP(info, "MS reconstruction");
+        msrec->clearEvent();
+        tcMS->GetEvent(jEv);
+        msrec->setPrimaryVertex(&pvert);
+        msrec->setClusters(msClus);
+        msrec->runTracking();
+      }
+    }
+
+    if (doTrackletVertex || doVTTracking) {
+      vtrec->closeVerticesOutput();
+      vtrec->closeTracksOutput();
+    }
+    if (doMSTracking) {
+      msrec->closeTracksOutput();
+    }
+
+    timer.Stop();
+    LOGP(info, "------ Tracking time ------");
+    timer.Print();
+    LOGP(info, "------------------------------");
+  }
+
+  if (doMatching) {
+    matching->initMatching();
+
+    TFile* ft = TFile::Open("TracksVerTel.root");
+    if (!ft || ft->IsZombie()) {
+      LOGP(error, "Cannot open TracksVerTel.root");
+      if (ft)
+        delete ft;
+      return -1;
+    }
+    TTree* tt = (TTree*)ft->Get("tracksVerTel");
+    if (!tt) {
+      LOGP(error, "Cannot find tree 'tracksVerTel' in TracksVerTel.root");
+      ft->Close();
+      delete ft;
+      return -1;
+    }
+    std::vector<NA6PTrack> vtTracks, *vtTracksPtr = &vtTracks;
+    tt->SetBranchAddress("VerTel", &vtTracksPtr);
+
+    TFile* fm = TFile::Open("TracksMuonSpec.root");
+    if (!fm || fm->IsZombie()) {
+      LOGP(error, "Cannot open TracksMuonSpec.root");
+      if (fm)
+        delete fm;
+      return -1;
+    }
+    TTree* tm = (TTree*)fm->Get("tracksMuonSpec");
+    if (!tm) {
+      LOGP(error, "Cannot find tree 'tracksMuonSpec' in TracksMuonSpec.root");
+      fm->Close();
+      delete fm;
+      return -1;
+    }
+    std::vector<NA6PTrack> msTracks, *msTracksPtr = &msTracks;
+    tm->SetBranchAddress("MuonSpec", &msTracksPtr);
+
+    TFile* fvc = TFile::Open("ClustersVerTel.root");
+    if (!fvc || fvc->IsZombie()) {
+      LOGP(error, "Cannot open ClustersVerTel.root");
+      if (fvc)
+        delete fvc;
+      return -1;
+    }
+    TTree* tvertelc = (TTree*)fvc->Get("clustersVerTel");
+    if (!tvertelc) {
+      LOGP(error, "Cannot find tree 'clustersVerTel' in ClustersVerTel.root");
+      fvc->Close();
+      delete fvc;
+      return -1;
+    }
+    std::vector<NA6PVerTelCluster> vtClusMatch, *vtClusMatchPtr = &vtClusMatch;
+    tvertelc->SetBranchAddress("VerTel", &vtClusMatchPtr);
+
+    TFile* fmc = TFile::Open("ClustersMuonSpec.root");
+    if (!fmc || fmc->IsZombie()) {
+      LOGP(error, "Cannot open ClustersMuonSpec.root");
+      if (fmc)
+        delete fmc;
+      return -1;
+    }
+    TTree* tmuonspec = (TTree*)fmc->Get("clustersMuonSpec");
+    if (!tmuonspec) {
+      LOGP(error, "Cannot find tree 'clustersMuonSpec' in ClustersMuonSpec.root");
+      fmc->Close();
+      delete fmc;
+      return -1;
+    }
+    std::vector<NA6PMuonSpecCluster> msClusMatch, *msClusMatchPtr = &msClusMatch;
+    tmuonspec->SetBranchAddress("MuonSpec", &msClusMatchPtr);
+
+    int nEvVT = tt->GetEntries();
+    int nEvMS = tm->GetEntries();
+    int nEv = std::min(nEvVT, nEvMS);
+    if (lastEv > nEv || lastEv < 0)
+      lastEv = nEv;
+    if (firstEv < 0)
+      firstEv = 0;
 
     TStopwatch timer;
     timer.Start();
 
+    NA6PVertex pvert;
     for (int jEv = firstEv; jEv < lastEv; jEv++) {
       LOGP(info, "Process event {}", jEv);
-      vtrec->clearEvent();
-      mcTree->GetEvent(jEv);
-      int nPart = mcArr->size();
-      float zvert = 0;
-      // get primary vertex position from the Kine Tree
-      for (int jp = 0; jp < nPart; jp++) {
-        auto curPart = mcArr->at(jp);
-        if (curPart.IsPrimary()) {
-          zvert = curPart.Vz();
-          break;
-        }
-      }
-      tc->GetEvent(jEv);
-      NA6PVertex pvert;
-      pvert.setXYZ(0., 0., zvert);
-      vtrec->setPrimaryVertex(&pvert);
-      vtrec->setClusters(vtClus);
-      if (vm["doTrackletVertex"].as<bool>())
-        vtrec->runVertexerTracklets();
-      if (vm["doVTTracking"].as<bool>())
-        vtrec->runTracking();
+      const double zvert = getPrimaryVertexZ(mcTree, mcArr, jEv);
+      pvert.setXYZ(0.f, 0.f, zvert);
+
+      tvertelc->GetEvent(jEv);
+      tmuonspec->GetEvent(jEv);
+      tt->GetEvent(jEv);
+      tm->GetEvent(jEv);
+
+      matching->setPrimaryVertex(&pvert);
+      matching->setVerTelClusters(vtClusMatch);
+      matching->setMuonSpecClusters(msClusMatch);
+      matching->setVerTelTracks(vtTracks);
+      matching->setMuonSpecTracks(msTracks);
+
+      matching->runMatching();
     }
-    vtrec->closeVerticesOutput();
-    vtrec->closeTracksOutput();
+    matching->closeTracksOutput();
+
     timer.Stop();
-    LOGP(info, "------ VT reconstruction time ------");
+    LOGP(info, "------ Matching time ------");
     timer.Print();
     LOGP(info, "------------------------------");
+
+    ft->Close();
+    delete ft;
+    fm->Close();
+    delete fm;
+    fvc->Close();
+    delete fvc;
+    fmc->Close();
+    delete fmc;
+  }
+
+  if (fcVT) {
+    fcVT->Close();
+    delete fcVT;
+  }
+  if (fcMS) {
+    fcMS->Close();
+    delete fcMS;
+  }
+  if (fk) {
     fk->Close();
     delete fk;
-    fc->Close();
-    delete fc;
   }
-  delete vtrec;
 
+  if (!vm["disable-write-ini"].as<bool>()) {
+    try {
+      std::string pth = na6p::utils::Str::rectifyDirectory(na6p::conf::ConfigurableParam::getOutputDir());
+      if (pth.empty()) {
+        pth = std::filesystem::current_path();
+      }
+      na6p::conf::ConfigurableParam::writeINI(paramsIni, "reco");
+      LOGP(info, "Stored configurable params to {}/{}", pth, paramsIni);
+    } catch (std::exception e) {
+      LOGP(error, "Failed to store configurable params, the reason is {}", e.what());
+    }
+  }
+
+  delete vtrec;
+  delete msrec;
+  delete matching;
   return 0;
 }

--- a/README.md
+++ b/README.md
@@ -45,4 +45,9 @@ na6psim -n 5 -g $NA6PROOT_ROOT/share/test/genbox.C+
 * \subpage refSIM
 /doxy -->
 
+## Reconstruction: [rec module](rec)
+<!-- doxy
+* \subpage refREC
+/doxy -->
+
 

--- a/rec/README.md
+++ b/rec/README.md
@@ -3,7 +3,101 @@
 /doxy -->
 
 # Reconstruction
+---
 
+Use the executable:
+
+```
+na6prec <options> --configKeyValues "<semicolon-separated configurable params>"
+```
+
+### Layout definition
+
+The detector layout is defined by the `ConfigurableParam`-based [NA6PRecoParam](../rec/include/NA6PRecoParam.h) class. Any parameter defined in this class can be modified from the command line:
+
+```
+na6prec <options> --configKeyValues "rec.msNIterationsTrackerCA=3;rec.zMatching=170;<other settings>"
+```
+
+After execution,  a `na6pRecoParam.ini` file will be created containing the reconstruction settings.
+
+Instead of passing a long `--configKeyValues` string on the command line, you can generate the `na6pRecoParam.ini` file once (even with default options) and then edit the values in the `[reco]` block.
+
+To run the reconstruction with modified parameters (and optionally override some of them from the command line), use:
+
+```
+na6prec <options> --load-ini <user-file.ini> --configKeyValues "<semicolon-separated configurable params>"
+```
+
+The priority order of parameters is:
+
+1. values provided via `--configKeyValues`
+2. values loaded from the `.ini` file
+3. class default values
+
+Writing the `.ini` file can be disabled with:
+
+```
+--disable-write-ini
+```
+### Execution control options
+
+In addition to the parameters in `NA6PRecoParam`, the executable provides options to control the event range.
+
+#### Event range
+
+```
+--firstevent, -f <int>
+--lastevent,  -l <int>
+```
+
+* `--firstevent` (`-f`): first event to process. Default: `0`.
+* `--lastevent` (`-l`): last event to process (inclusive). Default: `-1` (process until the end of the file).
+
+Example:
+
+```
+na6prec <options> -f 100 -l 999
+```
+
+Processes events from 100 to 999.
+
+#### Reconstruction step switches
+
+Each main reconstruction stage can be enabled or disabled from the command line:
+
+```
+--doHitsToRecPoints, -cl <bool>
+--doTrackletVertex,  -vert <bool>
+--doVTTracking,      -vt <bool>
+--doMSTracking,      -ms <bool>
+--doMatching,        -mt <bool>
+```
+
+* `--doHitsToRecPoints` (`-cl`): run the hits → clusters (rec-points) step.
+  Default: `true`.
+
+* `--doTrackletVertex` (`-vert`): run the tracklet-based vertex reconstruction.
+  Default: `true`.
+
+* `--doVTTracking` (`-vt`): run the Vertex Telescope (VT) tracking.
+  Default: `true`.
+
+* `--doMSTracking` (`-ms`): run the Muon Spectrometer (MS) tracking.
+  Default: `true`.
+
+* `--doMatching` (`-mt`): run the matching between VT and MS tracks.
+  Default: `true`.
+
+Example:
+
+```
+na6prec <options> --doMSTracking false --doMatching false
+```
+
+This runs the cluster creation, trackelt vertexing and VT reconstruction without MS tracking and VT–MS matching.
+
+---
 ## Clusters
 
 NA6PBaseCluster class defines the basic properties of cluster objects.

--- a/rec/include/NA6PMatching.h
+++ b/rec/include/NA6PMatching.h
@@ -26,8 +26,14 @@ class NA6PMatching : public NA6PReconstruction
 {
  public:
   NA6PMatching();
+  NA6PMatching(const char* recparfile, const char* geofile = "geometry.root", const char* geoname = "NA6P");
   ~NA6PMatching() override = default;
 
+  void setGeometryFile(const char* geofile, const char* geoname = "NA6P")
+  {
+    mGeoFilName = geofile;
+    mGeoObjName = geoname;
+  }
   void configureFromRecoParam(const std::string& filename = "");
   void setMCMatching(bool mc) { mMCMatching = mc; }
   void setMaxChi2Match(double v) { mMaxChi2Match = v; }
@@ -62,8 +68,7 @@ class NA6PMatching : public NA6PReconstruction
     mMuonSpecClusters = clusters;
   }
 
-  bool init(const char* filename, const char* geoname = "NA6P") override;
-
+  bool initMatching();
   void createTracksOutput() override;
   void clearTracks() override
   {
@@ -92,7 +97,10 @@ class NA6PMatching : public NA6PReconstruction
   std::vector<size_t> prefilterVerTelTracks();
 
   std::vector<NA6PVerTelCluster> mVerTelClusters, *hVerTelClusPtr = &mVerTelClusters;         // vector of clusters
-  std::vector<NA6PMuonSpecCluster> mMuonSpecClusters, *hMuonSpecClusPtr = &mMuonSpecClusters; // vector of clusters                                                     // cluster resolution, cm (for fast simu)
+  std::vector<NA6PMuonSpecCluster> mMuonSpecClusters, *hMuonSpecClusPtr = &mMuonSpecClusters; // vector of clusters
+  std::string mGeoFilName{};                                          // name of geometry file
+  std::string mGeoObjName{};                                          // name of geometry object
+  std::string mRecoParFilName{};                                      // name of reco param file
   double mZMatching = 38.1175;
   bool mIsZMatchingSet = false;
   bool mMCMatching = false;

--- a/rec/include/NA6PMuonSpecReconstruction.h
+++ b/rec/include/NA6PMuonSpecReconstruction.h
@@ -37,9 +37,16 @@ class NA6PMuonSpecReconstruction : public NA6PReconstruction
 {
  public:
   NA6PMuonSpecReconstruction();
+  NA6PMuonSpecReconstruction(const char* recparfile, const char* geofile = "geometry.root", const char* geoname = "NA6P");
   ~NA6PMuonSpecReconstruction() override = default;
 
-  bool init(const char* filename, const char* geoname = "NA6P") override;
+  void setRecoParamFile(const char* recparfile) { mRecoParFilName = recparfile; }
+  void setGeometryFile(const char* geofile, const char* geoname = "NA6P")
+  {
+    mGeoFilName = geofile;
+    mGeoObjName = geoname;
+  }
+  bool initTracker();
   // methods to steer cluster reconstruction
   void createClustersOutput() override;
   void clearClusters() override { mClusters.clear(); }
@@ -62,6 +69,9 @@ class NA6PMuonSpecReconstruction : public NA6PReconstruction
 
  private:
   std::vector<NA6PMuonSpecCluster> mClusters, *hClusPtr = &mClusters; // vector of clusters
+  std::string mGeoFilName{};                                          // name of geometry file
+  std::string mGeoObjName{};                                          // name of geometry object
+  std::string mRecoParFilName{};                                      // name of reco param file
   TFile* mClusFile = nullptr;                                         // file with clusters
   TTree* mClusTree = nullptr;                                         // tree of clusters
   double mCluResX = 100.e-4;                                          // cluster resolution, cm (for fast simu)

--- a/rec/src/NA6PMuonSpecReconstruction.cxx
+++ b/rec/src/NA6PMuonSpecReconstruction.cxx
@@ -12,13 +12,26 @@
 
 ClassImp(NA6PMuonSpecReconstruction)
 
-  NA6PMuonSpecReconstruction::NA6PMuonSpecReconstruction() : NA6PReconstruction("MuonSpec")
+  NA6PMuonSpecReconstruction::NA6PMuonSpecReconstruction() : NA6PReconstruction("MuonSpec"),
+                                                             mGeoFilName{"geometry.root"},
+                                                             mGeoObjName{"NA6P"},
+                                                             mRecoParFilName{""}
 {
 }
 
-bool NA6PMuonSpecReconstruction::init(const char* filename, const char* geoname)
+NA6PMuonSpecReconstruction::NA6PMuonSpecReconstruction(const char* recparfile,
+                                                       const char* geofile,
+                                                       const char* geoname) : NA6PReconstruction("MuonSpec"),
+                                                                              mGeoFilName{geofile},
+                                                                              mGeoObjName{geoname},
+                                                                              mRecoParFilName{recparfile}
 {
-  NA6PReconstruction::init(filename, geoname);
+  initTracker();
+}
+
+bool NA6PMuonSpecReconstruction::initTracker()
+{
+  NA6PReconstruction::init(mGeoFilName.c_str(), mGeoObjName.c_str());
   mMSTracker = new NA6PTrackerCA();
   mMSTracker->configureFromRecoParamMS();
   mMSTracker->setParticleHypothesis(13); // muon mass hypothesis

--- a/test/runMSTracking.C
+++ b/test/runMSTracking.C
@@ -24,7 +24,7 @@ void runMSTracking(int firstEv = 0,
   std::vector<NA6PMuonSpecCluster> msClus, *msClusPtr = &msClus;
   tc->SetBranchAddress("MuonSpec", &msClusPtr);
   NA6PMuonSpecReconstruction* msrec = new NA6PMuonSpecReconstruction();
-  msrec->init(Form("%s/geometry.root", dirSimu));
+  msrec->initTracker();
   auto msTracker = msrec->getTracker();
   // Example of configuring the tracker for Muon Spectrometer
   // msTracker->setNLayers(6);

--- a/test/runMatching.C
+++ b/test/runMatching.C
@@ -50,9 +50,10 @@ void runMatching(
   std::vector<NA6PTrack> msTracks, *msTrackPtr = &msTracks;
   tmstracks->SetBranchAddress("MuonSpec", &msTrackPtr);
 
-  NA6PMatching* matching = new NA6PMatching();
   na6p::conf::ConfigurableParam::updateFromFile(Form("%s/na6pLayout.ini",dirSimu), "", true);
-  matching->init(Form("%s/geometry.root", dirSimu));
+  NA6PMatching* matching = new NA6PMatching();
+  matching->configureFromRecoParam();
+  matching->setGeometryFile(Form("%s/geometry.root", dirSimu));
   matching->setZMatching(zmatch);
   matching->setMCMatching(useMC);
   
@@ -82,8 +83,11 @@ void runMatching(
     tmuonspec->GetEvent(jEv);
     tvttracks->GetEvent(jEv);
     tmstracks->GetEvent(jEv);
-    matching->setPrimaryVertexPosition(0., 0., zvert);
 
+    NA6PVertex pvert;
+    pvert.setXYZ(0., 0., zvert);
+    matching->setPrimaryVertex(&pvert);
+    
     matching->setVerTelClusters(vtClus);
     matching->setMuonSpecClusters(msClus);
     matching->setVerTelTracks(vtTracks);


### PR DESCRIPTION
This PR introduces the Muon Spectrometer reconstruction and matching within NA6PRec.
It also adds the corresponding reconstruction parameters to the configuration file.

The constructors and init methods of NA6PMuonSpecReconstruction and NA6PMatching have been updated following the same approach as in NA6PVerTel.