### PR TITLE
First implementation of a track vertexer

### DIFF
--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -31,6 +31,7 @@ set(DICTIONARY_HEADERS
   NA6PVerTelReconstruction.h
   NA6PMuonSpecReconstruction.h
   NA6PVertexerTracklets.h
+  NA6PVertexerTracks.h
   NA6PTrackerCA.h
   NA6PFastTrackFitter.h
   NA6PMatching.h

--- a/rec/include/NA6PLine.h
+++ b/rec/include/NA6PLine.h
@@ -25,7 +25,8 @@ class NA6PLine
 {
  public:
   NA6PLine() = default;
-  NA6PLine(const NA6PLine& source);
+  NA6PLine(const NA6PLine& source) = default;
+  NA6PLine& operator=(const NA6PLine& source) = default;
   NA6PLine(const float firstPoint[3], const float secondPoint[3]);
   
   static NA6PLine fromTwoPoints(const float p0[3], const float p1[3]);

--- a/rec/include/NA6PLine.h
+++ b/rec/include/NA6PLine.h
@@ -43,7 +43,7 @@ class NA6PLine
     return getDistanceFromPoint(*this, point);
   }
   std::array<float, 6> getDCAComponents(const float point[3]) const;
-  std::array<float, 6> getDCAComponents(const std::array<float, 3> point) const
+  std::array<float, 6> getDCAComponents(const std::array<float, 3>& point) const
   {
     return getDCAComponents(point.data());
   }

--- a/rec/include/NA6PLine.h
+++ b/rec/include/NA6PLine.h
@@ -27,7 +27,11 @@ class NA6PLine
   NA6PLine() = default;
   NA6PLine(const NA6PLine& source);
   NA6PLine(const float firstPoint[3], const float secondPoint[3]);
-
+  
+  static NA6PLine fromTwoPoints(const float p0[3], const float p1[3]);
+  static NA6PLine fromPointAndDirection(const float xyz[3], const float dir[3]);
+  static NA6PLine fromPointAndDirection(const double xyz[3], const double dir[3]);
+  
   static float getDistanceFromPoint(const NA6PLine& line, const float point[3]);
   static float getDistanceFromPoint(const NA6PLine& line, const std::array<float, 3> point)
   {
@@ -67,6 +71,31 @@ class NA6PLine
 };
 
 // static functions:
+
+inline NA6PLine NA6PLine::fromTwoPoints(const float p0[3], const float p1[3])
+{
+  NA6PLine l(p0, p1);
+  return l;
+}
+
+inline NA6PLine NA6PLine::fromPointAndDirection(const double xyz[3], const double dir[3])
+{
+  float f0[3] = {(float)xyz[0], (float)xyz[1], (float)xyz[2]};
+  float f1[3] = {(float)dir[0], (float)dir[1], (float)dir[2]};
+  return fromPointAndDirection(f0, f1);
+}
+
+inline NA6PLine NA6PLine::fromPointAndDirection(const float xyz[3], const float dir[3])
+{
+  NA6PLine l;
+  float norm = std::sqrt(dir[0]*dir[0] + dir[1]*dir[1] + dir[2]*dir[2]);
+  float inv  = (norm > 1e-12f) ? 1.f/norm : 0.f;
+  for (int i = 0; i < 3; i++) {
+    l.mOriginPoint[i]    = xyz[i];
+    l.mCosinesDirector[i] = dir[i] * inv;
+  }
+  return l;
+}
 
 inline float NA6PLine::getDistanceFromPoint(const NA6PLine& line, const float point[3])
 {

--- a/rec/include/NA6PTrack.h
+++ b/rec/include/NA6PTrack.h
@@ -151,6 +151,7 @@ class NA6PTrack
   }
   bool propagateToZBxByBz(double z, double maxDZ = 1.0, double xOverX0 = 0., double xTimesRho = 0., bool outer = false);
   bool propagateToDCA(NA6PTrack* partner);
+  bool propagateToDCABeamAxis(float beamX, float beamY, float maxDCA);
   bool update(double p[2], double cov[3]) { return mExtTrack.Update(p, cov); }
 
   virtual void print() const;

--- a/rec/include/NA6PVertex.h
+++ b/rec/include/NA6PVertex.h
@@ -43,7 +43,7 @@ class NA6PVertex
   NA6PVertex(const float* xyz, int nCont);
   NA6PVertex(const NA6PVertex&) = default;
   NA6PVertex& operator=(const NA6PVertex&) = default;
-  virtual ~NA6PVertex() = default;
+  ~NA6PVertex() = default;
 
   void init(const float* xyz, const float* cov, int nCont, float chi2);
   void setX(float x) { mPos.SetX(x); }
@@ -103,7 +103,7 @@ class NA6PVertex
   void addTrackID(int id) { mTrackIDs.push_back(id); }
   const std::vector<int>& getTrackIDs() const { return mTrackIDs; }
   
-  virtual void print() const;
+  void print() const;
   std::string asString() const;
 
  protected:

--- a/rec/include/NA6PVertex.h
+++ b/rec/include/NA6PVertex.h
@@ -100,15 +100,19 @@ class NA6PVertex
   float getChi2() const { return mChi2; }
   short getVertexType() const { return mVertexType; }
 
+  void addTrackID(int id) { mTrackIDs.push_back(id); }
+  const std::vector<int>& getTrackIDs() const { return mTrackIDs; }
+  
   virtual void print() const;
   std::string asString() const;
 
  protected:
-  ROOT::Math::XYZPointF mPos{0., 0., 0.};
-  std::array<float, kNCov> mCov{};
-  float mChi2 = 0.0;
-  int mNContributors = 0;
-  short mVertexType = kBaseVertex;
+  ROOT::Math::XYZPointF mPos{0., 0., 0.}; ///< vertex position
+  std::array<float, kNCov> mCov{};        ///< covariance matrix
+  float mChi2 = 0.0;                      ///< chi2
+  int mNContributors = 0;                 ///< number of contributors
+  short mVertexType = kBaseVertex;        ///< vertex type
+  std::vector<int> mTrackIDs;             ///< indices of tracks assigned to this vertex
 
   ClassDefNV(NA6PVertex, 1);
 };

--- a/rec/include/NA6PVertexerTracks.h
+++ b/rec/include/NA6PVertexerTracks.h
@@ -25,21 +25,23 @@ struct TrackVF {
          kNoVtx = -1,
          kDiscarded = kNoVtx - 1 };
 
-  NA6PLine mLine;           // straight line representation of the track
-  float mSig2XI = 0.f;      // XX component of inverse cov.matrix
-  float mSig2YI = 0.f;      // YY component of inverse cov.matrix
-  float mSig2ZI  = 0.f;  // ZZ component of inverse cov matrix  
-  float mSigXYI  = 0.f;  // XY component of inverse cov matrix
-  float mSigXZI  = 0.f;  // XZ component of inverse cov matrix
-  float mSigYZI  = 0.f;  // YZ component of inverse cov matrix
-  
-  float wgh = 0.f;      ///< track weight wrt current vertex seed
-  int vtxID = kNoVtx;       // assigned vertex
+  NA6PLine mLine;      // straight line representation of the track
+  float mSig2XI = 0.f; // XX component of inverse cov.matrix
+  float mSig2YI = 0.f; // YY component of inverse cov.matrix
+  float mSig2ZI = 0.f; // ZZ component of inverse cov matrix
+  float mSigXYI = 0.f; // XY component of inverse cov matrix
+  float mSigXZI = 0.f; // XZ component of inverse cov matrix
+  float mSigYZI = 0.f; // YZ component of inverse cov matrix
+  int trackIndex = -1; // track index
+  float wgh = 0.f;     ///< track weight wrt current vertex seed
+  int vtxID = kNoVtx;  // assigned vertex
 
   TrackVF() = default;
