### PR TITLE
Use material-dependent Bethe-Bloch; add configurable geometry interrogation step

### DIFF
--- a/rec/include/ExtTrackPar.h
+++ b/rec/include/ExtTrackPar.h
@@ -150,6 +150,8 @@ class ExtTrackPar: public TObject {
   Bool_t correctForMeanMaterialdEdx(Double_t xOverX0, Double_t xTimesRho, 
 	Double_t mass, Double_t dEdx, Bool_t anglecorr=kFALSE);
 
+  Bool_t correctForMeanMaterialGeneral(Double_t xOverX0, Double_t xTimesRho, Double_t mass, Bool_t anglecorr, Double_t density, Double_t atomicZ, Double_t zOverA);
+
   Bool_t correctForMeanMaterialZA(Double_t xOverX0, Double_t xTimesRho, 
                                   Double_t mass,
                                   Double_t zOverA=0.49848,

--- a/rec/include/NA6PFastTrackFitter.h
+++ b/rec/include/NA6PFastTrackFitter.h
@@ -75,6 +75,7 @@ class NA6PFastTrackFitter
   void setUseBatMidPointForSeed() { mOptionForSeedB = kBatMidPoint; }
   void setUseMaximumBForSeed() { mOptionForSeedB = kMaximumB; }
   void setUseIntegralBForSeed() { mOptionForSeedB = kIntegralB; }
+  void setMaxStepForMaterialRecording(double step) { mMaxStepForMaterialRecording = step; }
   int getLayersForSeed(std::array<int, 3>& layForSeed) const;
   int sortLayersForSeed(std::array<int, 3>& layForSeed, int dir) const;
   void computeSeed(int dir, std::array<int, 3>& layForSeed);
@@ -135,6 +136,7 @@ class NA6PFastTrackFitter
   double mPrimVertZ = 0.0;            // primary vertex z
   bool mIsPrimVertSet = false;        // flag for presence of prim vert z
   bool mCorrectForMaterial = true;    // flag for material corrections
+  double mMaxStepForMaterialRecording = 1.0; // step size for recording material budget along track (in cm)
 
   std::vector<const NA6PBaseCluster*> mClusters; // array with clusters
 

--- a/rec/include/NA6PMatching.h
+++ b/rec/include/NA6PMatching.h
@@ -38,6 +38,11 @@ class NA6PMatching : public NA6PReconstruction
     if (mTrackFitter)
       mTrackFitter->setMaxChi2Cl(v);
   }
+  void setMaxStepForMaterialRecording(double step)
+  {
+    if (mTrackFitter)
+      mTrackFitter->setMaxStepForMaterialRecording(step);
+  }
   void setMinTrackP(double p) { mMinTrackP = p; }
   void setMinVTHits(int n) { mMinVTHits = n; }
   void setMinMSHits(int n) { mMinMSHits = n; }

--- a/rec/include/NA6PRecoParam.h
+++ b/rec/include/NA6PRecoParam.h
@@ -9,7 +9,7 @@
 struct NA6PRecoParam : public na6p::conf::ConfigurableParamHelper<NA6PRecoParam> {
 
   static constexpr int MaxIterationsTrackerCA = 10;
-
+  float maxStepForMaterialRecording = 1.0; // in cm
   // VerTel reconstruction parameters
   int vtNLayers = 5;
   // tracklet vertexer

--- a/rec/include/NA6PTrack.h
+++ b/rec/include/NA6PTrack.h
@@ -145,11 +145,11 @@ class NA6PTrack
 
   template <typename ClusterType>
   void addCluster(const ClusterType* clu, int cluIndex, double chi2);
-  bool correctForMeanMaterial(double xOverX0, double xTimesRho, bool anglecorr = false)
+  bool correctForMeanMaterial(double xOverX0, double xTimesRho, double density = 0.f, double atomicZ = 0.f, double zOverA = 0.f, bool anglecorr = false)
   {
-    return mExtTrack.correctForMeanMaterial(xOverX0, xTimesRho, mMass, anglecorr);
+    return mExtTrack.correctForMeanMaterialGeneral(xOverX0, xTimesRho, mMass, anglecorr, density, atomicZ, zOverA);
   }
-  bool propagateToZBxByBz(double z, double maxDZ = 1.0, double xOverX0 = 0., double xTimesRho = 0., bool outer = false);
+  bool propagateToZBxByBz(double z, double maxDZ = 1.0, double xOverX0 = 0., double xTimesRho = 0., bool outer = false, double rho = 0.f, double atomicZ = 0.f, double atomicZoverA = 0.f);
   bool propagateToDCA(NA6PTrack* partner);
   bool update(double p[2], double cov[3]) { return mExtTrack.Update(p, cov); }
 

--- a/rec/include/NA6PTrackerCA.h
+++ b/rec/include/NA6PTrackerCA.h
@@ -105,6 +105,11 @@ class NA6PTrackerCA
     if (mTrackFitter)
       mTrackFitter->setUseBatMidPointForSeed();
   }
+  void setMaxStepForMaterialRecording(double step)
+  {
+    if (mTrackFitter)
+      mTrackFitter->setMaxStepForMaterialRecording(step);
+  }
   void configureFromRecoParamVT(const std::string& filename = "");
   void configureFromRecoParamMS(const std::string& filename = "");
   void setVerbosity(bool opt = true) { mVerbose = opt; }

--- a/rec/src/ExtTrackPar.cxx
+++ b/rec/src/ExtTrackPar.cxx
@@ -581,6 +581,38 @@ Bool_t ExtTrackPar::correctForMeanMaterialdEdx
   return kTRUE;
 }
 
