### PR TITLE
Set new seeding in matching and add outward+inward refit

### DIFF
--- a/rec/include/NA6PMatching.h
+++ b/rec/include/NA6PMatching.h
@@ -32,7 +32,12 @@ class NA6PMatching : public NA6PReconstruction
   void configureFromRecoParam(const std::string& filename = "");
   void setMCMatching(bool mc) { mMCMatching = mc; }
   void setMaxChi2Match(double v) { mMaxChi2Match = v; }
-  void setMaxChi2Refit(double v) { mMaxChi2Refit = v; }
+  void setMaxChi2Refit(double v)
+  {
+    mMaxChi2Refit = v;
+    if (mTrackFitter)
+      mTrackFitter->setMaxChi2Cl(v);
+  }
   void setMinTrackP(double p) { mMinTrackP = p; }
   void setMinVTHits(int n) { mMinVTHits = n; }
   void setMinMSHits(int n) { mMinMSHits = n; }
@@ -42,7 +47,8 @@ class NA6PMatching : public NA6PReconstruction
     mZMatching = z;
     mIsZMatchingSet = true;
   }
-
+  void setPropagateTracksToPrimaryVertex(bool propagate) { mPropagateTracksToPrimaryVertex = propagate; }
+  void setDoOutwardInwardFit(bool opt = true) { mDoOutwardInwardFit = opt; }
   void setVerTelTracks(const std::vector<NA6PTrack>& tracks)
   {
     mVerTelTracks = tracks;
@@ -93,6 +99,9 @@ class NA6PMatching : public NA6PReconstruction
 
   std::vector<NA6PVerTelCluster> mVerTelClusters, *hVerTelClusPtr = &mVerTelClusters;         // vector of clusters
   std::vector<NA6PMuonSpecCluster> mMuonSpecClusters, *hMuonSpecClusPtr = &mMuonSpecClusters; // vector of clusters
+
+  bool mDoOutwardInwardFit = false;
+  bool mPropagateTracksToPrimaryVertex = false;
   double mZMatching = 38.1175;
   bool mIsZMatchingSet = false;
   bool mMCMatching = false;

--- a/rec/include/NA6PRecoParam.h
+++ b/rec/include/NA6PRecoParam.h
@@ -71,15 +71,17 @@ struct NA6PRecoParam : public na6p::conf::ConfigurableParamHelper<NA6PRecoParam>
   int msMinNClusTracksCA[MaxIterationsTrackerCA] = {6, 6, 0, 0, 0, 0, 0, 0, 0};
   bool msDoConstrainedTrack = false;
   // Matching parameters
-  float zMatching = 40;
-  bool isZMatchingSet = false;
-  bool mcMatching = true;
-  int minVTHits = 5;
-  int minMSHits = 6;
-  float minTrackP = 2.0; // GeV/c
-  float maxChi2Match = std::numeric_limits<float>::max();
-  float maxChi2Refit = std::numeric_limits<float>::max();
-  float pMatchWindow = 3; // GeV/c
+  bool mtDoOutwardInwardFit = true;
+  bool mtPropagateMatchedTracksToPV = true;
+  float mtZMatching = 40;
+  bool mtIsZMatchingSet = false;
+  bool mtMCMatching = true;
+  int mtMinVTHits = 5;
+  int mtMinMSHits = 6;
+  float mtMinTrackP = 2.0; // GeV/c
+  float mtMaxChi2Match = std::numeric_limits<float>::max();
+  float mtMaxChi2Refit = std::numeric_limits<float>::max();
+  float mtPMatchWindow = 3; // GeV/c
 
   NA6PParamDef(NA6PRecoParam, "reco");
 };

--- a/rec/src/NA6PMatching.cxx
+++ b/rec/src/NA6PMatching.cxx
@@ -33,10 +33,11 @@ bool NA6PMatching::initMatching()
   mTrackFitter = new NA6PFastTrackFitter();
   mTrackFitter->loadGeometry(mGeoFilName.c_str(), mGeoObjName.c_str());
   mTrackFitter->enableMaterialCorrections();
-  mTrackFitter->setPropagateToPrimaryVertex(true);
+  mTrackFitter->setPropagateToPrimaryVertex(false);
   mTrackFitter->setNLayers(11);
   mTrackFitter->setParticleHypothesis(13); // muon mass hypothesis
-  mTrackFitter->setMaxChi2Cl(mMaxChi2Refit);
+  mTrackFitter->setUseIntegralBForSeed();
+  configureFromRecoParam(mRecoParFilName);
   createTracksOutput();
   return true;
 }
@@ -48,15 +49,17 @@ void NA6PMatching::configureFromRecoParam(const std::string& filename)
   }
   const auto& param = NA6PRecoParam::Instance();
 