-  TrackVF(const NA6PTrack& src) {
+  TrackVF(const NA6PTrack& src, int id)
+  {
     // NB: src must already be propagated to its DCA to the beam axis
     // before constructing TrackVF — call propagateToDCABeamAxis() first
+    trackIndex = id;
     double xyz[3], pxyz[3];
     src.getXYZ(xyz);
     src.getPXYZ(pxyz);
@@ -52,7 +54,7 @@ struct TrackVF {
     float szz = (cx * cx * sxx + cy * cy * syy + 2.f * cx * cy * sxy) * iczcz;
     float det = sxx * syy - sxy * sxy;
     if (det <= 1e-20f) {
-      mSig2ZI = -1.;
+      mSig2ZI = -1.f;
       return;
     }
     float detI = 1.f / det;
@@ -63,10 +65,11 @@ struct TrackVF {
     // xz and yz correlations neglected (mSigXZI = mSigYZI = 0)
     mSig2ZI = (szz > 0.f) ? 1.f / szz : 0.f;
   }
-  bool isValid() const { return mSig2ZI >= 0.f; }
+  bool isValid() const { return mSig2ZI > 0.f; }
   bool canUse() const { return vtxID == kNoVtx; }
+  bool canAssign() const { return wgh > 0. && vtxID == kNoVtx; }
 
-  std::array<float,3> getResiduals(const float vtxPos[3]) const
+  std::array<float, 3> getResiduals(const float vtxPos[3]) const
   {
     // vector from closest point on line to vtxPos
     auto comps = mLine.getDCAComponents(vtxPos);
@@ -81,30 +84,29 @@ struct TrackVF {
   }
   float evalChi2ToVertex(float dx, float dy) const
   {
-    constexpr float NDOF2I = 0.5;
+    constexpr float NDOF2I = 0.5f;
     float chi2T = dx * dx * mSig2XI + 2.f * dx * dy * mSigXYI + dy * dy * mSig2YI;
     chi2T *= NDOF2I;
     return chi2T;
   }
 
-  
   ClassDefNV(TrackVF, 1);
 };
 
 struct VertexSeed {
   float x = 0.f, y = 0.f, z = 0.f;
-  double wghSum = 0.;    // sum of tracks weights
-  double wghChi2 = 0.;   // sum of tracks weighted chi2's
+  double wghSum = 0.;                                                                              // sum of tracks weights
+  double wghChi2 = 0.;                                                                             // sum of tracks weighted chi2's
   double cxx = 0., cyy = 0., czz = 0., cxy = 0., cxz = 0., cyz = 0., cx0 = 0., cy0 = 0., cz0 = 0.; // elements of lin.equation matrix
-  float scaleSigma2 = 1.;  // scaling parameter on top of Tukey param
+  float scaleSigma2 = 1.;                                                                          // scaling parameter on top of Tukey param
   float scaleSigma2Prev = 1.;
   float maxScaleSigma2Tested = 0.;
   float scaleSig2ITuk2I = 0; // inverse squared Tukey parameter scaled by scaleSigma2
   int nScaleSlowConvergence = 0;
   int nScaleIncrease = 0;
   int nIterations = 0;
-  float chi2 = 0.f;       ///< final vertex chi2
-  int nContributors = 0;  ///< number of tracks contributing to current iteration
+  float chi2 = 0.f;      ///< final vertex chi2
+  int nContributors = 0; ///< number of tracks contributing to current iteration
 
   void setChi2(float c) { chi2 = c; }
   float getChi2() const { return chi2; }
@@ -131,20 +133,18 @@ struct VertexSeed {
     y = src.getY();
     z = src.getZ();
   }
-
 };
 
 class NA6PVertexerTracks
 {
 
  public:
-  
   enum class FitStatus : int { Failure,
                                PoolEmpty,
                                NotEnoughTracks,
                                IterateFurther,
                                OK };
-  
+
   NA6PVertexerTracks();
   ~NA6PVertexerTracks() = default;
 
@@ -170,51 +170,66 @@ class NA6PVertexerTracks
     mNBinsForPeakFind = nbins;
     configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
   }
+  void setTukey(float t) { mTukey2I = t > 0.f ? 1.f / (t * t) : 1.f / (kDefTukey * kDefTukey); }
+  void setMaxVerticesPerCluster(int n) { mMaxVerticesPerCluster = n; }
+  void setMaxTrialsPerCluster(int n) { mMaxTrialsPerCluster = n; }
   void setInitScaleSigma2(float s) { mInitScaleSigma2 = s; }
-  void setTukey2I(float t) { mTukey2I = t > 0.f ? 1.f / (t * t) : 1.f / (kDefTukey * kDefTukey); }
+  void setMaxIterations(int n) { mMaxIterations = n; }
   void setMinTracksPerVtx(int n) { mMinTracksPerVtx = n; }
-  
+  void setMinScale2(float s) { mMinScale2 = s; }
+  void setMaxScale2(float s) { mMaxScale2 = s; }
+  void setMaxChi2Mean(float c) { mMaxChi2Mean = c; }
+  void setMaxNScaleIncreased(int n) { mMaxNScaleIncreased = n; }
+  void setSlowConvergenceFactor(float f) { mSlowConvergenceFactor = f; }
+  void setMaxNScaleSlowConvergence(int n) { mMaxNScaleSlowConvergence = n; }
+  void setAcceptableScale2(float s) { mAcceptableScale2 = s; }
+  void setUpscaleFactor(float f) { mUpscaleFactor = f; }
+
+  void setVerbosity(bool opt = true) { mVerbose = opt; }
+
   void createTracksPool(const std::vector<NA6PTrack>& tracks);
   void buildAndFillHistoZ();
   int findPeakBin();
-  int findVertices();
+  int findVertices(std::vector<NA6PVertex>& vertices);
   bool fitVertex(float zSeed, NA6PVertex& vtx);
   FitStatus fitIteration(VertexSeed& vtxSeed);
   FitStatus evalIterations(VertexSeed& vtxSeed) const;
   bool upscaleSigma(VertexSeed& vtxSeed) const;
   bool solveVertex(VertexSeed& vtxSeed) const;
   void accountTrack(TrackVF& trc, VertexSeed& vtxSeed) const;
-  
+  void finalizeVertex(NA6PVertex& vtx, std::vector<NA6PVertex>& vertices);
+
  private:
-  std::vector<TrackVF> mTracksPool;  ///< tracks in internal representation used for vertexing
-  float mBeamX = 0.;                 ///< beam transverse coordindates
-  float mBeamY = 0.;                 ///< beam transverse coordindates
-  float mMaxDCA = 0.1;               ///< cut on DCA of track to beam line (cm)
-  float mZMin = -20.0;               ///< z range, min, cm
-  float mZMax = 5.;                  ///< z range, max, cm
-  int mNBinsForPeakFind = 250;       ///< 0.1 cm per bin
-  float mZBinWidth = 0.1;            ///< bin width 
-  std::vector<float> mHistZ;         ///< histogram for the peak finding method
-  std::vector<int>   mFilledBinsZ;   ///< indices of non-empty bins
-  int mMaxVerticesPerCluster = 5;                   ///< one vertex per target
-  int mMaxTrialsPerCluster = 2;                     //
-  static constexpr float kAlmost0F = 1e-12;         ///< tiny float
-  static constexpr float kDefTukey = 5.0f;          ///< def.value for tukey constant
+  std::vector<TrackVF> mTracksPool;               ///< tracks in internal representation used for vertexing
+  float mBeamX = 0.;                              ///< beam transverse coordindates
+  float mBeamY = 0.;                              ///< beam transverse coordindates
+  float mMaxDCA = 0.05;                           ///< cut on DCA of track to beam line (cm)
+  float mZMin = -20.0;                            ///< z range, min, cm
+  float mZMax = 5.;                               ///< z range, max, cm
+  int mNBinsForPeakFind = 250;                    ///< 0.1 cm per bin
+  float mZBinWidth = 0.1;                         ///< bin width
+  std::vector<float> mHistZ;                      ///< histogram for the peak finding method
+  std::vector<int> mFilledBinsZ;                  ///< indices of non-empty bins
+  int mMaxVerticesPerCluster = 5;                 ///< one vertex per target
+  int mMaxTrialsPerCluster = 100;                 //
+  static constexpr float kAlmost0F = 1e-7f;       ///< tiny float
+  static constexpr float kScaleStability = 0.1f;  ///< tolerance for scale change
+  static constexpr float kDefTukey = 5.0f;        ///< def.value for tukey constant
   float mTukey2I = 1.f / (kDefTukey * kDefTukey); ///< 1./[Tukey parameter]^2
-  float mInitScaleSigma2 = 10.f;      ///< scaling parameter on top of Tukey param
-  int mMaxIterations = 20;            ///< max iterations per vertex fit
-  int mMinTracksPerVtx = 2;           ///< minimum number of tracks per vertex
-  float mMinScale2 = 1.;              ///< min scaling factor^2
-  float mMaxScale2 = 50.;             ///< max slaling factor^2
-  float mMaxChi2Mean = 10.;           ///< max mean chi2 of vertex to accept
-  int mMaxNScaleIncreased = 2;        ///< max number of scaling-non-decreasing iterations
-  float mSlowConvergenceFactor = 0.5; ///< consider convergence as slow if ratio new/old scale2 exceeds it
-  int mMaxNScaleSlowConvergence = 3;  ///< max number of weak scaling decrease iterations
-  float mAcceptableScale2 = 4.;       ///< if below this factor, try to refit with minScale2
-  float mUpscaleFactor = 9.;          ///< factor for upscaling if not candidate is found
+  float mInitScaleSigma2 = 10.f;                  ///< scaling parameter on top of Tukey param
+  int mMaxIterations = 20;                        ///< max iterations per vertex fit
+  int mMinTracksPerVtx = 2;                       ///< minimum number of tracks per vertex
+  float mMinScale2 = 1.;                          ///< min scaling factor^2
+  float mMaxScale2 = 50.;                         ///< max slaling factor^2
+  float mMaxChi2Mean = 30.;                       ///< max mean chi2 of vertex to accept
+  int mMaxNScaleIncreased = 5;                    ///< max number of scaling-non-decreasing iterations
+  float mSlowConvergenceFactor = 0.5;             ///< consider convergence as slow if ratio new/old scale2 exceeds it
+  int mMaxNScaleSlowConvergence = 5;              ///< max number of weak scaling decrease iterations
+  float mAcceptableScale2 = 4.;                   ///< if below this factor, try to refit with minScale2
+  float mUpscaleFactor = 9.;                      ///< factor for upscaling if not candidate is found
+  bool mVerbose = false;                          ///< verbosity flag
 
   ClassDefNV(NA6PVertexerTracks, 1);
 };
-
 
 #endif

--- a/rec/include/NA6PVertexerTracks.h
+++ b/rec/include/NA6PVertexerTracks.h
@@ -21,12 +21,20 @@
 #include <NA6PVertex.h>
 
 struct TrackVF {
-  
+  enum { kUsed,
+         kNoVtx = -1,
+         kDiscarded = kNoVtx - 1 };
+
   NA6PLine mLine;           // straight line representation of the track
   float mSig2XI = 0.f;      // XX component of inverse cov.matrix
   float mSig2YI = 0.f;      // YY component of inverse cov.matrix
-  float mSigXYI = 0.f;      // XY component of inverse cov.matrix
-  float mWeightHisto = 0.f; // weight for histogram seeder 
+  float mSig2ZI  = 0.f;  // ZZ component of inverse cov matrix  
+  float mSigXYI  = 0.f;  // XY component of inverse cov matrix
+  float mSigXZI  = 0.f;  // XZ component of inverse cov matrix
+  float mSigYZI  = 0.f;  // YZ component of inverse cov matrix
+  
+  float wgh = 0.f;      ///< track weight wrt current vertex seed
+  int vtxID = kNoVtx;       // assigned vertex
 
   TrackVF() = default;
   TrackVF(const NA6PTrack& src) {
@@ -44,22 +52,42 @@ struct TrackVF {
     float szz = (cx * cx * sxx + cy * cy * syy + 2.f * cx * cy * sxy) * iczcz;
     float det = sxx * syy - sxy * sxy;
     if (det <= 1e-20f) {
-      mWeightHisto = -1;
+      mSig2ZI = -1.;
       return;
     }
-    auto detI = 1. / det;
-    mSig2XI = sxx * detI;
-    mSig2YI = syy * detI;
+    float detI = 1.f / det;
+    mSig2XI = syy * detI;
+    mSig2YI = sxx * detI;
     mSigXYI = -sxy * detI;
-    mWeightHisto = (szz > 0.f) ? 1.f / szz : 0.f;
+    // z weight from error propagation of transverse cov along track direction
+    // xz and yz correlations neglected (mSigXZI = mSigYZI = 0)
+    mSig2ZI = (szz > 0.f) ? 1.f / szz : 0.f;
   }
-  bool isValid() const { return mWeightHisto >= 0.f; }
-  std::array<float,3> residual(const float vtxPos[3]) const
+  bool isValid() const { return mSig2ZI >= 0.f; }
+  bool canUse() const { return vtxID == kNoVtx; }
+
+  std::array<float,3> getResiduals(const float vtxPos[3]) const
   {
     // vector from closest point on line to vtxPos
     auto comps = mLine.getDCAComponents(vtxPos);
     return {comps[0], comps[3], comps[5]}; // dx, dy, dz components
   }
+
+  float evalChi2ToVertex(const float vtxPos[3]) const
+  {
+    auto res = getResiduals(vtxPos); // track-vertex residuals and chi2
+    float dx = res[0], dy = res[1];
+    return evalChi2ToVertex(dx, dy);
+  }
+  float evalChi2ToVertex(float dx, float dy) const
+  {
+    constexpr float NDOF2I = 0.5;
+    float chi2T = dx * dx * mSig2XI + 2.f * dx * dy * mSigXYI + dy * dy * mSig2YI;
+    chi2T *= NDOF2I;
+    return chi2T;
+  }
+
+  
   ClassDefNV(TrackVF, 1);
 };
 
@@ -75,7 +103,12 @@ struct VertexSeed {
   int nScaleSlowConvergence = 0;
   int nScaleIncrease = 0;
   int nIterations = 0;
+  float chi2 = 0.f;       ///< final vertex chi2
+  int nContributors = 0;  ///< number of tracks contributing to current iteration
 
+  void setChi2(float c) { chi2 = c; }
+  float getChi2() const { return chi2; }
+  int getNContributors() const { return nContributors; }
   void setScale(float scale2, float tukey2I)
   {
     scaleSigma2Prev = scaleSigma2;
@@ -87,6 +120,7 @@ struct VertexSeed {
   {
     wghSum = 0.;
     wghChi2 = 0.;
+    nContributors = 0;
     cxx = cyy = czz = cxy = cxz = cyz = cx0 = cy0 = cz0 = 0.;
   }
 
@@ -136,27 +170,51 @@ class NA6PVertexerTracks
     mNBinsForPeakFind = nbins;
     configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
   }
+  void setInitScaleSigma2(float s) { mInitScaleSigma2 = s; }
+  void setTukey2I(float t) { mTukey2I = t > 0.f ? 1.f / (t * t) : 1.f / (kDefTukey * kDefTukey); }
+  void setMinTracksPerVtx(int n) { mMinTracksPerVtx = n; }
+  
   void createTracksPool(const std::vector<NA6PTrack>& tracks);
   void buildAndFillHistoZ();
   int findPeakBin();
   int findVertices();
-
+  bool fitVertex(float zSeed, NA6PVertex& vtx);
+  FitStatus fitIteration(VertexSeed& vtxSeed);
+  FitStatus evalIterations(VertexSeed& vtxSeed) const;
+  bool upscaleSigma(VertexSeed& vtxSeed) const;
+  bool solveVertex(VertexSeed& vtxSeed) const;
+  void accountTrack(TrackVF& trc, VertexSeed& vtxSeed) const;
   
  private:
   std::vector<TrackVF> mTracksPool;  ///< tracks in internal representation used for vertexing
-  float mBeamX = 0.;                 // beam transverse coordindates
-  float mBeamY = 0.;                 // beam transverse coordindates
-  float mMaxDCA = 0.1;               // cut on DCA of track to beam line (cm)
-  float mZMin = -20.0;               // z range, min, cm
-  float mZMax = 5.;                  // z range, max, cm
-  int mNBinsForPeakFind = 250;       // 0.1 cm per bin
-  float mZBinWidth = 0.1;            // bin width 
-  std::vector<float> mHistZ;         // histogram for the peak finding method
-  std::vector<int>   mFilledBinsZ;   // indices of non-empty bins
-  int mMaxVerticesPerCluster = 5;    // one vertex per target
-  int mMaxTrialsPerCluster = 2;      //
-  
+  float mBeamX = 0.;                 ///< beam transverse coordindates
+  float mBeamY = 0.;                 ///< beam transverse coordindates
+  float mMaxDCA = 0.1;               ///< cut on DCA of track to beam line (cm)
+  float mZMin = -20.0;               ///< z range, min, cm
+  float mZMax = 5.;                  ///< z range, max, cm
+  int mNBinsForPeakFind = 250;       ///< 0.1 cm per bin
+  float mZBinWidth = 0.1;            ///< bin width 
+  std::vector<float> mHistZ;         ///< histogram for the peak finding method
+  std::vector<int>   mFilledBinsZ;   ///< indices of non-empty bins
+  int mMaxVerticesPerCluster = 5;                   ///< one vertex per target
+  int mMaxTrialsPerCluster = 2;                     //
+  static constexpr float kAlmost0F = 1e-12;         ///< tiny float
+  static constexpr float kDefTukey = 5.0f;          ///< def.value for tukey constant
+  float mTukey2I = 1.f / (kDefTukey * kDefTukey); ///< 1./[Tukey parameter]^2
+  float mInitScaleSigma2 = 10.f;      ///< scaling parameter on top of Tukey param
+  int mMaxIterations = 20;            ///< max iterations per vertex fit
+  int mMinTracksPerVtx = 2;           ///< minimum number of tracks per vertex
+  float mMinScale2 = 1.;              ///< min scaling factor^2
+  float mMaxScale2 = 50.;             ///< max slaling factor^2
+  float mMaxChi2Mean = 10.;           ///< max mean chi2 of vertex to accept
+  int mMaxNScaleIncreased = 2;        ///< max number of scaling-non-decreasing iterations
+  float mSlowConvergenceFactor = 0.5; ///< consider convergence as slow if ratio new/old scale2 exceeds it
+  int mMaxNScaleSlowConvergence = 3;  ///< max number of weak scaling decrease iterations
+  float mAcceptableScale2 = 4.;       ///< if below this factor, try to refit with minScale2
+  float mUpscaleFactor = 9.;          ///< factor for upscaling if not candidate is found
+
   ClassDefNV(NA6PVertexerTracks, 1);
 };
+
 
 #endif

--- a/rec/include/NA6PVertexerTracks.h
+++ b/rec/include/NA6PVertexerTracks.h
@@ -1,0 +1,82 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_VERTEXER_TRACKS_H
+#define NA6P_VERTEXER_TRACKS_H
+
+#include <vector>
+#include <NA6PLine.h>
+#include <NA6PTrack.h>
+
+struct TrackVF {
+  
+  NA6PLine mLine;           // straight line representation of the track
+  float mSig2XI = 0.f;      // XX component of inverse cov.matrix
+  float mSig2YI = 0.f;      // YY component of inverse cov.matrix
+  float mSigXYI = 0.f;      // XY component of inverse cov.matrix
+  float mWeightHisto = 0.f; // weight for histogram seeder 
+
+  TrackVF() = default;
+  TrackVF(const NA6PTrack& src) {
+    // NB: src must already be propagated to its DCA to the beam axis
+    // before constructing TrackVF — call propagateToDCABeamAxis() first
+    double xyz[3], pxyz[3];
+    src.getXYZ(xyz);
+    src.getPXYZ(pxyz);
+    mLine = NA6PLine::fromPointAndDirection(xyz, pxyz);
+    float sxx = src.getSigmaX2(), syy = src.getSigmaY2(), sxy = src.getSigmaXY();
+    float cx = mLine.mCosinesDirector[0];
+    float cy = mLine.mCosinesDirector[1];
+    float cz = mLine.mCosinesDirector[2];
+    float iczcz = 1.f / (cz * cz);
+    float szz = (cx * cx * sxx + cy * cy * syy + 2.f * cx * cy * sxy) * iczcz;
+    float det = sxx * syy - sxy * sxy;
+    if (det <= 1e-20f) {
+      mWeightHisto = -1;
+      return;
+    }
+    auto detI = 1. / det;
+    mSig2XI = sxx * detI;
+    mSig2YI = syy * detI;
+    mSigXYI = -sxy * detI;
+    mWeightHisto = (szz > 0.f) ? 1.f / szz : 0.f;
+  }
+  bool isValid() const { return mWeightHisto >= 0.f; }
+  std::array<float,3> residual(const float vtxPos[3]) const
+  {
+    // vector from closest point on line to vtxPos
+    auto comps = mLine.getDCAComponents(vtxPos);
+    return {comps[0], comps[3], comps[5]}; // dx, dy, dz components
+  }
+  ClassDefNV(TrackVF, 1);
+};
+
+class NA6PVertexerTracks
+{
+
+ public:
+  void setBeamX(float x) { mBeamX = x; }
+  void setBeamY(float y) { mBeamY = y; }
+  void createTracksPool(const std::vector<NA6PTrack>& tracks);
+
+ private:
+  std::vector<TrackVF> mTracksPool;  ///< tracks in internal representation used for vertexing
+  float mBeamX = 0.;                 // beam transverse coordindates
+  float mBeamY = 0.;                 // beam transverse coordindates
+  float mMaxDCA = 0.1;               // cut on DCA of track to beam line (cm)
+  
+  ClassDefNV(NA6PVertexerTracks, 1);
+};
+
+#endif

--- a/rec/include/NA6PVertexerTracks.h
+++ b/rec/include/NA6PVertexerTracks.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <NA6PLine.h>
 #include <NA6PTrack.h>
+#include <NA6PVertex.h>
 
 struct TrackVF {
   
@@ -62,19 +63,98 @@ struct TrackVF {
   ClassDefNV(TrackVF, 1);
 };
 
+struct VertexSeed {
+  float x = 0.f, y = 0.f, z = 0.f;
+  double wghSum = 0.;    // sum of tracks weights
+  double wghChi2 = 0.;   // sum of tracks weighted chi2's
+  double cxx = 0., cyy = 0., czz = 0., cxy = 0., cxz = 0., cyz = 0., cx0 = 0., cy0 = 0., cz0 = 0.; // elements of lin.equation matrix
+  float scaleSigma2 = 1.;  // scaling parameter on top of Tukey param
+  float scaleSigma2Prev = 1.;
+  float maxScaleSigma2Tested = 0.;
+  float scaleSig2ITuk2I = 0; // inverse squared Tukey parameter scaled by scaleSigma2
+  int nScaleSlowConvergence = 0;
+  int nScaleIncrease = 0;
+  int nIterations = 0;
+
+  void setScale(float scale2, float tukey2I)
+  {
+    scaleSigma2Prev = scaleSigma2;
+    scaleSigma2 = scale2;
+    scaleSig2ITuk2I = tukey2I / scale2;
+  }
+
+  void resetForNewIteration()
+  {
+    wghSum = 0.;
+    wghChi2 = 0.;
+    cxx = cyy = czz = cxy = cxz = cyz = cx0 = cy0 = cz0 = 0.;
+  }
+
+  VertexSeed() = default;
+  VertexSeed(const NA6PVertex& src)
+  {
+    x = src.getX();
+    y = src.getY();
+    z = src.getZ();
+  }
+
+};
+
 class NA6PVertexerTracks
 {
 
  public:
+  
+  enum class FitStatus : int { Failure,
+                               PoolEmpty,
+                               NotEnoughTracks,
+                               IterateFurther,
+                               OK };
+  
+  NA6PVertexerTracks();
+  ~NA6PVertexerTracks() = default;
+
   void setBeamX(float x) { mBeamX = x; }
   void setBeamY(float y) { mBeamY = y; }
+  void configurePeakFinding(float zmin = -20.0, float zmax = 5., int nbins = 250)
+  {
+    mZMin = zmin;
+    mZMax = zmax;
+    mNBinsForPeakFind = nbins;
+    mZBinWidth = (mZMax - mZMin) / mNBinsForPeakFind;
+    mHistZ.assign(nbins, 0.f);
+  }
+  void setZRange(float zmin, float zmax)
+  {
+    mZMin = zmin;
+    mZMax = zmax;
+    if (mNBinsForPeakFind > 0)
+      configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
+  }
+  void setNBinsForPeakFind(int nbins)
+  {
+    mNBinsForPeakFind = nbins;
+    configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
+  }
   void createTracksPool(const std::vector<NA6PTrack>& tracks);
+  void buildAndFillHistoZ();
+  int findPeakBin();
+  int findVertices();
 
+  
  private:
   std::vector<TrackVF> mTracksPool;  ///< tracks in internal representation used for vertexing
   float mBeamX = 0.;                 // beam transverse coordindates
   float mBeamY = 0.;                 // beam transverse coordindates
   float mMaxDCA = 0.1;               // cut on DCA of track to beam line (cm)
+  float mZMin = -20.0;               // z range, min, cm
+  float mZMax = 5.;                  // z range, max, cm
+  int mNBinsForPeakFind = 250;       // 0.1 cm per bin
+  float mZBinWidth = 0.1;            // bin width 
+  std::vector<float> mHistZ;         // histogram for the peak finding method
+  std::vector<int>   mFilledBinsZ;   // indices of non-empty bins
+  int mMaxVerticesPerCluster = 5;    // one vertex per target
+  int mMaxTrialsPerCluster = 2;      //
   
   ClassDefNV(NA6PVertexerTracks, 1);
 };

--- a/rec/include/NA6PVertexerTracks.h
+++ b/rec/include/NA6PVertexerTracks.h
@@ -69,14 +69,14 @@ struct TrackVF {
   bool canUse() const { return vtxID == kNoVtx; }
   bool canAssign() const { return wgh > 0. && vtxID == kNoVtx; }
 
-  std::array<float, 3> getResiduals(const float vtxPos[3]) const
+  std::array<float, 3> getResiduals(const std::array<float,3>& vtxPos) const
   {
     // vector from closest point on line to vtxPos
     auto comps = mLine.getDCAComponents(vtxPos);
     return {comps[0], comps[3], comps[5]}; // dx, dy, dz components
   }
 
-  float evalChi2ToVertex(const float vtxPos[3]) const
+  float evalChi2ToVertex(const std::array<float,3>& vtxPos) const
   {
     auto res = getResiduals(vtxPos); // track-vertex residuals and chi2
     float dx = res[0], dy = res[1];

--- a/rec/src/NA6PLine.cxx
+++ b/rec/src/NA6PLine.cxx
@@ -4,15 +4,7 @@
 
 ClassImp(NA6PLine)
 
-  NA6PLine::NA6PLine(const NA6PLine& source)
-{
-  for (int i{0}; i < 3; ++i) {
-    mOriginPoint[i] = source.mOriginPoint[i];
-    mCosinesDirector[i] = source.mCosinesDirector[i];
-  }
-}
-
-NA6PLine::NA6PLine(const float firstPoint[3], const float secondPoint[3])
+  NA6PLine::NA6PLine(const float firstPoint[3], const float secondPoint[3])
 {
   for (int index{0}; index < 3; ++index) {
     mOriginPoint[index] = firstPoint[index];

--- a/rec/src/NA6PTrack.cxx
+++ b/rec/src/NA6PTrack.cxx
@@ -160,6 +160,48 @@ Bool_t NA6PTrack::propagateToDCA(NA6PTrack* partner)
   //
 }
 
+bool NA6PTrack::propagateToDCABeamAxis(float beamX, float beamY, float maxDCA)
+{
+  // iterative propagation to DCA with beam axis (beamX, beamY, *) in z_lab steps 
+  
+  double xyz[3], pxyz[3];
+  getXYZ(xyz);
+  getPXYZ(pxyz);
+
+  const int maxIter = 10;
+  for (int iter = 0; iter < maxIter; ++iter) {
+    double dx  = xyz[0] - beamX;
+    double dy  = xyz[1] - beamY;
+    double px  = pxyz[0];
+    double py  = pxyz[1];
+    double pz  = pxyz[2];
+    double pt2 = px*px + py*py;
+    if (pt2 < 1e-12) break;  // track parallel to beam, can't converge
+
+    // derivative of transverse distance w.r.t. z_lab:
+    // d/dz [(x-bx)^2 + (y-by)^2] = 2(dx*px/pz + dy*py/pz)
+    double ddistdz = dx * (px / pz) + dy * (py / pz);
+    // second derivative (approximated as pt^2/pz^2):
+    double d2distdz2 = pt2 / (pz*pz);
+
+    double dz = -ddistdz / d2distdz2;  // Newton step in z_lab
+
+    // dampen large steps
+    if (std::abs(dz) > 5.0) dz = std::copysign(5.0, dz);
+    if (std::abs(dz) < 1e-4) break;  // converged
+
+    double zNew = xyz[2] + dz;
+    if (!propagateToZBxByBz(zNew)) return false;
+
+    getXYZ(xyz);
+    getPXYZ(pxyz);
+  }
+
+  // final DCA check
+  double dx = xyz[0] - beamX, dy = xyz[1] - beamY;
+  return (dx*dx + dy*dy) < maxDCA * maxDCA;
+}
+
 //_______________________________________________________________________
 double NA6PTrack::getSigmaP2() const
 {

--- a/rec/src/NA6PVertexerTracks.cxx
+++ b/rec/src/NA6PVertexerTracks.cxx
@@ -1,4 +1,7 @@
 // NA6PCCopyright
+#include <fairlogger/Logger.h>
+#include "Math/SMatrix.h"
+#include "Math/SVector.h"
 #include <NA6PVertexerTracks.h>
 
 ClassImp(NA6PVertexerTracks)
@@ -8,6 +11,7 @@ NA6PVertexerTracks::NA6PVertexerTracks()
   configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
 }
 
+//___________________________________________________________________
 void NA6PVertexerTracks::createTracksPool(const std::vector<NA6PTrack>& tracks)
 {
   mTracksPool.clear();
@@ -35,11 +39,12 @@ void NA6PVertexerTracks::buildAndFillHistoZ()
       int bin = int((z - mZMin) / mZBinWidth);
       if (mHistZ[bin] == 0.f)
         mFilledBinsZ.push_back(bin);
-      mHistZ[bin] += tvf.mWeightHisto;  // weighted fill      
+      mHistZ[bin] += tvf.mSig2ZI;  // weighted fill      
     }
   }
 }
 
+//___________________________________________________________________
 int NA6PVertexerTracks::findPeakBin()
 {
   if (mFilledBinsZ.empty())
@@ -61,6 +66,7 @@ int NA6PVertexerTracks::findPeakBin()
   return maxBin;
 }
 
+//___________________________________________________________________
 int NA6PVertexerTracks::findVertices()
 {
   int nfound = 0, ntr = 0;
@@ -71,7 +77,190 @@ int NA6PVertexerTracks::findVertices()
     if (peakBin < 0) {
       break;
     }
-    float zv = mZMin + (peakBin + 0.5) * mZBinWidth;
+    float zSeed = mZMin + (peakBin + 0.5f) * mZBinWidth;
+    NA6PVertex vtx;
+    if (fitVertex(zSeed, vtx)) {
+    }
   }
   return nfound;
 }
+
+//___________________________________________________________________
+bool NA6PVertexerTracks::fitVertex(float zSeed, NA6PVertex& vtx)
+{
+  VertexSeed vtxSeed;
+  vtxSeed.x = mBeamX;
+  vtxSeed.y = mBeamY;
+  vtxSeed.z = zSeed;
+  vtxSeed.setScale(mInitScaleSigma2, mTukey2I);
+  vtxSeed.scaleSigma2Prev = mInitScaleSigma2;
+  vtx.setChi2(1.e30);
+  
+  FitStatus result = FitStatus::IterateFurther;
+  while (result == FitStatus::IterateFurther) {
+    vtxSeed.resetForNewIteration();
+    vtxSeed.nIterations++;
+    result = fitIteration(vtxSeed);
+
+    if (result == FitStatus::OK) {
+      result = evalIterations(vtxSeed);
+    } else if (result == FitStatus::NotEnoughTracks) {
+      if (vtxSeed.nIterations <= mMaxIterations && upscaleSigma(vtxSeed)) {
+        result = FitStatus::IterateFurther;
+        continue; // redo with stronger rescaling
+      } else {
+        break;
+      }
+    } else if (result == FitStatus::PoolEmpty || result == FitStatus::Failure) {
+      break;
+    }
+  }
+
+  if (result != FitStatus::OK) {
+    vtx.setChi2(vtxSeed.maxScaleSigma2Tested);
+    return false;
+  }
+  vtx.setXYZ(vtxSeed.x, vtxSeed.y, vtxSeed.z);
+  vtx.setNContributors(vtxSeed.nContributors);
+  vtx.setChi2(vtxSeed.getChi2());
+  vtx.setCov(vtxSeed.cxx, vtxSeed.cxy, vtxSeed.cxz, vtxSeed.cyy, vtxSeed.cyz, vtxSeed.czz);
+
+  return true;
+}
+
+//___________________________________________________________________
+NA6PVertexerTracks::FitStatus NA6PVertexerTracks::fitIteration(VertexSeed& vtxSeed)
+{
+  int nTested = 0;
+  for (auto& tvf : mTracksPool) {
+    if (tvf.canUse()) {
+      accountTrack(tvf, vtxSeed);
+      nTested++;
+    }
+  }
+
+  vtxSeed.maxScaleSigma2Tested = vtxSeed.scaleSigma2;
+  if (vtxSeed.getNContributors() < mMinTracksPerVtx) {
+    return nTested < mMinTracksPerVtx ? FitStatus::PoolEmpty : FitStatus::NotEnoughTracks;
+  }
+  if (!solveVertex(vtxSeed)) {
+    return FitStatus::Failure;
+  }
+  return FitStatus::OK;
+}
+
+//___________________________________________________________________
+void NA6PVertexerTracks::accountTrack(TrackVF& trc, VertexSeed& vtxSeed) const
+{
+  // deltas defined as track - vertex
+  float vtxPos[3] = {vtxSeed.x, vtxSeed.y, vtxSeed.z};
+  auto res = trc.getResiduals(vtxPos); 
+  float dx = res[0], dy = res[1], dz = res[2];
+  auto chi2T = trc.evalChi2ToVertex(dx, dy);
+  float wghT = (1.f - chi2T * vtxSeed.scaleSig2ITuk2I); // weighted distance to vertex
+  if (wghT < kAlmost0F) {
+    trc.wgh = 0.f;
+    return;
+  }
+  wghT *= wghT;
+  float sxxI = trc.mSig2XI * wghT;
+  float syyI = trc.mSig2YI * wghT;
+  float sxyI = trc.mSigXYI * wghT;
+  trc.wgh = wghT;
+  vtxSeed.wghSum += wghT;
+  vtxSeed.wghChi2 += wghT * chi2T;
+  vtxSeed.cxx += sxxI;
+  vtxSeed.cyy += syyI;
+  vtxSeed.cxy += sxyI;
+  vtxSeed.cx0 += sxxI * dx + sxyI * dy;
+  vtxSeed.cy0 += sxyI * dx + syyI * dy;
+  vtxSeed.czz += trc.mSig2ZI * wghT;
+  vtxSeed.cxz += trc.mSigXZI * wghT;
+  vtxSeed.cyz += trc.mSigYZI * wghT;
+  vtxSeed.cz0 += wghT * (trc.mSig2ZI * dz + trc.mSigXZI * dx + trc.mSigYZI * dy);
+
+  vtxSeed.nContributors++;
+}
+
+//___________________________________________________________________
+bool NA6PVertexerTracks::solveVertex(VertexSeed& vtxSeed) const
+{
+  ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>> mat;
+  mat(0, 0) = vtxSeed.cxx;
+  mat(0, 1) = vtxSeed.cxy;
+  mat(0, 2) = vtxSeed.cxz;
+  mat(1, 1) = vtxSeed.cyy;
+  mat(1, 2) = vtxSeed.cyz;
+  mat(2, 2) = vtxSeed.czz;
+  if (!mat.InvertFast()) {
+    LOGP(error, "Failed to invert matrix");
+    return false;
+  }
+  ROOT::Math::SVector<double, 3> rhs(vtxSeed.cx0, vtxSeed.cy0, vtxSeed.cz0);
+  auto sol = mat * rhs;
+  vtxSeed.x = sol(0);
+  vtxSeed.y = sol(1);
+  vtxSeed.z = sol(2);
+  vtxSeed.cxx = mat(0,0);  vtxSeed.cxy = mat(1,0);  vtxSeed.cyy = mat(1,1);
+  vtxSeed.cxz = mat(2,0);  vtxSeed.cyz = mat(2,1);  vtxSeed.czz = mat(2,2);
+
+  vtxSeed.setChi2((vtxSeed.getNContributors() - vtxSeed.wghSum) / vtxSeed.scaleSig2ITuk2I); // calculate chi^2
+  auto newScale = vtxSeed.wghSum > 0. ? vtxSeed.wghChi2 / vtxSeed.wghSum : mInitScaleSigma2;
+  vtxSeed.setScale(newScale < mMinScale2 ? mMinScale2 : newScale, mTukey2I);
+  return true;
+}
+
+//___________________________________________________________________
+NA6PVertexerTracks::FitStatus NA6PVertexerTracks::evalIterations(VertexSeed& vtxSeed) const
+{
+  // decide if new iteration should be done, prepare next one if needed
+  // if scaleSigma2 reached its lower limit stop
+  FitStatus result = FitStatus::IterateFurther;
+
+  if (vtxSeed.nIterations > mMaxIterations) {
+    result = FitStatus::Failure;
+    return result;
+  } else if (vtxSeed.scaleSigma2Prev <= mMinScale2 + kAlmost0F) {
+    result = FitStatus::OK;
+  }
+
+  if (result == FitStatus::OK) {
+    auto chi2Mean = vtxSeed.getChi2() / vtxSeed.getNContributors();
+    if (chi2Mean > mMaxChi2Mean) {
+      result = FitStatus::Failure;
+    } else {
+      return result;
+    }
+  }
+
+  if (vtxSeed.scaleSigma2 > vtxSeed.scaleSigma2Prev) {
+    if (++vtxSeed.nScaleIncrease > mMaxNScaleIncreased) {
+      result = FitStatus::Failure;
+    }
+  } else if (vtxSeed.scaleSigma2 > mSlowConvergenceFactor * vtxSeed.scaleSigma2Prev) {
+    if (++vtxSeed.nScaleSlowConvergence > mMaxNScaleSlowConvergence) {
+      if (vtxSeed.scaleSigma2 < mAcceptableScale2) {
+        vtxSeed.setScale(mMinScale2, mTukey2I);
+        result = FitStatus::IterateFurther;
+      } else {
+        result = FitStatus::Failure;
+      }
+    }
+  } else {
+    vtxSeed.nScaleSlowConvergence = 0;
+  }
+  return result;
+}
+
+//___________________________________________________________________
+bool NA6PVertexerTracks::upscaleSigma(VertexSeed& vtxSeed) const
+{
+  // scale upward the scaleSigma2 if needed
+  if (vtxSeed.scaleSigma2 < mMaxScale2) {
+    auto s = vtxSeed.scaleSigma2 * mUpscaleFactor;
+    vtxSeed.setScale(s > mMaxScale2 ? mMaxScale2 : s, mTukey2I);
+    return true;
+  }
+  return false;
+}
+

--- a/rec/src/NA6PVertexerTracks.cxx
+++ b/rec/src/NA6PVertexerTracks.cxx
@@ -175,7 +175,7 @@ NA6PVertexerTracks::FitStatus NA6PVertexerTracks::fitIteration(VertexSeed& vtxSe
 void NA6PVertexerTracks::accountTrack(TrackVF& trc, VertexSeed& vtxSeed) const
 {
   // deltas defined as track - vertex
-  float vtxPos[3] = {vtxSeed.x, vtxSeed.y, vtxSeed.z};
+  std::array<float,3> vtxPos = {vtxSeed.x, vtxSeed.y, vtxSeed.z};
   auto res = trc.getResiduals(vtxPos);
   float dx = res[0], dy = res[1], dz = res[2];
   auto chi2T = trc.evalChi2ToVertex(dx, dy);

--- a/rec/src/NA6PVertexerTracks.cxx
+++ b/rec/src/NA6PVertexerTracks.cxx
@@ -1,0 +1,21 @@
+// NA6PCCopyright
+#include <NA6PVertexerTracks.h>
+
+ClassImp(NA6PVertexerTracks)
+
+void NA6PVertexerTracks::createTracksPool(const std::vector<NA6PTrack>& tracks)
+{
+  mTracksPool.clear();
+  auto ntGlo = tracks.size();
+  mTracksPool.reserve(ntGlo);
+  for (uint32_t i = 0; i < ntGlo; i++) {
+    NA6PTrack trc = tracks[i];
+    if (!trc.propagateToDCABeamAxis(mBeamX, mBeamY, mMaxDCA))
+      continue;
+    auto& tvf = mTracksPool.emplace_back(trc);
+    if (!tvf.isValid()) {
+      mTracksPool.pop_back(); // discard bad track
+      continue;
+    }
+  }
+}

--- a/rec/src/NA6PVertexerTracks.cxx
+++ b/rec/src/NA6PVertexerTracks.cxx
@@ -6,7 +6,7 @@
 
 ClassImp(NA6PVertexerTracks)
 
-NA6PVertexerTracks::NA6PVertexerTracks()
+  NA6PVertexerTracks::NA6PVertexerTracks()
 {
   configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
 }
@@ -21,12 +21,14 @@ void NA6PVertexerTracks::createTracksPool(const std::vector<NA6PTrack>& tracks)
     NA6PTrack trc = tracks[i];
     if (!trc.propagateToDCABeamAxis(mBeamX, mBeamY, mMaxDCA))
       continue;
-    auto& tvf = mTracksPool.emplace_back(trc);
+    auto& tvf = mTracksPool.emplace_back(trc, i);
     if (!tvf.isValid()) {
       mTracksPool.pop_back(); // discard bad track
       continue;
     }
   }
+  if (mVerbose)
+    LOGP(info, "Number of tracks in pool = {}", mTracksPool.size());
 }
 
 void NA6PVertexerTracks::buildAndFillHistoZ()
@@ -39,7 +41,7 @@ void NA6PVertexerTracks::buildAndFillHistoZ()
       int bin = int((z - mZMin) / mZBinWidth);
       if (mHistZ[bin] == 0.f)
         mFilledBinsZ.push_back(bin);
-      mHistZ[bin] += tvf.mSig2ZI;  // weighted fill      
+      mHistZ[bin] += tvf.mSig2ZI; // weighted fill
     }
   }
 }
@@ -49,7 +51,7 @@ int NA6PVertexerTracks::findPeakBin()
 {
   if (mFilledBinsZ.empty())
     return -1;
-  
+
   int maxBin = -1, ib = mFilledBinsZ.size(), last = ib;
   float maxv = 0.f;
   while (ib--) {
@@ -58,7 +60,7 @@ int NA6PVertexerTracks::findPeakBin()
     if (v > maxv) {
       maxv = v;
       maxBin = bin;
-    } else if (v <= 0.f) {                      // bin was emptied
+    } else if (v <= 0.f) {                     // bin was emptied
       mFilledBinsZ[ib] = mFilledBinsZ[--last]; // move last non-empty bin in place of emptied one
     }
   }
@@ -67,9 +69,9 @@ int NA6PVertexerTracks::findPeakBin()
 }
 
 //___________________________________________________________________
-int NA6PVertexerTracks::findVertices()
+int NA6PVertexerTracks::findVertices(std::vector<NA6PVertex>& vertices)
 {
-  int nfound = 0, ntr = 0;
+  int nfound = 0;
   buildAndFillHistoZ();
   int nTrials = 0;
   while (nfound < mMaxVerticesPerCluster && nTrials < mMaxTrialsPerCluster) {
@@ -78,9 +80,17 @@ int NA6PVertexerTracks::findVertices()
       break;
     }
     float zSeed = mZMin + (peakBin + 0.5f) * mZBinWidth;
+
     NA6PVertex vtx;
     if (fitVertex(zSeed, vtx)) {
+      finalizeVertex(vtx, vertices);
+      nfound++;
+      nTrials = 0;
+    } else {
+      // suppress failed seeding bin and its proximities
+      mHistZ[peakBin] = -1.f;
     }
+    nTrials++;
   }
   return nfound;
 }
@@ -95,7 +105,7 @@ bool NA6PVertexerTracks::fitVertex(float zSeed, NA6PVertex& vtx)
   vtxSeed.setScale(mInitScaleSigma2, mTukey2I);
   vtxSeed.scaleSigma2Prev = mInitScaleSigma2;
   vtx.setChi2(1.e30);
-  
+
   FitStatus result = FitStatus::IterateFurther;
   while (result == FitStatus::IterateFurther) {
     vtxSeed.resetForNewIteration();
@@ -124,10 +134,23 @@ bool NA6PVertexerTracks::fitVertex(float zSeed, NA6PVertex& vtx)
   vtx.setNContributors(vtxSeed.nContributors);
   vtx.setChi2(vtxSeed.getChi2());
   vtx.setCov(vtxSeed.cxx, vtxSeed.cxy, vtxSeed.cxz, vtxSeed.cyy, vtxSeed.cyz, vtxSeed.czz);
+  vtx.setVertexType(NA6PVertex::kTrackPrimaryVertex);
 
   return true;
 }
 
+//___________________________________________________________________
+void NA6PVertexerTracks::finalizeVertex(NA6PVertex& vtx, std::vector<NA6PVertex>& vertices)
+{
+  int lastID = vertices.size();
+  for (auto& trc : mTracksPool) {
+    if (trc.canAssign()) {
+      vtx.addTrackID(trc.trackIndex);
+      trc.vtxID = lastID;
+    }
+  }
+  vertices.emplace_back(vtx);
+}
 //___________________________________________________________________
 NA6PVertexerTracks::FitStatus NA6PVertexerTracks::fitIteration(VertexSeed& vtxSeed)
 {
@@ -138,7 +161,6 @@ NA6PVertexerTracks::FitStatus NA6PVertexerTracks::fitIteration(VertexSeed& vtxSe
       nTested++;
     }
   }
-
   vtxSeed.maxScaleSigma2Tested = vtxSeed.scaleSigma2;
   if (vtxSeed.getNContributors() < mMinTracksPerVtx) {
     return nTested < mMinTracksPerVtx ? FitStatus::PoolEmpty : FitStatus::NotEnoughTracks;
@@ -154,7 +176,7 @@ void NA6PVertexerTracks::accountTrack(TrackVF& trc, VertexSeed& vtxSeed) const
 {
   // deltas defined as track - vertex
   float vtxPos[3] = {vtxSeed.x, vtxSeed.y, vtxSeed.z};
-  auto res = trc.getResiduals(vtxPos); 
+  auto res = trc.getResiduals(vtxPos);
   float dx = res[0], dy = res[1], dz = res[2];
   auto chi2T = trc.evalChi2ToVertex(dx, dy);
   float wghT = (1.f - chi2T * vtxSeed.scaleSig2ITuk2I); // weighted distance to vertex
@@ -198,11 +220,16 @@ bool NA6PVertexerTracks::solveVertex(VertexSeed& vtxSeed) const
   }
   ROOT::Math::SVector<double, 3> rhs(vtxSeed.cx0, vtxSeed.cy0, vtxSeed.cz0);
   auto sol = mat * rhs;
-  vtxSeed.x = sol(0);
-  vtxSeed.y = sol(1);
-  vtxSeed.z = sol(2);
-  vtxSeed.cxx = mat(0,0);  vtxSeed.cxy = mat(1,0);  vtxSeed.cyy = mat(1,1);
-  vtxSeed.cxz = mat(2,0);  vtxSeed.cyz = mat(2,1);  vtxSeed.czz = mat(2,2);
+  // sol gives a correction to the current position, not the absolute position
+  vtxSeed.x += sol(0);
+  vtxSeed.y += sol(1);
+  vtxSeed.z += sol(2);
+  vtxSeed.cxx = mat(0, 0);
+  vtxSeed.cxy = mat(1, 0);
+  vtxSeed.cyy = mat(1, 1);
+  vtxSeed.cxz = mat(2, 0);
+  vtxSeed.cyz = mat(2, 1);
+  vtxSeed.czz = mat(2, 2);
 
   vtxSeed.setChi2((vtxSeed.getNContributors() - vtxSeed.wghSum) / vtxSeed.scaleSig2ITuk2I); // calculate chi^2
   auto newScale = vtxSeed.wghSum > 0. ? vtxSeed.wghChi2 / vtxSeed.wghSum : mInitScaleSigma2;
@@ -216,11 +243,16 @@ NA6PVertexerTracks::FitStatus NA6PVertexerTracks::evalIterations(VertexSeed& vtx
   // decide if new iteration should be done, prepare next one if needed
   // if scaleSigma2 reached its lower limit stop
   FitStatus result = FitStatus::IterateFurther;
+  if (mVerbose)
+    LOGP(debug, "evalIteration: after {} iterations, scaleSigma2Prev = {}, scaleSigma2 = {}, nScaleIncrease = {}, nScaleSlowConvergence = {}, chi2 = {}", vtxSeed.nIterations, vtxSeed.scaleSigma2Prev, vtxSeed.scaleSigma2, vtxSeed.nScaleIncrease, vtxSeed.nScaleSlowConvergence, vtxSeed.getChi2() / vtxSeed.getNContributors());
 
   if (vtxSeed.nIterations > mMaxIterations) {
     result = FitStatus::Failure;
     return result;
   } else if (vtxSeed.scaleSigma2Prev <= mMinScale2 + kAlmost0F) {
+    result = FitStatus::OK;
+  } else if (std::abs(vtxSeed.scaleSigma2 - vtxSeed.scaleSigma2Prev) < kScaleStability * vtxSeed.scaleSigma2Prev) {
+    // scale is oscillating at a fixed point
     result = FitStatus::OK;
   }
 
@@ -263,4 +295,3 @@ bool NA6PVertexerTracks::upscaleSigma(VertexSeed& vtxSeed) const
   }
   return false;
 }
-

--- a/rec/src/NA6PVertexerTracks.cxx
+++ b/rec/src/NA6PVertexerTracks.cxx
@@ -3,6 +3,11 @@
 
 ClassImp(NA6PVertexerTracks)
 
+NA6PVertexerTracks::NA6PVertexerTracks()
+{
+  configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
+}
+
 void NA6PVertexerTracks::createTracksPool(const std::vector<NA6PTrack>& tracks)
 {
   mTracksPool.clear();
@@ -18,4 +23,55 @@ void NA6PVertexerTracks::createTracksPool(const std::vector<NA6PTrack>& tracks)
       continue;
     }
   }