+Bool_t ExtTrackPar::correctForMeanMaterialGeneral(Double_t xOverX0, Double_t xTimesRho, Double_t mass, Bool_t anglecorr, Double_t density, Double_t atomicZ, Double_t zOverA)
+{
+  //------------------------------------------------------------------
+  // This function corrects the track parameters for the crossed material.
+  // "xOverX0"   - X/X0, the thickness in units of the radiation length.
+  // "xTimesRho" - is the product length*density (g/cm^2).
+  //     It should be passed as negative when propagating tracks
+  //     from the intreaction point to the outside of the central barrel.
+  // "mass" - the mass of this particle (GeV/c^2). mass<0 means charge=2
+  // "density" - mean density (g/cm^3)
+  // "atomicZ" - mean Z
+  // "zOverA" - mean Z/A
+  // "anglecorr" - switch for the angular correction
+  // "Bethe" - function calculating the energy loss (GeV/(g/cm^2))
+  //------------------------------------------------------------------
+
+  Double_t bg = getP() / mass;
+  if (mass < 0) {
+    if (mass < -990) {
+      printf("Mass %f corresponds to unknown PID particle\n", mass);
+      return kFALSE;
+    }
+    bg = -2 * bg;
+  }
+  Double_t mI = (atomicZ < 13) ? (12. * atomicZ + 7.) * 1.e-9 : (9.76 * atomicZ + 58.8 * TMath::Power(atomicZ, -0.19)) * 1.e-9;
+  Double_t dEdx = BetheBlochGeant(bg, density, 0.2, 3, mI, zOverA);
+  if (mass < 0)
+    dEdx *= 4;
+
+  return correctForMeanMaterialdEdx(xOverX0, xTimesRho, mass, dEdx, anglecorr);
+}
+
 Bool_t ExtTrackPar::correctForMeanMaterial
 (Double_t xOverX0,  Double_t xTimesRho, Double_t mass, 
  Bool_t anglecorr,

--- a/rec/src/NA6PFastTrackFitter.cxx
+++ b/rec/src/NA6PFastTrackFitter.cxx
@@ -242,6 +242,7 @@ int NA6PFastTrackFitter::propagateToZOuter(NA6PTrack* trc, double zTo) const
 
 int NA6PFastTrackFitter::propagateToZImpl(NA6PTrack* trc, double zFrom, double zTo, int dir, bool outer) const
 {
+  double maxStepForProp = 1;
   // Validate track state
   if (trc->getTrackExtParam().getAlpha() < 0) {
     return -1;
@@ -258,40 +259,53 @@ int NA6PFastTrackFitter::propagateToZImpl(NA6PTrack* trc, double zFrom, double z
     return -1;
   }
 
-  // Get starting position
-  double start[3];
-  if (outer) {
-    trc->getXYZOuter(start);
-  } else {
-    trc->getXYZ(start);
-  }
+  const double totalDeltaZ = zTo - zFrom;
+  const double stepSize = dir * mMaxStepForMaterialRecording; // signed step
+  const int nSteps = std::max(1, static_cast<int>(std::abs(totalDeltaZ) / mMaxStepForMaterialRecording));
 
-  // Create temporary track and propagate without material to get endpoint
-  NA6PTrack tmpTrc = *trc;
-  if (!tmpTrc.propagateToZBxByBz(zTo, 1., 0., 0., outer)) {
-    return 0;
-  }
+  double zCurrent = zFrom;
+  for (int iStep = 0; iStep < nSteps; iStep++) {
+    double zNext = (iStep == nSteps - 1) ? zTo : zCurrent + stepSize;
 
-  double end[3];
-  if (outer) {
-    tmpTrc.getXYZOuter(end);
-  } else {
-    tmpTrc.getXYZ(end);
-  }
+    // Get starting position for this step
+    double start[3];
+    if (outer) {
+      trc->getXYZOuter(start);
+    } else {
+      trc->getXYZ(start);
+    }
 
-  // Calculate material budget along path
-  double mparam[7] = {0.};
-  if (mCorrectForMaterial) {
-    getMeanMaterialBudgetFromGeom(start, end, mparam);
-  }
+    // Create temporary track and propagate without material to get endpoint
+    NA6PTrack tmpTrc = *trc;
+    if (!tmpTrc.propagateToZBxByBz(zNext, 1., 0., 0., outer)) {
+      return 0;
+    }
 
-  double xrho = mparam[0] * mparam[4]; // length * density
-  double x2x0 = mparam[1];             // X/X0
-  double corrELoss = 1.0;
+    double end[3];
+    if (outer) {
+      tmpTrc.getXYZOuter(end);
+    } else {
+      tmpTrc.getXYZ(end);
+    }
 
-  // Propagate with material corrections
-  if (!trc->propagateToZBxByBz(zTo, 1., x2x0, -dir * xrho * corrELoss, outer)) {
-    return 0;
+    // Calculate material budget along this step
+    double mparam[7] = {0.};
+    if (mCorrectForMaterial) {
+      getMeanMaterialBudgetFromGeom(start, end, mparam);
+    }
+
+    double density = mparam[0];
+    double xrho = density * mparam[4]; // density * length
+    double x2x0 = mparam[1];             // X/X0
+    double atomicZ = mparam[3];
+    double zOverA = mparam[5];
+
+    double corrELoss = 1.0;    
+    // Propagate with material corrections
+    if (!trc->propagateToZBxByBz(zNext, 1., x2x0, -dir * xrho * corrELoss, outer, density, atomicZ, zOverA)) {
+      return 0;
+    }
+    zCurrent = zNext;
   }
 
   return 1;

--- a/rec/src/NA6PTrack.cxx
+++ b/rec/src/NA6PTrack.cxx
@@ -98,7 +98,7 @@ Bool_t NA6PTrack::init(const double* xyz, const double* pxyz, int sign, double e
 }
 
 //_______________________________________________________________________
-Bool_t NA6PTrack::propagateToZBxByBz(double z, double maxDZ, double xOverX0, double xTimesRho, bool outer)
+Bool_t NA6PTrack::propagateToZBxByBz(double z, double maxDZ, double xOverX0, double xTimesRho, bool outer, double density, double atomicZ, double zOverA)
 {
   // propagate the track to position Z in uniform material with xOverX0 rad lgt and xTimesRho lgt*density
   double zCurr = outer ? getZLabOuter() : getZLab();
@@ -134,8 +134,7 @@ Bool_t NA6PTrack::propagateToZBxByBz(double z, double maxDZ, double xOverX0, dou
       return false;
     }
 
-    if (TMath::Abs(xTimesRho) > 1e-6 &&
-        !correctForMeanMaterial(xOverX0 / nz, xTimesRho / nz)) {
+    if (TMath::Abs(xTimesRho) > 1e-6 && !correctForMeanMaterial(xOverX0 / nz, xTimesRho / nz, density, atomicZ, zOverA)) {
       return false;
     }
   }

--- a/rec/src/NA6PTrackerCA.cxx
+++ b/rec/src/NA6PTrackerCA.cxx
@@ -107,6 +107,7 @@ void NA6PTrackerCA::configureFromRecoParamVT(const std::string& filename)
   setDoTrackConstrainedToPrimVert(param.vtDoConstrainedTrack);
   setNumberOfIterations(param.vtNIterationsTrackerCA);
   setNLayers(param.vtNLayers);
+  setMaxStepForMaterialRecording(param.maxStepForMaterialRecording);
 
   for (int jIter = 0; jIter < mNIterationsCA; ++jIter) {
     setIterationParams(jIter,
@@ -133,6 +134,7 @@ void NA6PTrackerCA::configureFromRecoParamMS(const std::string& filename)
   setNLayers(param.msNLayers);
   setStartLayer(param.vtNLayers);
   setDoTrackConstrainedToPrimVert(param.msDoConstrainedTrack);
+  setMaxStepForMaterialRecording(param.maxStepForMaterialRecording);
   for (int jIter = 0; jIter < mNIterationsCA; ++jIter) {
     setIterationParams(jIter,
                        param.msMaxDeltaThetaTrackletsCA[jIter],


### PR DESCRIPTION
The reconstructed J/ψ mass showed a 40 MeV shift when using the MS. This bias was caused by two factors: first, the Bethe-Bloch formula used for energy-loss correction employed silicon-specific parameters; second, the material recording step when propagating the track from zFrom to zTo was not splitted in steps, no matter the distance.
This PR splits the material interrogation into finer steps, controlled by the new configurable maxStepForMaterialRecording, and uses the mean Z, Z/A, and density to assign the correct Bethe-Bloch parameters.
With a finer step and proper Bethe-Bloch parameters, the J/ψ mass shift is corrected.