### PR TITLE
MS tracks: fit outward + match to MID + refit inward

### DIFF
--- a/rec/include/NA6PFastTrackFitter.h
+++ b/rec/include/NA6PFastTrackFitter.h
@@ -81,6 +81,7 @@ class NA6PFastTrackFitter
   void computeSeed(int dir = -1);
   void computeSeedOuter() { computeSeed(-1); }
   void computeSeedInner() { computeSeed(1); }
+  void printClusters() const;
   void printSeed() const;
   const double* getSeedMomentum() const { return mSeedMom; }
   const double* getSeedPosition() const { return mSeedPos; }

--- a/rec/include/NA6PTrack.h
+++ b/rec/include/NA6PTrack.h
@@ -110,6 +110,10 @@ class NA6PTrack
   double getSigmaPX2() const;
   double getSigmaPY2() const;
   double getSigmaPZ2() const;
+  double getChi2VTOuter() const { return mChi2VTOuter; }
+  double getChi2MSOuter() const { return mChi2MSOuter; }
+  double getChi2VTRefit() const { return mChi2VTRefit; }
+  double getChi2MSRefit() const { return mChi2MSRefit; }
   double getNormChi2() const { return mNClusters < 3 ? 0 : (mChi2VT + mChi2MS) / ((mNClusters << 1) - kNDOF); }
   double getPredictedChi2(double* p, double* cov) const { return mExtTrack.getPredictedChi2(p, cov); }
 
@@ -117,6 +121,10 @@ class NA6PTrack
   void setMatchChi2(double chi2) { mMatchChi2 = chi2; }
   void setChi2VT(double chi2) { mChi2VT = chi2; }
   void setChi2MS(double chi2) { mChi2MS = chi2; }
+  void setChi2VTOuter(double chi2) { mChi2VTOuter = chi2; }
+  void setChi2MSOuter(double chi2) { mChi2MSOuter = chi2; }
+  void setChi2VTRefit(double chi2) { mChi2VTRefit = chi2; }
+  void setChi2MSRefit(double chi2) { mChi2MSRefit = chi2; }
   void setParticleLabel(int idx, int lr)
   {
     if (lr < kMaxLr)
@@ -151,6 +159,10 @@ class NA6PTrack
   double mMatchChi2 = 0.f;                   // total chi2
   double mChi2VT = 0.f;                      // total chi2 VT
   double mChi2MS = 0.f;                      // total chi2 MS
+  double mChi2VTOuter = 0.f;                 // total chi2 VT outward fit
+  double mChi2MSOuter = 0.f;                 // total chi2 MS outward fit
+  double mChi2VTRefit = 0.f;                 // total chi2 VT inward refit
+  double mChi2MSRefit = 0.f;                 // total chi2 MS inward refit
   uint32_t mClusterMap = 0;                  // pattern of clusters per layer
   int mNClusters = 0;                        // total hits
   int mNClustersVT = 0;                      // total VT hits
@@ -169,7 +181,7 @@ class NA6PTrack
   bool propagateToZBxByBz(double z, const double* bxyz) { return mExtTrack.propagateToBxByBz(z, bxyz); }
   bool propagateToZBxByBzOuter(double z, const double* bxyz) { return mOuter.propagateToBxByBz(z, bxyz); }
 
-  ClassDefNV(NA6PTrack, 2)
+  ClassDefNV(NA6PTrack, 3)
 };
 
 //_______________________________________________________________________

--- a/rec/src/NA6PFastTrackFitter.cxx
+++ b/rec/src/NA6PFastTrackFitter.cxx
@@ -708,7 +708,9 @@ NA6PTrack* NA6PFastTrackFitter::fitTrackPoints(int dir, NA6PTrack* seed)
     zCurr = zNext;
   }
 
-  if (!isGoodFit)
+  if (!isGoodFit) {
+    delete currTr;
     return nullptr;
+  }
   return currTr;
 }

--- a/rec/src/NA6PFastTrackFitter.cxx
+++ b/rec/src/NA6PFastTrackFitter.cxx
@@ -56,6 +56,17 @@ void NA6PFastTrackFitter::addCluster(int jLay, const NA6PBaseCluster& cl)
   mClusters[jLay] = &cl;
 }
 