+}
+
+void NA6PVertexerTracks::buildAndFillHistoZ()
+{
+  std::fill(mHistZ.begin(), mHistZ.end(), 0.f);
+  mFilledBinsZ.clear();
+  for (const auto& tvf : mTracksPool) {
+    float z = tvf.mLine.mOriginPoint[2];
+    if (z >= mZMin && z < mZMax) {
+      int bin = int((z - mZMin) / mZBinWidth);
+      if (mHistZ[bin] == 0.f)
+        mFilledBinsZ.push_back(bin);
+      mHistZ[bin] += tvf.mWeightHisto;  // weighted fill      
+    }
+  }
+}
+
+int NA6PVertexerTracks::findPeakBin()
+{
+  if (mFilledBinsZ.empty())
+    return -1;
+  
+  int maxBin = -1, ib = mFilledBinsZ.size(), last = ib;
+  float maxv = 0.f;
+  while (ib--) {
+    auto bin = mFilledBinsZ[ib];
+    auto v = mHistZ[bin];
+    if (v > maxv) {
+      maxv = v;
+      maxBin = bin;
+    } else if (v <= 0.f) {                      // bin was emptied
+      mFilledBinsZ[ib] = mFilledBinsZ[--last]; // move last non-empty bin in place of emptied one
+    }
+  }
+  mFilledBinsZ.resize(last);
+  return maxBin;
+}
+
+int NA6PVertexerTracks::findVertices()
+{
+  int nfound = 0, ntr = 0;
+  buildAndFillHistoZ();
+  int nTrials = 0;
+  while (nfound < mMaxVerticesPerCluster && nTrials < mMaxTrialsPerCluster) {
+    int peakBin = findPeakBin();
+    if (peakBin < 0) {
+      break;
+    }
+    float zv = mZMin + (peakBin + 0.5) * mZBinWidth;
+  }
+  return nfound;
 }

