### PR TITLE
Fix determination of sigma_z + compute pulls in macro

### DIFF
--- a/rec/include/NA6PVertexerTracks.h
+++ b/rec/include/NA6PVertexerTracks.h
@@ -50,8 +50,8 @@ struct TrackVF {
     float cx = mLine.mCosinesDirector[0];
     float cy = mLine.mCosinesDirector[1];
     float cz = mLine.mCosinesDirector[2];
-    float iczcz = 1.f / (cz * cz);
-    float szz = (cx * cx * sxx + cy * cy * syy + 2.f * cx * cy * sxy) * iczcz;
+    float pt2 = cx * cx + cy * cy;
+    float szz = (pt2 > 1e-6f) ? 0.5f * (sxx + syy) * (cz * cz) / pt2 : 1e10f;
     float det = sxx * syy - sxy * sxy;
     if (det <= 1e-20f) {
       mSig2ZI = -1.f;
@@ -69,14 +69,14 @@ struct TrackVF {
   bool canUse() const { return vtxID == kNoVtx; }
   bool canAssign() const { return wgh > 0. && vtxID == kNoVtx; }
 
-  std::array<float, 3> getResiduals(const std::array<float,3>& vtxPos) const
+  std::array<float, 3> getResiduals(const std::array<float, 3>& vtxPos) const
   {
     // vector from closest point on line to vtxPos
     auto comps = mLine.getDCAComponents(vtxPos);
     return {comps[0], comps[3], comps[5]}; // dx, dy, dz components
   }
 
-  float evalChi2ToVertex(const std::array<float,3>& vtxPos) const
+  float evalChi2ToVertex(const std::array<float, 3>& vtxPos) const
   {
     auto res = getResiduals(vtxPos); // track-vertex residuals and chi2
     float dx = res[0], dy = res[1];
@@ -213,7 +213,7 @@ class NA6PVertexerTracks
   int mMaxVerticesPerCluster = 5;                 ///< one vertex per target
   int mMaxTrialsPerCluster = 100;                 //
   static constexpr float kAlmost0F = 1e-7f;       ///< tiny float
-  static constexpr float kScaleStability = 0.1f;  ///< tolerance for scale change
+  //  static constexpr float kScaleStability = 0.1f;  ///< tolerance for scale change
   static constexpr float kDefTukey = 5.0f;        ///< def.value for tukey constant
   float mTukey2I = 1.f / (kDefTukey * kDefTukey); ///< 1./[Tukey parameter]^2
   float mInitScaleSigma2 = 10.f;                  ///< scaling parameter on top of Tukey param

--- a/rec/src/NA6PVertexerTracks.cxx
+++ b/rec/src/NA6PVertexerTracks.cxx
@@ -261,9 +261,9 @@ NA6PVertexerTracks::FitStatus NA6PVertexerTracks::evalIterations(VertexSeed& vtx
     return result;
   } else if (vtxSeed.scaleSigma2Prev <= mMinScale2 + kAlmost0F) {
     result = FitStatus::OK;
-  } else if (std::abs(vtxSeed.scaleSigma2 - vtxSeed.scaleSigma2Prev) < kScaleStability * vtxSeed.scaleSigma2Prev) {
-    // scale is oscillating at a fixed point
-    result = FitStatus::OK;
+    // } else if (std::abs(vtxSeed.scaleSigma2 - vtxSeed.scaleSigma2Prev) < kScaleStability * vtxSeed.scaleSigma2Prev) {
+    //   // scale is oscillating at a fixed point
+    //   result = FitStatus::OK;
   }
 
   if (result == FitStatus::OK) {

--- a/test/runVertexerTracks.C
+++ b/test/runVertexerTracks.C
@@ -8,6 +8,7 @@
 #include "MagneticField.h"
 #include "NA6PVertex.h"
 #include "NA6PVertexerTracks.h"
+#include "NA6PMCEventHeader.h"
 #endif
 
 void runVertexerTracks(const char* dirSimu = ".")
@@ -27,15 +28,29 @@ void runVertexerTracks(const char* dirSimu = ".")
   TTree* mcTree = (TTree*)fk->Get("mckine");
   std::vector<TParticle>* mcArr = nullptr;
   mcTree->SetBranchAddress("tracks", &mcArr);
+  NA6PMCEventHeader* mcHead = nullptr;
+  mcTree->SetBranchAddress("header", &mcHead);
 
   TH1F* hncontr = new TH1F("hncontr", ";N_{contributors}", 100, -0.5, 999.5);
   TH1F* hnvert = new TH1F("hnvert", ";Number of reco vertices", 11, -0.5, 10.5);
-  TH2F* hxrecgen = new TH2F("hxrecgen", ";x_{gen} (cm);x_{rec} (cm)", 50, -0.05, 0.05, 50, -0.05, 0.05);
-  TH2F* hyrecgen = new TH2F("hyrecgen", ";y_{gen} (cm);y_{rec} (cm)", 50, -0.05, 0.05, 50, -0.05, 0.05);
-  TH2F* hzrecgen = new TH2F("hzrecgen", ";z_{gen} (cm);z_{rec} (cm)", 50, -4., 2., 50, -4., 2.);
-  TH1F* hdx = new TH1F("hdx", ";x_{rec} - x_{gen} (cm)", 100, -0.05, 0.05);
-  TH1F* hdy = new TH1F("hdy", ";y_{rec} - y_{gen} (cm)", 100, -0.05, 0.05);
-  TH1F* hdz = new TH1F("hdz", ";z_{rec} - z_{gen} (cm)", 100, -0.5, 0.5);
+  TH2F* hxrecgen = new TH2F("hxrecgen", ";x_{gen} (cm);x_{rec} (cm)", 100, -0.05, 0.05, 100, -0.05, 0.05);
+  TH2F* hyrecgen = new TH2F("hyrecgen", ";y_{gen} (cm);y_{rec} (cm)", 100, -0.05, 0.05, 100, -0.05, 0.05);
+  TH2F* hzrecgen = new TH2F("hzrecgen", ";z_{gen} (cm);z_{rec} (cm)", 100, -4., 4., 100, -4., 4.);
+  TH1F* hxrec = new TH1F("hxrec", ";x_{rec,main} (cm)", 100, -0.1, 0.1);
+  TH1F* hyrec = new TH1F("hyrec", ";y_{rec,main} (cm)", 100, -0.1, 0.1);
+  TH1F* hzrec = new TH1F("hzrec", ";z_{rec,main} (cm)", 200, -4., 4.);
+  TH1F* hdx = new TH1F("hdx", ";x_{rec} - x_{gen} (#mum)", 100, -40., 40.);
+  TH1F* hdy = new TH1F("hdy", ";y_{rec} - y_{gen} (#mum)", 100, -40., 40.);
+  TH1F* hdz = new TH1F("hdz", ";z_{rec} - z_{gen} (#mum)", 100, -200., 200.);
+  TH1F* hsigx = new TH1F("hsigx", ";#sigma_{x} (#mum)", 100, 0., 50.);
+  TH1F* hsigy = new TH1F("hsigy", ";#sigma_{y} (#mum)", 100, 0., 50.);
+  TH1F* hsigz = new TH1F("hsigz", ";#sigma_{z} (#mum)", 100, 0., 250.);
+  TH1F* hpullx = new TH1F("hpullx", ";(x_{rec} - x_{gen}) / #sigma_{x}", 100, -5., 5.);
+  TH1F* hpully = new TH1F("hpully", ";(y_{rec} - y_{gen}) / #sigma_{y}", 100, -5., 5.);
+  TH1F* hpullz = new TH1F("hpullz", ";(z_{rec} - z_{gen}) / #sigma_{z}", 100, -5., 5.);
+  TH1F* hzRecDiff = new TH1F("hzRecDiff", ";z_{rec}^{pil} - z_{rec}^{main} (cm)", 100, -5, 5);
+  TH1F* hcontRatio = new TH1F("hcontRatio", ";n_{Contrib}^{pil} / n_{Contrib}^{main}", 101, 0., 1.01);
+  TH2F* hzdrc = new TH2F("hzdrc", ";n_{Contrib}^{A} / n_{Contrib}^{B};|z_{rec}^{A} - z_{rec}^{B}| (cm)", 101, 0., 1.01, 100, 0, 5);
 
   NA6PVertexerTracks* vertxr = new NA6PVertexerTracks();
   vertxr->setVerbosity(true);
@@ -47,21 +62,12 @@ void runVertexerTracks(const char* dirSimu = ".")
     trTree->GetEvent(jEv);
     int nPart = mcArr->size();
     int nTracks = trArr->size();
-    printf("Event %d particles = %d tracks = %d\n", jEv, nPart, nTracks);
+    double xVertGen = mcHead->getVX();
+    double yVertGen = mcHead->getVY();
+    double zVertGen = mcHead->getVZ();
 
-    double xVertGen = 0;
-    double yVertGen = 0;
-    double zVertGen = 0;
-    // get primary vertex position from the Kine Tree
-    for (int jp = 0; jp < nPart; jp++) {
-      auto curPart = mcArr->at(jp);
-      if (curPart.IsPrimary()) {
-        xVertGen = curPart.Vx();
-        yVertGen = curPart.Vy();
-        zVertGen = curPart.Vz();
-        break;
-      }
-    }
+    printf("Event %d particles = %d tracks = %d true z vertex position = %f\n", jEv, nPart, nTracks, zVertGen);
+
     vertxr->setBeamX(xVertGen);
     vertxr->setBeamY(yVertGen);
     vertxr->createTracksPool(*trArr);
@@ -69,43 +75,128 @@ void runVertexerTracks(const char* dirSimu = ".")
     vertxr->findVertices(vertices);
     int nVertices = vertices.size();
     hnvert->Fill(nVertices);
-    int jv = 0;
-    for (auto vert : vertices) {
-      double xRec = vert.getX();
-      double yRec = vert.getY();
-      double zRec = vert.getZ();
-      if (jv == 0) {
+    int nv = vertices.size();
+    std::vector<int> multSort(nv); // sort time indices in multiplicity
+    std::iota(multSort.begin(), multSort.end(), 0);
+    std::sort(multSort.begin(), multSort.end(), [vertices](int i, int j) {
+      return vertices[i].getNContributors() > vertices[j].getNContributors();
+    });
+    auto& vt0 = vertices[0];
+    for (int im = 0; im < nv; im++) { // loop from highest multiplicity to lowest one
+      int it1 = multSort[im];
+      auto& vtI = vertices[it1];
+      double xRec = vtI.getX();
+      double yRec = vtI.getY();
+      double zRec = vtI.getZ();
+      double sigx = vtI.getSigmaX();
+      double sigy = vtI.getSigmaY();
+      double sigz = vtI.getSigmaZ();
+      if (im == 0) {
+        hxrec->Fill(xRec);
+        hyrec->Fill(yRec);
+        hzrec->Fill(zRec);
         hxrecgen->Fill(xVertGen, xRec);
         hyrecgen->Fill(yVertGen, yRec);
         hzrecgen->Fill(zVertGen, zRec);
-        hdx->Fill(xRec - xVertGen);
-        hdy->Fill(yRec - yVertGen);
-        hdz->Fill(zRec - zVertGen);
-        hncontr->Fill(vert.getNContributors());
+        hdx->Fill((xRec - xVertGen) * 1e4);
+        hdy->Fill((yRec - yVertGen) * 1e4);
+        hdz->Fill((zRec - zVertGen) * 1e4);
+        hsigx->Fill(sigx * 1e4);
+        hsigy->Fill(sigy * 1e4);
+        hsigz->Fill(sigz * 1e4);
+        hpullx->Fill((xRec - xVertGen) / sigx);
+        hpully->Fill((yRec - yVertGen) / sigy);
+        hpullz->Fill((zRec - zVertGen) / sigz);
+        hncontr->Fill(vtI.getNContributors());
       }
-      printf("Vertex %d, z = %f contrib = %d\n", jv++, zRec, vert.getNContributors());
+      if (im > 0) {
+        float zDiff0 = vtI.getZ() - vt0.getZ();
+        float rCont0 = float(vtI.getNContributors()) / float(vt0.getNContributors());
+        hzRecDiff->Fill(zDiff0);
+        hcontRatio->Fill(rCont0);
+      }
+      for (int in = im + 1; in < nv; in++) { // loop from highest multiplicity to lowest one
+        int it2 = multSort[in];
+        auto& vtJ = vertices[it2];
+        float zDiff = vtI.getZ() - vtJ.getZ();
+        float rCont = float(vtJ.getNContributors()) / float(vtI.getNContributors());
+        hzdrc->Fill(rCont, std::abs(zDiff));
+      }
     }
   }
 
-  TCanvas* cv = new TCanvas("cv", "", 1000, 500);
-  cv->Divide(2, 1);
+  TCanvas* cv = new TCanvas("cv", "", 1400, 800);
+  cv->Divide(3, 2);
   cv->cd(1);
+  hnvert->SetLineWidth(2);
   hnvert->Draw();
   cv->cd(2);
+  hncontr->SetLineWidth(2);
   hncontr->Draw();
+  cv->cd(4);
+  hxrec->SetFillColor(kBlue - 9);
+  hxrec->SetFillStyle(1001);
+  hxrec->Draw();
+  cv->cd(5);
+  hyrec->SetFillColor(kBlue - 9);
+  hyrec->SetFillStyle(1001);
+  hyrec->Draw();
+  cv->cd(6);
+  hzrec->SetFillColor(kBlue - 9);
+  hzrec->SetFillStyle(1001);
+  hzrec->Draw();
 
-  TCanvas* coutp = new TCanvas("coutp", "", 1400, 800);
-  coutp->Divide(3, 2);
-  coutp->cd(1);
+  TCanvas* cres = new TCanvas("cres", "", 1400, 800);
+  cres->Divide(3, 2);
+  cres->cd(1);
   hxrecgen->Draw("colz");
-  coutp->cd(2);
+  cres->cd(2);
   hyrecgen->Draw("colz");
-  coutp->cd(3);
+  cres->cd(3);
   hzrecgen->Draw("colz");
-  coutp->cd(4);
+  cres->cd(4);
+  hdx->SetFillColor(kOrange + 2);
+  hdx->SetFillStyle(1001);
   hdx->Draw();
-  coutp->cd(5);
+  cres->cd(5);
+  hdy->SetFillColor(kOrange + 2);
+  hdy->SetFillStyle(1001);
   hdy->Draw();
-  coutp->cd(6);
+  cres->cd(6);
+  hdz->SetFillColor(kOrange + 2);
+  hdz->SetFillStyle(1001);
   hdz->Draw();
+
+  TCanvas* cpull = new TCanvas("cpull", "", 1400, 800);
+  cpull->Divide(3, 2);
+  cpull->cd(1);
+  hsigx->SetLineWidth(2);
+  hsigx->Draw();
+  cpull->cd(2);
+  hsigy->SetLineWidth(2);
+  hsigy->Draw();
+  cpull->cd(3);
+  hsigz->SetLineWidth(2);
+  hsigz->Draw();
+  cpull->cd(4);
+  hpullx->SetFillColor(kTeal - 7);
+  hpullx->SetFillStyle(1001);
+  hpullx->Draw();
+  cpull->cd(5);
+  hpully->SetFillColor(kTeal - 7);
+  hpully->SetFillStyle(1001);
+  hpully->Draw();
+  cpull->cd(6);
+  hpullz->SetFillColor(kTeal - 7);
+  hpullz->SetFillStyle(1001);
+  hpullz->Draw();
+
+  TCanvas* cpil = new TCanvas("cz", "", 1200, 800);
+  cpil->Divide(2, 2);
+  cpil->cd(1);
+  hzRecDiff->Draw();
+  cpil->cd(2);
+  hcontRatio->Draw();
+  cpil->cd(3);
+  hzdrc->Draw("colz");
 }


### PR DESCRIPTION
To get reasonable pulls, I modified the assignment of the uncertainty on the z of the TrackVF using a projection of the uncertainties on x and y via the director cosines. Probably this can be revised and improved once we will have the native parameterization for the track.
Thnaks to @galocco for spotting the bad resolution on z and the wide pulls.

The performance for the residuals and pulls for central events using NA49 parameterization is the following:

<img width="1678" height="936" alt="PrimVertexResidualsFixDzFixSigZ" src="https://github.com/user-attachments/assets/8ec78ace-7df6-48bd-9a0a-307bb458f976" />

<img width="1678" height="936" alt="PrimVertexPullsFixDzFixSigZ" src="https://github.com/user-attachments/assets/df7dd13c-a5b7-4489-b061-9da259308366" />