+void NA6PFastTrackFitter::printClusters() const
+{
+  LOGP(info, "N layers = {}", mNLayers);
+  for (int jLay = 0; jLay < mNLayers; ++jLay) {
+    if (mClusters[jLay])
+      LOGP(info, "Layer {} Cluster position = {} {} {}", jLay, mClusters[jLay]->getXLab(), mClusters[jLay]->getYLab(), mClusters[jLay]->getZLab());
+    else
+      LOGP(info, "Layer {} No cluster", jLay);
+  }
+}
+
 void NA6PFastTrackFitter::setSeed(const double* pos, const double* mom, int charge)
 {
   if (!pos || !mom) {
@@ -540,7 +551,6 @@ void NA6PFastTrackFitter::computeSeed(int dir, std::array<int, 3>& layForSeed)
     }
     bxyz[1] = aveField / totLength;
   }
-
   // circle fit: compute center (cx, cz) and radius
   double determ = 2.0 * (x1 * (z2 - z3) + x2 * (z3 - z1) + x3 * (z1 - z2));
   double cx = 0.0, cz = 0.0, radius = 1e6;
@@ -620,10 +630,12 @@ NA6PTrack* NA6PFastTrackFitter::fitTrackPoints(int dir, NA6PTrack* seed)
     LOGP(error, "Cannot fit track with only {} clusters\n", nClus);
     return nullptr;
   }
-  NA6PTrack* currTr = nullptr;
+  NA6PTrack* currTr = new NA6PTrack();
   if (seed) {
     // Seed provided as a track from previous pass
-    currTr = new NA6PTrack(*seed);
+    currTr->setParam(seed->getTrackExtParam());
+    seed->getXYZ(mSeedPos);
+    seed->getPXYZ(mSeedMom);
     mIsSeedSet = true;
   } else {
     if (!mIsSeedSet) {
@@ -633,11 +645,10 @@ NA6PTrack* NA6PFastTrackFitter::fitTrackPoints(int dir, NA6PTrack* seed)
       else
         computeSeedOuter();
     }
-    if (!mIsSeedSet)
-      LOGP(warn, "Track seed not computed properly, will run the fit w/o seed");
-    currTr = new NA6PTrack();
     if (mIsSeedSet)
       currTr->init(mSeedPos, mSeedMom, mCharge);
+    else
+      LOGP(warn, "Track seed not computed properly, will run the fit w/o seed");
   }
   currTr->setMass(mMass);
   currTr->resetCovariance(-1);

--- a/rec/src/NA6PTrackerCA.cxx
+++ b/rec/src/NA6PTrackerCA.cxx
@@ -804,11 +804,15 @@ void NA6PTrackerCA::fitAndSelectTracks(const std::vector<TrackCandidate>& trackC
           if (inwRefitPtr) {
             fitTrackFast.setParam(inwRefitPtr->getTrackExtParam());
             fitTrackFast.setStatusRefitInward(true);
+            fitTrackFast.setChi2VTRefit(inwRefitPtr->getChi2VT());
+            fitTrackFast.setChi2MSRefit(inwRefitPtr->getChi2MS());
           } else
             fitTrackFast.setStatusRefitInward(false);
         }
         mTrackFitter->propagateToZ(outwRefitPtr.get(), mZOutProp);
         fitTrackFast.setOuterParam(outwRefitPtr->getTrackExtParam());
+        fitTrackFast.setChi2VTOuter(outwRefitPtr->getChi2VT());
+        fitTrackFast.setChi2MSOuter(outwRefitPtr->getChi2MS());
       }
     }
     if (mPropagateTracksToPrimaryVertex)


### PR DESCRIPTION
With this commit, the macro runMSTrackMIDTrackletMatching.C produces an output root file with a TTree of tracks that are built starting from 4-cluster tracks in the MS + matching to segments in the MID + outward propagation of the tracks to the MID (attaching the clusters in the MID) + inward refit of a 6-cluster track.
This should allow us to compare the performance (efficiency, fakes, resolutions ...) of 4-cluster (MS only) tracks, 6-clusters tracks (MS+MID reconstructed together), and 4+2 tracks (with this matching approach).
Note that the cuts used in the track-tracklet matching are preliminary and hard coded in the macro. They are just meant for initial debug and studies. If this approach will turn out to be the best one, I will do a better implementation in NA6PMuonSpecReconstruction.