--- a/rec/src/recLinkDef.h
+++ b/rec/src/recLinkDef.h
@@ -24,6 +24,7 @@
 #pragma link C++ class NA6PMatching + ;
 #pragma link C++ class ExtTrackPar + ;
 #pragma link C++ class NA6PVertexerTracklets + ;
+#pragma link C++ class NA6PVertexerTracks + ;
 #pragma link C++ class NA6PTrackerCA + ;
 #pragma link C++ class NA6PFastTrackFitter + ;
 

--- a/test/runVertexerTracks.C
+++ b/test/runVertexerTracks.C
@@ -1,0 +1,92 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <TTree.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TCanvas.h>
+#include <TParticle.h>
+#include "MagneticField.h"
+#include "NA6PVertex.h"
+#include "NA6PVertexerTracks.h"
+#endif
+
+void runVertexerTracks(const char* dirSimu = ".")
+{
+  auto magField = new MagneticField();
+  magField->loadField();
+  magField->setAsGlobalField();
+
+  TFile* ft = new TFile(Form("%s/TracksVerTel.root", dirSimu));
+  if (!ft)
+    return;
+  TTree* trTree = (TTree*)ft->Get("tracksVerTel");
+  std::vector<NA6PTrack>* trArr = nullptr;
+  trTree->SetBranchAddress("VerTel", &trArr);
+
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+
+  TH1F* hncontr = new TH1F("hncontr", "", 100, -0.5, 999.5);
+  TH1F* hnvert = new TH1F("hnvert", "", 11, -0.5, 10.5);
+  TH1F* hdx = new TH1F("hdx", "", 100, -0.2, 0.2);
+  TH1F* hdy = new TH1F("hdy", "", 100, -0.2, 0.2);
+  TH1F* hdz = new TH1F("hdz", "", 100, -0.5, 0.5);
+
+  NA6PVertexerTracks* vertxr = new NA6PVertexerTracks();
+  vertxr->setVerbosity(true);
+
+  int nEv = trTree->GetEntries();
+  printf("Number of events = %d\n", nEv);
+  for (int jEv = 0; jEv < nEv; jEv++) {
+    mcTree->GetEvent(jEv);
+    trTree->GetEvent(jEv);
+    int nPart = mcArr->size();
+    int nTracks = trArr->size();
+    printf("Event %d particles = %d tracks = %d\n", jEv, nPart, nTracks);
+
+    double xVertGen = 0;
+    double yVertGen = 0;
+    double zVertGen = 0;
+    // get primary vertex position from the Kine Tree
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      if (curPart.IsPrimary()) {
+        xVertGen = curPart.Vx();
+        yVertGen = curPart.Vy();
+        zVertGen = curPart.Vz();
+        break;
+      }
+    }
+    vertxr->setBeamX(xVertGen);
+    vertxr->setBeamY(yVertGen);
+    vertxr->createTracksPool(*trArr);
+    std::vector<NA6PVertex> vertices;
+    vertxr->findVertices(vertices);
+    int nVertices = vertices.size();
+    hnvert->Fill(nVertices);
+    int jv = 0;
+    for (auto vert : vertices) {
+      double xRec = vert.getX();
+      double yRec = vert.getY();
+      double zRec = vert.getZ();
+      printf("Vertex %d, z = %f contrib = %d\n", jv++, zRec, vert.getNContributors());
+      hdx->Fill(xRec - xVertGen);
+      hdy->Fill(yRec - yVertGen);
+      hdz->Fill(zRec - zVertGen);
+      hncontr->Fill(vert.getNContributors());
+    }
+  }
+  TCanvas* coutp = new TCanvas("coutp", "", 1200, 800);
+  coutp->Divide(3, 2);
+  coutp->cd(1);
+  hnvert->Draw();
+  coutp->cd(2);
+  hncontr->Draw();
+  coutp->cd(4);
+  hdx->Draw();
+  coutp->cd(5);
+  hdy->Draw();
+  coutp->cd(6);
+  hdz->Draw();
+}