-  if (param.isZMatchingSet)
-    setZMatching(param.zMatching);
-  setMCMatching(param.mcMatching);
-  setMinVTHits(param.minVTHits);
-  setMinMSHits(param.minMSHits);
-  setMinTrackP(param.minTrackP);
-  setMaxChi2Match(param.maxChi2Match);
-  setMaxChi2Refit(param.maxChi2Refit);
-  setPMatchWindow(param.pMatchWindow);
+  if (param.mtIsZMatchingSet)
+    setZMatching(param.mtZMatching);
+  setMCMatching(param.mtMCMatching);
+  setMinVTHits(param.mtMinVTHits);
+  setMinMSHits(param.mtMinMSHits);
+  setMinTrackP(param.mtMinTrackP);
+  setMaxChi2Match(param.mtMaxChi2Match);
+  setMaxChi2Refit(param.mtMaxChi2Refit);
+  setPMatchWindow(param.mtPMatchWindow);
+  setPropagateTracksToPrimaryVertex(param.mtPropagateMatchedTracksToPV);
+  setDoOutwardInwardFit(param.mtDoOutwardInwardFit);
 }
 
 void NA6PMatching::createTracksOutput()
@@ -192,7 +195,7 @@ std::unordered_map<int, int> NA6PMatching::buildMCMatchingIndex()
   for (size_t i = 0; i < mVerTelTracks.size(); ++i) {
     const auto& vt = mVerTelTracks[i];
     int pid = vt.getParticleID();
-    if (pid <= 0)
+    if (pid <= 0 || vt.getNHits() < mMinVTHits)
       continue;
 
     // Prefer track with more hits if there are duplicates with same particle ID
@@ -219,7 +222,10 @@ std::vector<size_t> NA6PMatching::prefilterVerTelTracks()
   return validIndices;
 }
 
-bool NA6PMatching::fitAndStoreMatchedTrack(const NA6PTrack& vtTrk, const NA6PTrack& msTrk, int particleId, double matchChi2)
+bool NA6PMatching::fitAndStoreMatchedTrack(const NA6PTrack& vtTrk,
+                                           const NA6PTrack& msTrk,
+                                           int particleId,
+                                           double matchChi2)
 {
   mTrackFitter->cleanupAndStartFit();
 
@@ -227,16 +233,41 @@ bool NA6PMatching::fitAndStoreMatchedTrack(const NA6PTrack& vtTrk, const NA6PTra
   addClustersToFitter(msTrk, hMuonSpecClusPtr);
 
   NA6PTrack matchedTrack;
-  if (!mTrackFitter->fitTrackPoints(matchedTrack)) {
+  NA6PTrack seed;
+  NA6PTrack* seedPtr = nullptr;
+
+  if (mDoOutwardInwardFit) {
+
+    NA6PTrack vtSeed = vtTrk;
+
+    const float zFirstVTCluster =
+        mVerTelClusters[vtTrk.getClusterIndex(0)].getZLab();
+
+    if (vtSeed.getZLab() != zFirstVTCluster) {
+      mTrackFitter->propagateToZ(&vtSeed, zFirstVTCluster);
+    }
+
+    if (!mTrackFitter->fitTrackPointsOutward(seed, &vtSeed)) {
+      LOGP(warn, "Fit of matched track failed, skipping");
+      return false;
+    }
+
+    seedPtr = &seed;
+  }
+
+  if (!mTrackFitter->fitTrackPointsInward(matchedTrack, seedPtr)) {
     LOGP(warn, "Refit of matched track failed, skipping");
     return false;
   }
 
   matchedTrack.setParticleID(particleId);
   matchedTrack.setMatchChi2(matchChi2);
-  mTrackFitter->propagateToZ(&matchedTrack, mPrimaryVertex->getZ());
-  mMatchedTracks.push_back(std::move(matchedTrack));
 
+  if (mPropagateTracksToPrimaryVertex) {
+    mTrackFitter->propagateToZ(&matchedTrack, mPrimaryVertex->getZ());
+  }
+
+  mMatchedTracks.push_back(std::move(matchedTrack));
   return true;
 }
 
@@ -280,7 +311,6 @@ void NA6PMatching::runDataMatching()
 
     const auto& vtTrack = mVerTelTracks[vtIdx];
     int matchedPartID = isTrueMatch ? msTrack.getParticleID() : -std::abs(msTrack.getParticleID());
-
     fitAndStoreMatchedTrack(vtTrack, msTrack, matchedPartID, bestChi2);
   }
 }


### PR DESCRIPTION
This PR introduces several improvements and fixes to the matching:
- Fix missing configureFromRecoParam call in initMatching
- Set seeding using the integral B field
- Add an option to perform an outward fit using the VT track as seed, followed by an inward (final) refit using the outward-refitted track as seed
- Rename matching-related variables
- Add nMinHit selection in MCMatching as in the chi2-based matching