### PR TITLE
First implementation of a class to manage VT pixel plane segmentation

### DIFF
--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -33,6 +33,7 @@ set(DICTIONARY_HEADERS
   NA6PGenCocktail.h
   NA6PBaseHit.h
   NA6PVerTelHit.h
+  NA6PVerTelSegmentation.h
   NA6PMuonSpecHit.h
   NA6PMuonSpecModularHit.h
   GenMUONLMR.h

--- a/sim/include/NA6PVerTelSegmentation.h
+++ b/sim/include/NA6PVerTelSegmentation.h
@@ -1,0 +1,58 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_VERTEL_SEGMENTATION_H
+#define NA6P_VERTEL_SEGMENTATION_H
+
+#include <Rtypes.h>
+
+// define dead areas and segmentation of the VT modules
+
+class NA6PVerTelSegmentation
+{
+ public:
+  
+  NA6PVerTelSegmentation() = default;
+
+  void setOffsetX(float val) { mOffsX = val;}
+  void setOffsetY(float val) { mOffsY = val;}
+  void setInterChipGap(float val) { mInterChipGap = val;}
+  
+  int isInAcc(float x, float y) const;
+  
+ protected:
+  static const float XSizeTot;
+  static const float YSizeTot; // readout side
+  static const float DeadXLong;  // right end cap
+  static const float DeadXShort; // left end cap (readout)
+  static const float DeadYBottom; // bottom dead zone
+  static const float DeadYTop; // top dead zone
+  static const float DeadTopBotHalves; // dead space between top and bottom halves
+  static const float DeadXTile;  // dead space between tiles in X
+  static const float DeadXDataBackbone; // dead space between every segment (triplet of tiles)
+  static const int NXTiles;
+  static const int NXSegments;
+  static const int NYSensors;
+  static const float DXTile;
+  static const float DXSegment;
+  static const float DYSens;
+  
+  float mOffsX = 0.3;
+  float mOffsY = -0.3;
+  float mInterChipGap = 0.02;
+  
+  ClassDefNV(NA6PVerTelSegmentation, 1);
+};
+
+#endif

--- a/sim/include/NA6PVerTelSegmentation.h
+++ b/sim/include/NA6PVerTelSegmentation.h
@@ -22,34 +22,40 @@
 class NA6PVerTelSegmentation
 {
  public:
+  static constexpr float DeadXLong = 0.45;                            // right end cap
+  static constexpr float DeadXShort = 0.15;                           // left end cap (readout)
+  static constexpr float DeadYBottom = 0.0525;                        // bottom dead zone
+  static constexpr float DeadYTop = 0.0525;                           // top dead zone
+  static constexpr float DeadTopBotHalves = 0.012;                    // dead space between top and bottom halves
+  static constexpr float DeadXTile = 0.002;                           // dead space between tiles in X
+  static constexpr float DeadXDataBackbone = 0.006;                   // dead space between every segment (triplet of tiles)
+  static constexpr float XSizeTot = 12.9996 + DeadXShort + DeadXLong; // 13.5996;
+  static constexpr float YSizeTot = 13.5898 + DeadYBottom + DeadYTop; // 13.6948; // readout side
+  static constexpr int NXTiles = 36;                                  // tiles (3 tiles per segment)
+  static constexpr int NXSegments = 12;                               // group of 3 tiles
+  static constexpr int NYSensors = 7;                                 // number of rows along y
+  static constexpr float DXSegment = (XSizeTot - DeadXShort - DeadXLong) / NXSegments;
+  static constexpr float DXTile = (DXSegment - DeadXDataBackbone) / 3;
+  static constexpr float DYSens = YSizeTot / NYSensors;
+
   NA6PVerTelSegmentation() = default;
 
   void setOffsetX(float val) { mOffsX = val; }
   void setOffsetY(float val) { mOffsY = val; }
   void setInterChipGap(float val) { mInterChipGap = val; }
+  void setStaggered(bool val);
 
   int isInAcc(float x, float y) const;
 
  protected:
-  static const float XSizeTot;
-  static const float YSizeTot;          // readout side
-  static const float DeadXLong;         // right end cap
-  static const float DeadXShort;        // left end cap (readout)
-  static const float DeadYBottom;       // bottom dead zone
-  static const float DeadYTop;          // top dead zone
-  static const float DeadTopBotHalves;  // dead space between top and bottom halves
-  static const float DeadXTile;         // dead space between tiles in X
-  static const float DeadXDataBackbone; // dead space between every segment (triplet of tiles)
-  static const int NXTiles;
-  static const int NXSegments;
-  static const int NYSensors;
-  static const float DXTile;
-  static const float DXSegment;
-  static const float DYSens;
-
   float mOffsX = 0.3;
   float mOffsY = -0.3;
   float mInterChipGap = 0.02;
+  bool mStaggered = false;
+  float mDeadXLongEff = DeadXLong;
+  float mDeadXShortEff = DeadXShort;
+  float mDeadYBottomEff = DeadYBottom;
+  float mDeadYTopEff = DeadYTop;
 
   ClassDefNV(NA6PVerTelSegmentation, 1);
 };

--- a/sim/include/NA6PVerTelSegmentation.h
+++ b/sim/include/NA6PVerTelSegmentation.h
@@ -22,24 +22,23 @@
 class NA6PVerTelSegmentation
 {
  public:
-  
   NA6PVerTelSegmentation() = default;
 
-  void setOffsetX(float val) { mOffsX = val;}
-  void setOffsetY(float val) { mOffsY = val;}
-  void setInterChipGap(float val) { mInterChipGap = val;}
-  
+  void setOffsetX(float val) { mOffsX = val; }
+  void setOffsetY(float val) { mOffsY = val; }
+  void setInterChipGap(float val) { mInterChipGap = val; }
+
   int isInAcc(float x, float y) const;
-  
+
  protected:
   static const float XSizeTot;
-  static const float YSizeTot; // readout side
-  static const float DeadXLong;  // right end cap
-  static const float DeadXShort; // left end cap (readout)
-  static const float DeadYBottom; // bottom dead zone
-  static const float DeadYTop; // top dead zone
-  static const float DeadTopBotHalves; // dead space between top and bottom halves
-  static const float DeadXTile;  // dead space between tiles in X
+  static const float YSizeTot;          // readout side
+  static const float DeadXLong;         // right end cap
+  static const float DeadXShort;        // left end cap (readout)
+  static const float DeadYBottom;       // bottom dead zone
+  static const float DeadYTop;          // top dead zone
+  static const float DeadTopBotHalves;  // dead space between top and bottom halves
+  static const float DeadXTile;         // dead space between tiles in X
   static const float DeadXDataBackbone; // dead space between every segment (triplet of tiles)
   static const int NXTiles;
   static const int NXSegments;
@@ -47,11 +46,11 @@ class NA6PVerTelSegmentation
   static const float DXTile;
   static const float DXSegment;
   static const float DYSens;
-  
+
   float mOffsX = 0.3;
   float mOffsY = -0.3;
   float mInterChipGap = 0.02;
-  
+
   ClassDefNV(NA6PVerTelSegmentation, 1);
 };
 

--- a/sim/src/NA6PVerTelSegmentation.cxx
+++ b/sim/src/NA6PVerTelSegmentation.cxx
@@ -2,22 +2,21 @@
 
 #include "NA6PVerTelSegmentation.h"
 
-const float NA6PVerTelSegmentation::DeadXShort = 0.15;    // short end cap
-const float NA6PVerTelSegmentation::DeadXLong = 0.45;     // long end cap   (readout)
-const float NA6PVerTelSegmentation::DeadYBottom = 0.0525; // bottom dead zone
-const float NA6PVerTelSegmentation::DeadYTop = 0.0525;    // top dead zone
-
-const float NA6PVerTelSegmentation::DeadTopBotHalves = 0.012;                    // dead space between top and bottom halves
-const float NA6PVerTelSegmentation::DeadXTile = 0.002;                           // dead space between tiles in X (apart from DeadXDataBackbone after each 3 tiles)
-const float NA6PVerTelSegmentation::DeadXDataBackbone = 0.006;                   // dead space between segments
-const float NA6PVerTelSegmentation::XSizeTot = 12.9996 + DeadXShort + DeadXLong; // 13.5996;
-const float NA6PVerTelSegmentation::YSizeTot = 13.5898 + DeadYBottom + DeadYTop; // 13.6948; // readout side
-const int NA6PVerTelSegmentation::NXTiles = 36;
-const int NA6PVerTelSegmentation::NXSegments = 12; // group of 3 tiles
-const int NA6PVerTelSegmentation::NYSensors = 7;
-const float NA6PVerTelSegmentation::DYSens = YSizeTot / NYSensors;
-const float NA6PVerTelSegmentation::DXSegment = (XSizeTot - DeadXShort - DeadXLong) / NXSegments;
-const float NA6PVerTelSegmentation::DXTile = (DXSegment - DeadXDataBackbone) / 3;
+void NA6PVerTelSegmentation::setStaggered(bool val)
+{
+  mStaggered = val;
+  if (val) {
+    mDeadXLongEff = DeadXLong + DeadXShort;
+    mDeadXShortEff = 0.f;
+    mDeadYTopEff = DeadYTop + DeadYBottom;
+    mDeadYBottomEff = 0.f;
+  } else {
+    mDeadXLongEff = DeadXLong;
+    mDeadXShortEff = DeadXShort;
+    mDeadYTopEff = DeadYTop;
+    mDeadYBottomEff = DeadYBottom;
+  }
+}
 
 int NA6PVerTelSegmentation::isInAcc(float x, float y) const
 {
@@ -26,29 +25,29 @@ int NA6PVerTelSegmentation::isInAcc(float x, float y) const
   float absOffY = std::abs(mOffsY) - mInterChipGap / 2;
   if ((x < -absOffX && y < absOffY) ||
       (x > -absOffX && y < -absOffY)) {
+    // flip signs for Q3 and Q4
     x = -x;
     y = -y;
   }
 
   x -= mOffsX;
-  if (x < 0.) {
+  if (x < 0.) { // Q2 + Q4
     y += mOffsY - mInterChipGap / 2;
     x += XSizeTot + mInterChipGap / 2; // relate to chip local left/bottom corner
-  } else {
+  } else {                             // Q1 + Q3
     y -= mOffsY + mInterChipGap / 2;
-    y = YSizeTot - y;
     x = (XSizeTot + mInterChipGap / 2) - x; // relate to chip local left/bottom corner
   }
 
   if (x < 0 || x > XSizeTot || y < 0 || y > YSizeTot)
     return 0;
 
-  if (x < DeadXLong || x > XSizeTot - DeadXShort || y < DeadYBottom || y > YSizeTot - DeadYTop)
+  if (x < mDeadXLongEff || x > XSizeTot - mDeadXShortEff || y < mDeadYBottomEff || y > YSizeTot - mDeadYTopEff)
     return -1;
-  x -= DeadXLong;
+  x -= mDeadXLongEff;
   int sens = int(y / DYSens);
   y -= sens * DYSens;
-  if (y < DeadYBottom || y > DYSens - DeadYTop)
+  if (y < mDeadYBottomEff || y > DYSens - mDeadYTopEff)
     return -1;
   int topbot = int(y / (DYSens / 2));
   y -= topbot * (DYSens / 2);

--- a/sim/src/NA6PVerTelSegmentation.cxx
+++ b/sim/src/NA6PVerTelSegmentation.cxx
@@ -1,0 +1,61 @@
+// NA6PCCopyright
+
+#include "NA6PVerTelSegmentation.h"
+
+const float NA6PVerTelSegmentation::DeadXShort = 0.15;  // short end cap
+const float NA6PVerTelSegmentation::DeadXLong = 0.45;   // long end cap   (readout)
+const float NA6PVerTelSegmentation::DeadYBottom = 0.0525; // bottom dead zone
+const float NA6PVerTelSegmentation::DeadYTop = 0.0525; // top dead zone
+
+const float NA6PVerTelSegmentation::DeadTopBotHalves = 0.012; // dead space between top and bottom halves
+const float NA6PVerTelSegmentation::DeadXTile = 0.002; // dead space between tiles in X (apart from DeadXDataBackbone after each 3 tiles)
+const float NA6PVerTelSegmentation::DeadXDataBackbone = 0.006; // dead space between segments
+const float NA6PVerTelSegmentation::XSizeTot = 12.9996 + DeadXShort +  DeadXLong;// 13.5996;
+const float NA6PVerTelSegmentation::YSizeTot = 13.5898 + DeadYBottom + DeadYTop; // 13.6948; // readout side
+const int   NA6PVerTelSegmentation::NXTiles = 36;
+const int   NA6PVerTelSegmentation::NXSegments = 12; // group of 3 tiles
+const int   NA6PVerTelSegmentation::NYSensors = 7;
+const float NA6PVerTelSegmentation::DYSens = YSizeTot / NYSensors;
+const float NA6PVerTelSegmentation::DXSegment = (XSizeTot - DeadXShort - DeadXLong) / NXSegments;
+const float NA6PVerTelSegmentation::DXTile = (DXSegment - DeadXDataBackbone) / 3;
+
+int NA6PVerTelSegmentation::isInAcc(float x, float y) const
+{
+
+  float absOffX = std::abs(mOffsX) - mInterChipGap/2;
+  float absOffY = std::abs(mOffsY) - mInterChipGap/2;
+  if ( (x < -absOffX && y < absOffY) ||
+       (x > -absOffX && y < -absOffY) ) {
+    x = -x;
+    y = -y;
+  }
+  
+  x -= mOffsX;
+  if (x < 0.) {
+    y += mOffsY - mInterChipGap/2;
+    x += XSizeTot + mInterChipGap/2; // relate to chip local left/bottom corner
+  } else {    
+    y -= mOffsY + mInterChipGap/2;
+    y = YSizeTot - y;
+    x = (XSizeTot + mInterChipGap/2) - x; // relate to chip local left/bottom corner
+  }
+
+  if (x < 0 || x > XSizeTot || y < 0 || y > YSizeTot) return 0;
+  
+  if (x < DeadXLong || x > XSizeTot - DeadXShort || y < DeadYBottom || y > YSizeTot - DeadYTop) return -1;
+  x -= DeadXLong;
+  int sens = int(y / DYSens);
+  y -= sens * DYSens;
+  if (y < DeadYBottom || y > DYSens - DeadYTop) return -1;
+  int topbot = int(y / (DYSens / 2));
+  y -= topbot * (DYSens / 2);
+  if (y < DeadTopBotHalves / 2) return -1;
+  int segm = int(x / DXSegment);
+  x -= segm * DXSegment;
+  if (x > DXSegment - DeadXDataBackbone) return -1;
+  int tile = int(x / DXTile);
+  x -= tile * DXTile;
+  if (x < DeadXTile) return -1;
+
+  return 1;
+}

--- a/sim/src/NA6PVerTelSegmentation.cxx
+++ b/sim/src/NA6PVerTelSegmentation.cxx
@@ -2,19 +2,19 @@
 
 #include "NA6PVerTelSegmentation.h"
 
-const float NA6PVerTelSegmentation::DeadXShort = 0.15;  // short end cap
-const float NA6PVerTelSegmentation::DeadXLong = 0.45;   // long end cap   (readout)
+const float NA6PVerTelSegmentation::DeadXShort = 0.15;    // short end cap
+const float NA6PVerTelSegmentation::DeadXLong = 0.45;     // long end cap   (readout)
 const float NA6PVerTelSegmentation::DeadYBottom = 0.0525; // bottom dead zone
-const float NA6PVerTelSegmentation::DeadYTop = 0.0525; // top dead zone
+const float NA6PVerTelSegmentation::DeadYTop = 0.0525;    // top dead zone
 
-const float NA6PVerTelSegmentation::DeadTopBotHalves = 0.012; // dead space between top and bottom halves
-const float NA6PVerTelSegmentation::DeadXTile = 0.002; // dead space between tiles in X (apart from DeadXDataBackbone after each 3 tiles)
-const float NA6PVerTelSegmentation::DeadXDataBackbone = 0.006; // dead space between segments
-const float NA6PVerTelSegmentation::XSizeTot = 12.9996 + DeadXShort +  DeadXLong;// 13.5996;
+const float NA6PVerTelSegmentation::DeadTopBotHalves = 0.012;                    // dead space between top and bottom halves
+const float NA6PVerTelSegmentation::DeadXTile = 0.002;                           // dead space between tiles in X (apart from DeadXDataBackbone after each 3 tiles)
+const float NA6PVerTelSegmentation::DeadXDataBackbone = 0.006;                   // dead space between segments
+const float NA6PVerTelSegmentation::XSizeTot = 12.9996 + DeadXShort + DeadXLong; // 13.5996;
 const float NA6PVerTelSegmentation::YSizeTot = 13.5898 + DeadYBottom + DeadYTop; // 13.6948; // readout side
-const int   NA6PVerTelSegmentation::NXTiles = 36;
-const int   NA6PVerTelSegmentation::NXSegments = 12; // group of 3 tiles
-const int   NA6PVerTelSegmentation::NYSensors = 7;
+const int NA6PVerTelSegmentation::NXTiles = 36;
+const int NA6PVerTelSegmentation::NXSegments = 12; // group of 3 tiles
+const int NA6PVerTelSegmentation::NYSensors = 7;
 const float NA6PVerTelSegmentation::DYSens = YSizeTot / NYSensors;
 const float NA6PVerTelSegmentation::DXSegment = (XSizeTot - DeadXShort - DeadXLong) / NXSegments;
 const float NA6PVerTelSegmentation::DXTile = (DXSegment - DeadXDataBackbone) / 3;
@@ -22,40 +22,46 @@ const float NA6PVerTelSegmentation::DXTile = (DXSegment - DeadXDataBackbone) / 3
 int NA6PVerTelSegmentation::isInAcc(float x, float y) const
 {
 
-  float absOffX = std::abs(mOffsX) - mInterChipGap/2;
-  float absOffY = std::abs(mOffsY) - mInterChipGap/2;
-  if ( (x < -absOffX && y < absOffY) ||
-       (x > -absOffX && y < -absOffY) ) {
+  float absOffX = std::abs(mOffsX) - mInterChipGap / 2;
+  float absOffY = std::abs(mOffsY) - mInterChipGap / 2;
+  if ((x < -absOffX && y < absOffY) ||
+      (x > -absOffX && y < -absOffY)) {
     x = -x;
     y = -y;
   }
-  
+
   x -= mOffsX;
   if (x < 0.) {
-    y += mOffsY - mInterChipGap/2;
-    x += XSizeTot + mInterChipGap/2; // relate to chip local left/bottom corner
-  } else {    
-    y -= mOffsY + mInterChipGap/2;
+    y += mOffsY - mInterChipGap / 2;
+    x += XSizeTot + mInterChipGap / 2; // relate to chip local left/bottom corner
+  } else {
+    y -= mOffsY + mInterChipGap / 2;
     y = YSizeTot - y;
-    x = (XSizeTot + mInterChipGap/2) - x; // relate to chip local left/bottom corner
+    x = (XSizeTot + mInterChipGap / 2) - x; // relate to chip local left/bottom corner
   }
 
-  if (x < 0 || x > XSizeTot || y < 0 || y > YSizeTot) return 0;
-  
-  if (x < DeadXLong || x > XSizeTot - DeadXShort || y < DeadYBottom || y > YSizeTot - DeadYTop) return -1;
+  if (x < 0 || x > XSizeTot || y < 0 || y > YSizeTot)
+    return 0;
+
+  if (x < DeadXLong || x > XSizeTot - DeadXShort || y < DeadYBottom || y > YSizeTot - DeadYTop)
+    return -1;
   x -= DeadXLong;
   int sens = int(y / DYSens);
   y -= sens * DYSens;
-  if (y < DeadYBottom || y > DYSens - DeadYTop) return -1;
+  if (y < DeadYBottom || y > DYSens - DeadYTop)
+    return -1;
   int topbot = int(y / (DYSens / 2));
   y -= topbot * (DYSens / 2);
-  if (y < DeadTopBotHalves / 2) return -1;
+  if (y < DeadTopBotHalves / 2)
+    return -1;
   int segm = int(x / DXSegment);
   x -= segm * DXSegment;
-  if (x > DXSegment - DeadXDataBackbone) return -1;
+  if (x > DXSegment - DeadXDataBackbone)
+    return -1;
   int tile = int(x / DXTile);
   x -= tile * DXTile;
-  if (x < DeadXTile) return -1;
+  if (x < DeadXTile)
+    return -1;
 
   return 1;
 }

--- a/sim/src/simLinkDef.h
+++ b/sim/src/simLinkDef.h
@@ -18,6 +18,9 @@
 #pragma link C++ class NA6PVerTelHit + ;
 #pragma link C++ class std::vector < NA6PVerTelHit> + ;
 
+#pragma link C++ class NA6PVerTelSegmentation + ;
+#pragma link C++ class std::vector < NA6PVerTelSegmentation> + ;
+
 #pragma link C++ class NA6PMuonSpecHit + ;
 #pragma link C++ class std::vector < NA6PMuonSpecHit> + ;
 


### PR DESCRIPTION
Hi,
with this PR, I ported the isInAcc method of KMCPixelPlane of the fast simulation into a new class NA6PVerTelSegmentation that in the next future can also manage the conversion of hit coordinate into indices of fired pixels, acting as an helper in the digitization of the VT.
For the time being, the method isInAcc can be used in the fast conversion of hits to clusters in order to discard the hits in the inactive regions of the VT plane.

The usage is simple, having a hit with coordinates xhit and yhit:
  NA6PVerTelSegmentation vt;
  int accOk = vt.isInAcc(xhit, yhit);
  if (accOk == 1) {
    // this is a good hit, to be accepted

Here are some plots showing the results for random generation of hits over one plane :
<img width="958" height="936" alt="VertTelPlane" src="https://github.com/user-attachments/assets/ac5ca188-bc99-4b87-b02f-ca1f8a42bb93" />

<img width="958" height="936" alt="VertTelPlaneZoom" src="https://github.com/user-attachments/assets/6fa567ce-d80b-40b4-a608-0e76070becc3" />

As compared to the implementation in the fast simulation, I added a selection to tag as out of acceptance the hits in the zone between the top half sensor unit and the bottom half sensor unit:
  if (y < DeadYBottom || y > DYSens - DeadYTop) return -1;
  int topbot = int(y / (DYSens / 2));
  y -= topbot * (DYSens / 2);
  if (y < DeadTopBotHalves / 2) return -1;
Let me know if this is correct.

Once this method is validated, I will add a call in the conversions of hits to recpoints.