--- a/test/runVertexerTracks.C
+++ b/test/runVertexerTracks.C
@@ -2,6 +2,7 @@
 #include <TTree.h>
 #include <TFile.h>
 #include <TH1F.h>
+#include <TH2F.h>
 #include <TCanvas.h>
 #include <TParticle.h>
 #include "MagneticField.h"
@@ -27,11 +28,14 @@ void runVertexerTracks(const char* dirSimu = ".")
   std::vector<TParticle>* mcArr = nullptr;
   mcTree->SetBranchAddress("tracks", &mcArr);
 
-  TH1F* hncontr = new TH1F("hncontr", "", 100, -0.5, 999.5);
-  TH1F* hnvert = new TH1F("hnvert", "", 11, -0.5, 10.5);
-  TH1F* hdx = new TH1F("hdx", "", 100, -0.2, 0.2);
-  TH1F* hdy = new TH1F("hdy", "", 100, -0.2, 0.2);
-  TH1F* hdz = new TH1F("hdz", "", 100, -0.5, 0.5);
+  TH1F* hncontr = new TH1F("hncontr", ";N_{contributors}", 100, -0.5, 999.5);
+  TH1F* hnvert = new TH1F("hnvert", ";Number of reco vertices", 11, -0.5, 10.5);
+  TH2F* hxrecgen = new TH2F("hxrecgen", ";x_{gen} (cm);x_{rec} (cm)", 50, -0.05, 0.05, 50, -0.05, 0.05);
+  TH2F* hyrecgen = new TH2F("hyrecgen", ";y_{gen} (cm);y_{rec} (cm)", 50, -0.05, 0.05, 50, -0.05, 0.05);
+  TH2F* hzrecgen = new TH2F("hzrecgen", ";z_{gen} (cm);z_{rec} (cm)", 50, -4., 2., 50, -4., 2.);
+  TH1F* hdx = new TH1F("hdx", ";x_{rec} - x_{gen} (cm)", 100, -0.05, 0.05);
+  TH1F* hdy = new TH1F("hdy", ";y_{rec} - y_{gen} (cm)", 100, -0.05, 0.05);
+  TH1F* hdz = new TH1F("hdz", ";z_{rec} - z_{gen} (cm)", 100, -0.5, 0.5);
 
   NA6PVertexerTracks* vertxr = new NA6PVertexerTracks();
   vertxr->setVerbosity(true);
