### PR TITLE
Fix overlaps

### DIFF
--- a/sim/src/NA6PMuonSpecModular.cxx
+++ b/sim/src/NA6PMuonSpecModular.cxx
@@ -79,14 +79,14 @@ void NA6PMuonSpecModular::createGeometry(TGeoVolume* world)
 {
   const auto& param = NA6PLayoutParam::Instance();
 
-  const float EnvelopDXH = 1;
-  const float EnvelopDYH = 1;
   const float EnvelopDZH = 1;
   float pixChipDz = param.thicknessMSPlane[0];
 
   createMaterials();
 
   for (int ist = 0; ist < param.nMSPlanes; ist++) {
+    const float EnvelopDXH = param.dimXMSPlaneHole[ist] / 2.0f;
+    const float EnvelopDYH = param.dimYMSPlaneHole[ist] / 2.0f;
     auto* sensorShape = new TGeoBBox("SensorShape", param.msChipDX[ist] / 2.0f, param.msChipDY[ist] / 2.0f, pixChipDz / 2.0f);
     TGeoVolume* MSSensor = new TGeoVolume("MSSensor", sensorShape, NA6PTGeoHelper::instance().getMedium(addName("Silicon")));
     MSSensor->SetLineColor(NA6PTGeoHelper::instance().getMediumColor(addName("Silicon")));


### PR DESCRIPTION
There were still some overlaps in the geometry I overlooked between MS0 and the world and between MEP48 and the world. They didn't cause any evident issue.
There are still some related to the MS dipole that I don't think are causing any issue, and that would be harder to fix by changing the gdml:

  Overlap: DipoleMS extruded by: DipoleMS/coil_big_top ovlp=4.2
  Overlap: DipoleMS extruded by: DipoleMS/coil_big_bottom ovlp=4.2
  Overlap : DipoleMS/b1_l_pv0x39ed4fd0 overlapping DipoleMS/coil_small_bottom ovlp=1.4995
  Overlap : DipoleMS/b1_l_pv0x39ed4fd0 overlapping DipoleMS/coil_small_top ovlp=1.4995
  Overlap : DipoleMS/coil_big_top overlapping DipoleMS/coil_small_top ovlp=0.5
  Overlap : DipoleMS/coil_big_bottom overlapping DipoleMS/coil_small_bottom ovlp=0.5
