### PR TITLE
Add envelopes for MEP48 yokes

### DIFF
--- a/sim/src/NA6PMagnetsGDML.cxx
+++ b/sim/src/NA6PMagnetsGDML.cxx
@@ -55,6 +55,8 @@ void NA6PMagnetsGDML::assignMediaToGDMLVolumes()
     assignAirIfNeeded("World");
     assignAirIfNeeded("MNP33");
     assignAirIfNeeded("MEP48");
+    assignAirIfNeeded("EnvYokeUp");
+    assignAirIfNeeded("EnvYokeDown");
   }
 
   TGeoMedium* feVT = helper.getMedium("Iron_DipoleVT", /*fatalIfMissing=*/true);


### PR DESCRIPTION
When using the GDML geometry, the material recorded by tracks inside the MEP48 gap was incorrect for particles with |y| > 10 cm. Tracks were sometimes assigned iron instead of the correct material.

According to Claude, the issue is related to a known navigation problem in ROOT involving TGeoTessellated solids. In particular, the Contains() / Inside() checks in the TGeoNavigator navigation chain can misclassify points as being inside the iron volume when the tessellated solid is:
- non-convex (C-shaped geometry)
- large (~83k triangles)
- a direct child of an assembly with a rotation transformation.

This combination leads to incorrect material attribution in the gap region.

The solution (implemented by Claude) consists of wrapping each tessellated yoke half in a box-shaped air envelope volume. The navigator evaluates the box first, and only descends into the tessellated solid if the point lies inside the box. Since the box tightly bounds the iron mesh, the gap region remains correctly classified as air.
Changes made to the gdml:
- added two box solids (EnvYokeUpBox, EnvYokeDownBox): 1710×1325×3135 mm with 5mm margin around the mesh bounding box
- added two envelope volumes (EnvYokeUp, EnvYokeDown): material G4_AIR, containing yokeUp/yokeDown as daughters, offset to keep the tessellated solid at its original position
- in MEP48 assembly: replaced the direct yokeUp/yokeDown physvols with EnvYokeUp/EnvYokeDown

In the figure, the material budget obtained from NA6PFastTrackFitter::getMeanMaterialBudgetFromGeom, using 1 cm steps, is shown for three configurations: without GDML, with the original GDML geometry, and with the fixed version.

<img width="2000" height="1125" alt="xOvX0" src="https://github.com/user-attachments/assets/9023237d-e402-4c3c-bb99-5f9cad8d947d" />