@@ -70,19 +74,34 @@ void runVertexerTracks(const char* dirSimu = ".")
       double xRec = vert.getX();
       double yRec = vert.getY();
       double zRec = vert.getZ();
+      if (jv == 0) {
+        hxrecgen->Fill(xVertGen, xRec);
+        hyrecgen->Fill(yVertGen, yRec);
+        hzrecgen->Fill(zVertGen, zRec);
+        hdx->Fill(xRec - xVertGen);
+        hdy->Fill(yRec - yVertGen);
+        hdz->Fill(zRec - zVertGen);
+        hncontr->Fill(vert.getNContributors());
+      }
       printf("Vertex %d, z = %f contrib = %d\n", jv++, zRec, vert.getNContributors());
-      hdx->Fill(xRec - xVertGen);
-      hdy->Fill(yRec - yVertGen);
-      hdz->Fill(zRec - zVertGen);
-      hncontr->Fill(vert.getNContributors());
     }
   }
-  TCanvas* coutp = new TCanvas("coutp", "", 1200, 800);
+
+  TCanvas* cv = new TCanvas("cv", "", 1000, 500);
+  cv->Divide(2, 1);
+  cv->cd(1);
+  hnvert->Draw();
+  cv->cd(2);
+  hncontr->Draw();
+
+  TCanvas* coutp = new TCanvas("coutp", "", 1400, 800);
   coutp->Divide(3, 2);
   coutp->cd(1);
-  hnvert->Draw();
+  hxrecgen->Draw("colz");
   coutp->cd(2);
-  hncontr->Draw();
+  hyrecgen->Draw("colz");
+  coutp->cd(3);
+  hzrecgen->Draw("colz");
   coutp->cd(4);
   hdx->Draw();
   coutp->cd(5);


### PR DESCRIPTION
This PR ports the PVertexer class used to compute the primary vertex in O2. 
Following some indications from Ruben, I removed the time "dimension" from the vertex search.
I did not yet implement the step of debris reduction.
I did some basic checks on few Pb-Pb events, mainly to check that the code works and finds reasonable positions.
