### PR TITLE
Vertex Telescope digitization 

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -22,6 +22,7 @@ set(DICTIONARY_HEADERS
   MagneticField.h
   NA6PBeamParam.h
   NA6PBeam.h
+  NA6PGeometryManager.h
   ) # Add all class headers requiring dictionary
   
 set(DICTIONARY_LINKDEF ${THIS_SRC_DIR}/${MOD_NAME}LinkDef.h)

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -23,6 +23,8 @@ set(DICTIONARY_HEADERS
   NA6PBeamParam.h
   NA6PBeam.h
   NA6PGeometryManager.h
+  NA6PMCComposedLabel.h
+  NA6PMCTruthContainer.h
   ) # Add all class headers requiring dictionary
   
 set(DICTIONARY_LINKDEF ${THIS_SRC_DIR}/${MOD_NAME}LinkDef.h)

--- a/base/include/NA6PGeometryManager.h
+++ b/base/include/NA6PGeometryManager.h
@@ -1,0 +1,54 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_GEOMETRY_MANAGER_H
+#define NA6P_GEOMETRY_MANAGER_H
+
+#include <Rtypes.h>
+#include <TGeoMatrix.h>
+
+class TFile;
+class TGeoVolume;
+
+// helper class to interface to the geometry (martices, sizes) of sensors
+
+class NA6PGeometryManager
+{
+ public:
+  static constexpr int kNVTModulesPerLayer = 4;
+
+  NA6PGeometryManager() = default;
+  ~NA6PGeometryManager() = default;
+
+  bool loadGeometry(const char* filename = "geometry.root", const char* geoname = "NA6P");
+  bool isGeometryLoaded() const { return mGeoLoaded; }
+
+  const TGeoHMatrix& getMatrix(int jMod) const { return mMatrices[jMod]; }
+  float getModuleHalfX(int jMod) const { return mModuleHalfX[jMod]; }
+  float getModuleHalfY(int jMod) const { return mModuleHalfY[jMod]; }
+  float getModuleFullX(int jMod) const { return mModuleHalfX[jMod] * 2.0f; }
+  float getModuleFullY(int jMod) const { return mModuleHalfY[jMod] * 2.0f; }
+
+ private:
+  bool fillModuleSize(int jMod, TGeoVolume* vol);
+
+ protected:
+  std::vector<TGeoHMatrix> mMatrices{}; ///< local-to-global transforms
+  std::vector<float> mModuleHalfX;      ///< Module half length along x
+  std::vector<float> mModuleHalfY;      ///< Module half length along y
+  bool mGeoLoaded{false};               ///< flag for successful load of geo
+  ClassDefNV(NA6PGeometryManager, 1);
+};
+
+#endif

--- a/base/include/NA6PMCComposedLabel.h
+++ b/base/include/NA6PMCComposedLabel.h
@@ -1,0 +1,152 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_MCCOMPOSEDLABEL_H
+#define NA6P_MCCOMPOSEDLABEL_H
+
+#include <Rtypes.h>
+#include <string>
+
+// Composed Label to encode MC track id, event it comes from and the source (file)
+// Ported from ALICEO2
+
+
+class NA6PMCComposedLabel
+{
+ private:
+  static constexpr uint64_t ul0x1 = 0x1;
+  static constexpr uint64_t NotSet = 0xffffffffffffffff;
+  static constexpr uint64_t Noise = 0xfffffffffffffffe;
+  static constexpr uint64_t Fake = ul0x1 << 63;
+  static constexpr int NReservedBits = 1;
+
+  uint64_t mLabel = NotSet; ///< MC label encoding MCtrack ID and MCevent origin
+  
+ public:
+  // number of bits reserved for MC track ID, DON'T modify this, since the
+  // track ID might be negative
+  static constexpr int nbitsTrackID = 31; // number of bits reserved for MC track ID
+  static constexpr int nbitsEvID = 19;    // number of bits reserved for MC event ID
+  static constexpr int nbitsSrcID = 8;    // number of bits reserved for MC source ID
+  // the rest of the bits is reserved at the moment
+
+  // check if the fields are defined consistently
+  static_assert(nbitsTrackID + nbitsEvID + nbitsSrcID <= sizeof(uint64_t) * 8 - NReservedBits,
+                "Fields cannot be stored in 64 bits");
+  
+  // mask to extract MC track ID
+  static constexpr uint64_t maskTrackID = (ul0x1 << nbitsTrackID) - 1;
+  // mask to extract MC track ID
+  static constexpr uint64_t maskEvID = (ul0x1 << nbitsEvID) - 1;
+  // mask to extract MC track ID
+  static constexpr uint64_t maskSrcID = (ul0x1 << nbitsSrcID) - 1;
+  // mask for all used fields
+  static constexpr uint64_t maskFull = (ul0x1 << (nbitsTrackID + nbitsEvID + nbitsSrcID)) - 1;
+
+  // constructors
+  NA6PMCComposedLabel(int trackID, int evID, int srcID, bool fake = false) { set(trackID, evID, srcID, fake); }
+  NA6PMCComposedLabel(bool noise = false)
+  {
+    if (noise) {
+      mLabel = Noise;
+    } else {
+      mLabel = NotSet;
+    }
+  }
+  ~NA6PMCComposedLabel() = default;
+
+  void set(unsigned int trackID, int evID, int srcID, bool fake)
+  {
+    /// compose label: the track 1st cast to UInt32_t to preserve the sign!
+    mLabel = (maskTrackID & static_cast<uint64_t>(trackID)) |
+             (maskEvID & static_cast<uint64_t>(evID)) << nbitsTrackID |
+             (maskSrcID & static_cast<uint64_t>(srcID)) << (nbitsTrackID + nbitsEvID);
+    if (fake) {
+      setFakeFlag();
+    }
+  }
+
+  void unset() { mLabel = NotSet; }
+  void setNoise() { mLabel = Noise; }
+  void setFakeFlag(bool v = true)
+  {
+    if (v) {
+      mLabel |= Fake;
+    } else {
+      mLabel &= ~Fake;
+    }
+  }
+
+  // check if label was assigned
+  bool isSet() const { return mLabel != NotSet; }
+  // check if label was not assigned
+  bool isEmpty() const { return mLabel == NotSet; }
+  // check if label comes from QED contrib
+  bool isQED() const { return getSourceID() == 99; }
+  // check if label corresponds to real particle (for the moment QED is not included)
+  bool isNoise() const { return mLabel == Noise || isQED(); }
+  // check if label was assigned as for correctly identified particle
+  bool isValid() const { return isSet() && !isNoise(); }
+
+  // check if label was assigned as for incorrectly identified particle or not set or noise
+  bool isFake() const { return mLabel & Fake; }
+  // check if label was assigned as for correctly identified particle
+  bool isCorrect() const { return !isFake(); }
+
+  // return 1 if the tracks are the same and correctly identified
+  // 0 if the tracks are the same but at least one of them is fake
+  // -1 otherwhise
+  int compare(const NA6PMCComposedLabel& other) const
+  {
+    if (getEventID() != other.getEventID() || getSourceID() != other.getSourceID()) {
+      return -1;
+    }
+    int tr1 = getTrackID(), tr2 = other.getTrackID();
+    return (tr1 == tr2) ? ((isCorrect() && other.isCorrect()) ? 1 : 0) : -1;
+  }
+  // comparison operator, compares only label, not eventual weight or correctness info
+  bool operator==(const NA6PMCComposedLabel& other) const { return (mLabel & maskFull) == (other.mLabel & maskFull); }
+  bool operator!=(const NA6PMCComposedLabel& other) const { return (mLabel & maskFull) != (other.mLabel & maskFull); }
+  // relation operators needed for some sorting methods
+  bool operator<(const NA6PMCComposedLabel& other) const { return (mLabel & maskFull) < (other.mLabel & maskFull); }
+  bool operator>(const NA6PMCComposedLabel& other) const { return (mLabel & maskFull) > (other.mLabel & maskFull); }
+
+  // getters
+  int getTrackID() const { return static_cast<int>(mLabel & maskTrackID); }
+  int getTrackIDSigned() const { return isFake() ? -getTrackID() : getTrackID(); }
+  int getEventID() const { return (mLabel >> nbitsTrackID) & maskEvID; }
+  int getSourceID() const { return (mLabel >> (nbitsTrackID + nbitsEvID)) & maskSrcID; }
+  uint64_t getTrackEventSourceID() const { return static_cast<uint64_t>(mLabel & maskFull); }
+  void get(int& trackID, int& evID, int& srcID, bool& fake) const
+  {
+    /// parse label
+    trackID = getTrackID();
+    evID = getEventID();
+    srcID = getSourceID();
+    fake = isFake();
+  }
+  // allow to retrieve bare label
+  uint64_t getRawValue() const { return mLabel; }
+
+  static constexpr int maxSourceID() { return maskSrcID; }
+  static constexpr int maxEventID() { return maskEvID; }
+  static constexpr int maxTrackID() { return maskTrackID; }
+
+  void print() const;
+  std::string asString() const;
+  
+  ClassDefNV(NA6PMCComposedLabel, 1);
+};
+
+#endif

--- a/base/include/NA6PMCTruthContainer.h
+++ b/base/include/NA6PMCTruthContainer.h
@@ -1,0 +1,335 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2026 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_MCTRUTHCONTAINER_H
+#define NA6P_MCTRUTHCONTAINER_H
+
+#include "NA6PMCComposedLabel.h"
+#include <span>
+
+class NA6PMCTruthContainer
+{
+ private:
+  std::vector<uint32_t> mHeaderArray; // the header structure array serves as an index into the actual storage
+  std::vector<NA6PMCComposedLabel> mTruthArray;   // the buffer containing the actual truth information
+  std::vector<char> mStreamerData; // buffer used for streaming a flat raw buffer
+  
+  size_t getSize(uint32_t dataindex) const
+  {
+    // calculate size / number of labels from a difference in pointed indices
+    const auto size = (dataindex < getIndexedSize() - 1)
+      ? getMCTruthHeader(dataindex + 1) - getMCTruthHeader(dataindex)
+      : getNElements() - getMCTruthHeader(dataindex);
+    return size;
+  }
+
+ public:
+  // constructor
+  NA6PMCTruthContainer() = default;
+  // destructor
+  ~NA6PMCTruthContainer() = default;
+  // copy constructor
+  NA6PMCTruthContainer(const NA6PMCTruthContainer& other) = default;
+  // move constructor
+  NA6PMCTruthContainer(NA6PMCTruthContainer&& other) = default;
+  // construct from raw data
+  NA6PMCTruthContainer(std::vector<uint32_t>& header, std::vector<NA6PMCComposedLabel>& truthArray)
+  {
+    setFrom(header, truthArray);
+  }
+  // assignment operator
+  NA6PMCTruthContainer& operator=(const NA6PMCTruthContainer& other) = default;
+  // move assignment operator
+  NA6PMCTruthContainer& operator=(NA6PMCTruthContainer&& other) = default;
+
+  // Set container directly from header + truthArray.
+  void setFrom(std::vector<uint32_t>& header, std::vector<NA6PMCComposedLabel>& truthArray)
+  {
+    mHeaderArray = std::move(header);
+    mTruthArray = std::move(truthArray);
+  }
+
+  struct FlatHeader {
+    uint8_t version = 1;
+    uint8_t sizeofHeaderElement = sizeof(uint32_t);
+    uint8_t sizeofTruthElement = sizeof(NA6PMCComposedLabel);
+    uint8_t reserved = 0;
+    uint32_t nofHeaderElements;
+    uint32_t nofTruthElements;
+  };
+
+  // access
+  uint32_t getMCTruthHeader(uint32_t dataindex) const { return mHeaderArray[dataindex]; }
+  // access the element directly (can be encapsulated better away)... needs proper element index
+  // which can be obtained from the MCTruthHeader startposition and size
+  NA6PMCComposedLabel const& getElement(uint32_t elementindex) const { return mTruthArray[elementindex]; }
+  // return the number of original data indexed here
+  size_t getIndexedSize() const { return mHeaderArray.size(); }
+  // return the number of elements (labels) pointed to in this container
+  size_t getNElements() const { return mTruthArray.size(); }
+  // return unterlaying vector of elements
+  const std::vector<NA6PMCComposedLabel>& getTruthArray() const
+  {
+    return mTruthArray;
+  }
+
+  // get individual "view" container for a given data index
+  // the caller can do modifications on this view (such as sorting)
+  std::span<NA6PMCComposedLabel> getLabels(uint32_t dataindex)
+  {
+    if (dataindex >= getIndexedSize()) {
+      return std::span<NA6PMCComposedLabel>();
+    }
+    return std::span<NA6PMCComposedLabel>(&mTruthArray[getMCTruthHeader(dataindex)], getSize(dataindex));
+  }
+  
+  // get individual const "view" container for a given data index
+  // the caller can't do modifications on this view
+  std::span<const NA6PMCComposedLabel> getLabels(uint32_t dataindex) const
+  {
+    if (dataindex >= getIndexedSize()) {
+      return std::span<const NA6PMCComposedLabel>();
+    }
+    return std::span<const NA6PMCComposedLabel>(&mTruthArray[getMCTruthHeader(dataindex)], getSize(dataindex));
+  }
+
+  void clear()
+  {
+    mHeaderArray.clear();
+    mTruthArray.clear();
+  }
+  void clear_andfreememory()
+  {
+    clear();
+    // this forces the desctructor being called on existing buffers
+    mHeaderArray = std::vector<uint32_t>();
+    mTruthArray = std::vector<NA6PMCComposedLabel>();
+    mStreamerData = std::vector<char>();
+  }
+  // add element for a particular dataindex
+  // at the moment only strictly consecutive modes are supported
+  // noElement indicates that actually no label/element will be added for this dataindex
+  void addElement(uint32_t dataindex, NA6PMCComposedLabel const& element, bool noElement = false)
+  {
+    if (dataindex < mHeaderArray.size()) {
+      // look if we have something for this dataindex already
+      // must currently be the last one
+      // because mTruthArray is a sequential array and
+      // labels for a given data-index must occupy a contiguous block.
+      if (dataindex != (mHeaderArray.size() - 1)) {
+        throw std::runtime_error("NA6PMCTruthContainer: unsupported code path");
+      }
+    } else {
+      // add empty holes = how many data-indices were skipped (had zero labels)
+      // between the last one filled and this new one
+      int holes = dataindex - mHeaderArray.size();
+      assert(holes >= 0);
+      for (int i = 0; i < holes; ++i) {
+        // For each skipped index, a header entry is created, pointing to the end of mTruthArray 
+        mHeaderArray.emplace_back(mTruthArray.size());
+      }
+      // add the header entry for the new dataindex 
+      mHeaderArray.emplace_back(mTruthArray.size());
+    }
+    if (!noElement) {
+      // append the new label to the flat array 
+      mTruthArray.emplace_back(element);
+    }
+  }
+  /// adds a data index that has no label
+  void addNoLabelIndex(uint32_t dataindex)
+  {
+    addElement(dataindex, NA6PMCComposedLabel(), true);
+  }
+  // convenience interface to add multiple labels at once
+  void addElements(uint32_t dataindex, const std::vector<NA6PMCComposedLabel>& elements)
+  {
+    addNoLabelIndex(dataindex);
+    for (auto& e : elements) {
+      addElement(dataindex, e);
+    }
+  }
+  // Add element at last position or for a previous index
+  // (at random access position).
+  // This might be a slow process since data has to be moved internally
+  // so this function should be used with care.
+  void addElementRandomAccess(uint32_t dataindex, NA6PMCComposedLabel const& element)
+  {
+    if (dataindex > mHeaderArray.size()) {
+      throw std::runtime_error("NA6PMCTruthContainer: addElementRandomAccess does not support holes");
+    } else if (dataindex == mHeaderArray.size() ) {
+      // a new dataindex -> push element at back
+      mHeaderArray.resize(dataindex + 1);
+      mHeaderArray[dataindex] = mTruthArray.size();
+      mTruthArray.emplace_back(element);
+    } else if (dataindex == mHeaderArray.size() - 1) {
+      // if appending at end use fast function
+      addElement(dataindex, element);
+    } else {
+      // existing dataindex
+      // have to:
+      // a) move data;
+      // b) insert new element;
+      // c) adjust indices of all headers right to this
+      auto currentindex = mHeaderArray[dataindex];
+      auto lastindex = currentindex + getSize(dataindex);
+      // resize truth array
+      mTruthArray.resize(mTruthArray.size() + 1);
+      // move data (have to do from right to left)
+      for (size_t i = mTruthArray.size() - 1; i > lastindex; --i) {
+        mTruthArray[i] = mTruthArray[i - 1];
+      }
+      // insert new element
+      mTruthArray[lastindex] = element;
+
+      // fix headers
+      for (uint32_t i = dataindex + 1; i < mHeaderArray.size(); ++i) {
+        auto oldindex = mHeaderArray[i];
+        mHeaderArray[i] = (oldindex != (uint32_t)-1) ? oldindex + 1 : oldindex;
+      }
+    }
+  }
+
+  // merge another container to the back of this one
+  void mergeAtBack(NA6PMCTruthContainer const& other)
+  {
+    const auto oldtruthsize = mTruthArray.size();
+    const auto oldheadersize = mHeaderArray.size();
+
+    // copy from other
+    std::copy(other.mHeaderArray.begin(), other.mHeaderArray.end(), std::back_inserter(mHeaderArray));
+    std::copy(other.mTruthArray.begin(), other.mTruthArray.end(), std::back_inserter(mTruthArray));
+
+    // adjust information of newly attached part
+    for (uint32_t i = oldheadersize; i < mHeaderArray.size(); ++i) {
+      mHeaderArray[i] += oldtruthsize;
+    }
+  }
+
+  // merge part of another container ("n" entries starting from "from") to the back of this one
+  void mergeAtBack(NA6PMCTruthContainer const& other, size_t from, size_t n)
+  {
+    const auto oldtruthsize = mTruthArray.size();
+    const auto oldheadersize = mHeaderArray.size();
+    auto endIdx = from + n;
+    assert(endIdx <= other.mHeaderArray.size());
+    const auto* headBeg = &other.mHeaderArray[from];
+    const auto* headEnd = headBeg + n;
+    const auto* trtArrBeg = &other.mTruthArray[other.getMCTruthHeader(from)];
+    const auto* trtArrEnd = (endIdx == other.mHeaderArray.size()) ? (&other.mTruthArray.back()) + 1 : &other.mTruthArray[other.getMCTruthHeader(endIdx)];
+
+    // copy from other
+    std::copy(headBeg, headEnd, std::back_inserter(mHeaderArray));
+    std::copy(trtArrBeg, trtArrEnd, std::back_inserter(mTruthArray));
+    long offset = long(oldtruthsize) - other.getMCTruthHeader(from);
+    // adjust information of newly attached part
+    for (uint32_t i = oldheadersize; i < mHeaderArray.size(); ++i) {
+      mHeaderArray[i] += offset;
+    }
+  }
+  
+  /// Flatten the internal arrays to the provided container
+  /// Copies the content of the two vectors of PODs to a contiguous container.
+  /// The flattened data starts with a specific header @ref FlatHeader describing
+  /// size and content of the two vectors within the raw buffer.
+  size_t flatten_to(std::vector<char>& container) const
+  {
+    size_t bufferSize = sizeof(FlatHeader) + sizeof(uint32_t) * mHeaderArray.size() + sizeof(NA6PMCComposedLabel) * mTruthArray.size();
+    container.resize(bufferSize);
+    char* target = container.data();
+    auto& flatheader = *reinterpret_cast<FlatHeader*>(target);
+    target += sizeof(FlatHeader);
+    flatheader.version = 1;
+    flatheader.sizeofHeaderElement = sizeof(uint32_t);
+    flatheader.sizeofTruthElement = sizeof(NA6PMCComposedLabel);
+    flatheader.reserved = 0;
+    flatheader.nofHeaderElements = mHeaderArray.size();
+    flatheader.nofTruthElements = mTruthArray.size();
+    size_t copySize = flatheader.sizeofHeaderElement * flatheader.nofHeaderElements;
+    memcpy(target, mHeaderArray.data(), copySize);
+    target += copySize;
+    copySize = flatheader.sizeofTruthElement * flatheader.nofTruthElements;
+    memcpy(target, mTruthArray.data(), copySize);
+    return bufferSize;
+  }
+  
+  /// Restore internal vectors from a raw buffer
+  /// The two vectors are resized according to the information in the \a FlatHeader
+  /// struct at the beginning of the buffer. Data is copied to the vectors.
+  void restore_from(const char* buffer, size_t bufferSize)
+  {
+    if (buffer == nullptr || bufferSize < sizeof(FlatHeader)) {
+      return;
+    }
+    auto* source = buffer;
+    auto& flatheader = *reinterpret_cast<FlatHeader const*>(source);
+    source += sizeof(FlatHeader);
+    if (bufferSize < sizeof(FlatHeader) + flatheader.sizeofHeaderElement * flatheader.nofHeaderElements + flatheader.sizeofTruthElement * flatheader.nofTruthElements) {
+      throw std::runtime_error("inconsistent buffer size: too small");
+    }
+    if (flatheader.sizeofHeaderElement != sizeof(uint32_t) || flatheader.sizeofTruthElement != sizeof(NA6PMCComposedLabel)) {
+      // not yet handled
+      throw std::runtime_error("member element sizes don't match");
+    }
+    // TODO: with a spectator memory resource the vectors can be built directly
+    // over the original buffer, there is the implementation for a memory resource
+    // working on a FairMQ message, here we would need two memory resources over
+    // the two ranges of the input buffer
+    // for now doing a copy
+    mHeaderArray.resize(flatheader.nofHeaderElements);
+    mTruthArray.resize(flatheader.nofTruthElements);
+    size_t copySize = flatheader.sizeofHeaderElement * flatheader.nofHeaderElements;
+    memcpy(mHeaderArray.data(), source, copySize);
+    source += copySize;
+    copySize = flatheader.sizeofTruthElement * flatheader.nofTruthElements;
+    memcpy(mTruthArray.data(), source, copySize);
+  }
+  
+  /// Inflate the object from the internal buffer
+  /// The class has a specific member to store flattened data. Due to some limitations in ROOT
+  /// it is more efficient to first flatten the objects to a raw buffer and empty the two vectors
+  /// before serialization. This function restores the vectors from the internal raw buffer.
+  /// Called from the custom streamer.
+  void inflate()
+  {
+    if (mHeaderArray.size() > 0) {
+      mStreamerData.clear();
+      return;
+    }
+    restore_from(mStreamerData.data(), mStreamerData.size());
+    mStreamerData.clear();
+  }
+
+  /// Deflate the object to the internal buffer
+  /// The class has a specific member to store flattened data. Due to some limitations in ROOT
+  /// it is more efficient to first flatten the objects to a raw buffer and empty the two vectors
+  /// before serialization. This function stores the vectors to the internal raw buffer.
+  /// Called from the custom streamer.
+  void deflate()
+  {
+    if (mStreamerData.size() > 0) {
+      clear();
+      return;
+    }
+    mStreamerData.clear();
+    flatten_to(mStreamerData);
+    clear();
+  }
+  
+  void print() const;
+  std::string asString() const;
+  
+  ClassDefNV(NA6PMCTruthContainer, 1);
+};
+#endif

--- a/base/src/NA6PGeometryManager.cxx
+++ b/base/src/NA6PGeometryManager.cxx
@@ -1,3 +1,5 @@
+// NA6PCCopyright
+
 #include <fairlogger/Logger.h>
 #include <TGeoNode.h>
 #include <TGeoPhysicalNode.h>

--- a/base/src/NA6PGeometryManager.cxx
+++ b/base/src/NA6PGeometryManager.cxx
@@ -1,0 +1,125 @@
+#include <fairlogger/Logger.h>
+#include <TGeoNode.h>
+#include <TGeoPhysicalNode.h>
+#include <TGeoBBox.h>
+#include <TGeoManager.h>
+#include <TFile.h>
+#include "NA6PLayoutParam.h"
+#include "NA6PGeometryManager.h"
+
+bool NA6PGeometryManager::loadGeometry(const char* filename, const char* geoname)
+{
+  if (mGeoLoaded)
+    return true;
+
+  if (!gGeoManager) {
+    TFile* f = TFile::Open(filename);
+    if (!f || f->IsZombie()) {
+      LOGP(error, "Cannot open geometry file {}", filename);
+      return false;
+    }
+    gGeoManager = (TGeoManager*)f->Get(geoname);
+    if (!gGeoManager) {
+      LOGP(error, "No geometry with name {} found in file {}", geoname, filename);
+      f->Close();
+      return false;
+    }
+    f->Close();
+  }
+
+  int nAlignMod = gGeoManager->GetNAlignable();
+  std::vector<bool> isMatrixLoaded;
+  bool doIter = false;
+  if (nAlignMod == 0) {
+    LOGP(info, "No alignable volumes in the geometry, resort to volume names for Vertex Telescope");
+    const auto& param = NA6PLayoutParam::Instance();
+    nAlignMod = param.nVerTelPlanes * kNVTModulesPerLayer;
+    doIter = true;
+  } else {
+    LOGP(info, "Load geometry info for {} alignable volumes", nAlignMod);
+  }
+  isMatrixLoaded.assign(nAlignMod, false);
+  mMatrices.resize(nAlignMod);
+  mModuleHalfX.assign(nAlignMod, 0.);
+  mModuleHalfY.assign(nAlignMod, 0.);
+
+  if (doIter) {
+    TGeoIterator next(gGeoManager->GetTopVolume());
+    TGeoNode* node = nullptr;
+    while ((node = next())) {
+      TString name = node->GetName();
+      if (name.BeginsWith("PixelSensor_")) {
+        Int_t currentLevel = next.GetLevel();
+        if (currentLevel <= 0)
+          continue;
+        TGeoNode* motherNode = next.GetNode(currentLevel - 1);
+        int layer = motherNode->GetNumber() % 10;
+        int modNum = node->GetNumber() % 10;
+        int modIndex = kNVTModulesPerLayer * layer + modNum;
+        if (modIndex < 0 || modIndex >= nAlignMod) {
+          LOGP(error, "Wrong module index {} (layer={}, modNum={})", modIndex, layer, modNum);
+          continue;
+        }
+        mMatrices[modIndex] = *(next.GetCurrentMatrix());
+        bool sizeOk = fillModuleSize(modIndex, node->GetVolume());
+        if (!sizeOk)
+          continue;
+        isMatrixLoaded[modIndex] = true;
+      }
+    }
+  } else {
+    for (int jMod = 0; jMod < nAlignMod; ++jMod) {
+      TGeoPNEntry* entry = gGeoManager->GetAlignableEntry(jMod);
+      if (!entry)
+        continue;
+      if (entry->GetGlobalOrig()) {
+        mMatrices[jMod] = *(entry->GetGlobalOrig());
+      } else {
+        LOGP(error, "Module {} has a null global matrix", jMod);
+        continue;
+      }
+      const char* path = entry->GetPath();
+      if (!gGeoManager->cd(path)) {
+        LOGP(error, "Failed to navigate to geometry path: {}", path);
+        continue;
+      }
+      bool sizeOk = fillModuleSize(jMod, gGeoManager->GetCurrentVolume());
+      if (!sizeOk)
+        continue;
+      isMatrixLoaded[jMod] = true;
+    }
+  }
+  mGeoLoaded = true;
+  for (int jMod = 0; jMod < nAlignMod; ++jMod) {
+    if (!isMatrixLoaded[jMod]) {
+      LOGP(error, "Matrix not loaded for module {}", jMod);
+      mGeoLoaded = false;
+    } else {
+      LOGP(info, "Module {} Txyz {} {} {} size {} {}",
+           jMod, mMatrices[jMod].GetTranslation()[0], mMatrices[jMod].GetTranslation()[1], mMatrices[jMod].GetTranslation()[2],
+           mModuleHalfX[jMod] * 2, mModuleHalfY[jMod] * 2);
+    }
+  }
+  return mGeoLoaded;
+}
+
+bool NA6PGeometryManager::fillModuleSize(int jMod, TGeoVolume* vol)
+{
+  if (!vol) {
+    LOGP(error, "Null pointer to volume");
+    return false;
+  }
+  TGeoShape* shape = vol->GetShape();
+  if (!shape) {
+    LOGP(error, "Null pointer to shape");
+    return false;
+  }
+  if (shape->IsA() != TGeoBBox::Class()) {
+    LOGP(error, "Module shape is not a TGeoBBox");
+    return false;
+  }
+  TGeoBBox* box = static_cast<TGeoBBox*>(shape);
+  mModuleHalfX[jMod] = static_cast<float>(box->GetDX());
+  mModuleHalfY[jMod] = static_cast<float>(box->GetDY());
+  return true;
+}

--- a/base/src/NA6PMCComposedLabel.cxx
+++ b/base/src/NA6PMCComposedLabel.cxx
@@ -1,0 +1,20 @@
+// NA6PCCopyright
+
+#include <fmt/format.h>
+#include <fairlogger/Logger.h>
+#include "NA6PMCComposedLabel.h"
+
+//_____________________________________________
+std::string NA6PMCComposedLabel::asString() const
+{
+  if (isValid()) {
+    return fmt::format("[sourceID:{}/eventID:{}/fake:{}/trackID:{:6d}]", getSourceID(), getEventID(), isFake() ? 'Y' : 'N', getTrackID());
+  }
+  return isNoise() ? "[noise]" : "[unset]";
+}
+
+//_____________________________________________
+void NA6PMCComposedLabel::print() const
+{
+  LOGP(info, "{}", asString());
+}

--- a/base/src/NA6PMCTruthContainer.cxx
+++ b/base/src/NA6PMCTruthContainer.cxx
@@ -1,0 +1,29 @@
+#include <fmt/format.h>
+#include <fairlogger/Logger.h>
+#include <TBuffer.h>
+#include "NA6PMCTruthContainer.h"
+
+//_____________________________________________
+std::string NA6PMCTruthContainer::asString() const
+{
+  return fmt::format("NA6PMCTruthContainer index = {} for {} elements(s), flat buffer size {}", getIndexedSize(), getNElements(), mStreamerData.size());
+}
+
+//_____________________________________________
+void NA6PMCTruthContainer::print() const
+{
+  LOGP(info, "{}", asString());
+}
+
+//_____________________________________________
+void NA6PMCTruthContainer::Streamer(TBuffer& R__b)
+{
+  if (R__b.IsReading()) {
+    R__b.ReadClassBuffer(NA6PMCTruthContainer::Class(), this);
+    inflate();
+  } else {
+    deflate();
+    R__b.WriteClassBuffer(NA6PMCTruthContainer::Class(), this);
+    inflate();
+  }
+}

--- a/base/src/baseLinkDef.h
+++ b/base/src/baseLinkDef.h
@@ -15,5 +15,6 @@
 #pragma link C++ class na6p::conf::ConfigurableParamHelper < NA6PBeamParam> + ;
 
 #pragma link C++ class NA6PBeam + ;
+#pragma link C++ class NA6PGeometryManager + ;
 
 #endif

--- a/base/src/baseLinkDef.h
+++ b/base/src/baseLinkDef.h
@@ -16,5 +16,7 @@
 
 #pragma link C++ class NA6PBeam + ;
 #pragma link C++ class NA6PGeometryManager + ;
+#pragma link C++ class NA6PMCComposedLabel + ;
+#pragma link C++ class NA6PMCTruthContainer-;
 
 #endif

--- a/rec/include/NA6PVerTelReconstruction.h
+++ b/rec/include/NA6PVerTelReconstruction.h
@@ -49,6 +49,7 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   void closeClustersOutput() override;
   // fast method to smear the hits bypassing digitization and cluster finder
   void setClusterSpaceResolution(double clures) { mCluRes = clures; }
+  void setEmulateNoGaps(bool val = true) { mEmulateNoGaps = val; }
   void hitsToRecPoints(const std::vector<NA6PVerTelHit>& hits);
   NA6PTrackerCA* getTracker() const { return mVTTracker; }
 
@@ -72,6 +73,7 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   TFile* mClusFile = nullptr;                                       // file with clusters
   TTree* mClusTree = nullptr;                                       // tree of clusters
   double mCluRes = 5.e-4;                                           // cluster resolution, cm (for fast simu)
+  bool mEmulateNoGaps = false;                                      // enable sensor acceptance overlaps in hitsToRecPoints
   std::vector<NA6PVertex> mVertices, *hVerticesPtr = &mVertices;    // vector of vertices
   TFile* mVertexFile = nullptr;                                     // file with vertices
   TTree* mVertexTree = nullptr;                                     // tree of vertices

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -5,6 +5,8 @@
 #include <TRandom3.h>
 #include <fairlogger/Logger.h>
 #include "NA6PVerTelHit.h"
+#include "NA6PVerTelSegmentation.h"
+#include "NA6PVerTelDigitizer.h"
 #include "NA6PTrackerCA.h"
 #include "NA6PVertexerTracklets.h"
 #include "NA6PVerTelReconstruction.h"
@@ -104,11 +106,21 @@ void NA6PVerTelReconstruction::setClusters(std::vector<NA6PVerTelCluster>& clust
 void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>& hits)
 {
   int nHits = hits.size();
+  NA6PVerTelSegmentation vt;
+  if (mEmulateNoGaps)
+    vt.setStaggered(true);
+  NA6PVerTelDigitizer dig;
+  dig.initGeometry();
+
   for (int jHit = 0; jHit < nHits; ++jHit) {
     const auto& hit = hits[jHit];
     double x = hit.getX();
     double y = hit.getY();
     double z = hit.getZ();
+    double xyzLocS[3], xyzLocE[3];
+    dig.getHitLocalCoord(hit, xyzLocS, xyzLocE);
+    if (vt.isInAcc(xyzLocS[0], xyzLocS[1]) != 1)
+      continue;
     double ex2clu = 5.e-4;
     double ey2clu = 5.e-4;
     if (mCluRes > 0) {

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -33,6 +33,7 @@ set(DICTIONARY_HEADERS
   NA6PGenCocktail.h
   NA6PBaseHit.h
   NA6PVerTelHit.h
+  NA6PVerTelDigit.h
   NA6PVerTelDigitizer.h
   NA6PVerTelSegmentation.h
   NA6PVerTelPreDigitContainer.h

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -33,7 +33,9 @@ set(DICTIONARY_HEADERS
   NA6PGenCocktail.h
   NA6PBaseHit.h
   NA6PVerTelHit.h
+  NA6PVerTelDigitizer.h
   NA6PVerTelSegmentation.h
+  NA6PVerTelPreDigitContainer.h
   NA6PMuonSpecHit.h
   NA6PMuonSpecModularHit.h
   GenMUONLMR.h

--- a/sim/include/NA6PVerTelDigit.h
+++ b/sim/include/NA6PVerTelDigit.h
@@ -18,6 +18,10 @@
 #include <Rtypes.h>
 
 // object for VT digits
+// NOTE: VTPixID uses C++ bit fields which ROOT cannot stream correctly.
+// Do not access mPixID branches directly via TTree::Scan() or TTree::Draw().
+// Always use the getters (getRSU(), getTile(), getRow(), getCol())
+// to access pixel indices.
 
 struct VTPixID {
 
@@ -59,30 +63,31 @@ class NA6PVerTelDigit
 {
  public:
   NA6PVerTelDigit() = default;
-  NA6PVerTelDigit(UShort_t detID, UShort_t rsu, UShort_t tile,
-                  UShort_t row, UShort_t col, int pid = -1);
+  NA6PVerTelDigit(uint16_t detID, const VTPixID& id, int pid = -1);
+  NA6PVerTelDigit(uint16_t detID, uint32_t rsu, uint32_t tile,
+                  uint32_t row, uint32_t col, int pid = -1);
 
-  UShort_t getDetectorID() const { return mDetectorID; }
+  uint16_t getDetectorID() const { return mDetectorID; }
   const VTPixID& getPixID() const { return mPixID; }
-  UShort_t getRSU() const { return mPixID.rsu; }
-  UShort_t getTile() const { return mPixID.tile; }
-  UShort_t getRow() const { return mPixID.row; }
-  UShort_t getCol() const { return mPixID.col; }
+  uint32_t getRSU() const { return mPixID.rsu; }
+  uint32_t getTile() const { return mPixID.tile; }
+  uint32_t getRow() const { return mPixID.row; }
+  uint32_t getCol() const { return mPixID.col; }
   int getParticleID() const { return mParticleID; }
 
-  void setDetectorID(int id) { mDetectorID = id; }
+  void setDetectorID(uint16_t id) { mDetectorID = id; }
   void setPixID(const VTPixID& id) { mPixID = id; }
-  void setRSU(int id) { mPixID.rsu = id; }
-  void setTile(int id) { mPixID.tile = id; }
-  void setRow(int id) { mPixID.row = id; }
-  void setCol(int id) { mPixID.col = id; }
+  void setRSU(uint32_t id) { mPixID.rsu = id; }
+  void setTile(uint32_t id) { mPixID.tile = id; }
+  void setRow(uint32_t id) { mPixID.row = id; }
+  void setCol(uint32_t id) { mPixID.col = id; }
   void setParticleID(int id) { mParticleID = id; }
 
   void print() const;
   std::string asString() const;
 
  protected:
-  UShort_t mDetectorID = 0; // the detector/sensor id
+  uint16_t mDetectorID = 0; // the detector/sensor id
   VTPixID mPixID;           // pixel identifier
   int mParticleID = -1;     // Particle ID
 

--- a/sim/include/NA6PVerTelDigit.h
+++ b/sim/include/NA6PVerTelDigit.h
@@ -63,9 +63,9 @@ class NA6PVerTelDigit
 {
  public:
   NA6PVerTelDigit() = default;
-  NA6PVerTelDigit(uint16_t detID, const VTPixID& id, int pid = -1);
+  NA6PVerTelDigit(uint16_t detID, const VTPixID& id);
   NA6PVerTelDigit(uint16_t detID, uint32_t rsu, uint32_t tile,
-                  uint32_t row, uint32_t col, int pid = -1);
+                  uint32_t row, uint32_t col);
 
   uint16_t getDetectorID() const { return mDetectorID; }
   const VTPixID& getPixID() const { return mPixID; }
@@ -73,7 +73,6 @@ class NA6PVerTelDigit
   uint32_t getTile() const { return mPixID.tile; }
   uint32_t getRow() const { return mPixID.row; }
   uint32_t getCol() const { return mPixID.col; }
-  int getParticleID() const { return mParticleID; }
 
   void setDetectorID(uint16_t id) { mDetectorID = id; }
   void setPixID(const VTPixID& id) { mPixID = id; }
@@ -81,7 +80,6 @@ class NA6PVerTelDigit
   void setTile(uint32_t id) { mPixID.tile = id; }
   void setRow(uint32_t id) { mPixID.row = id; }
   void setCol(uint32_t id) { mPixID.col = id; }
-  void setParticleID(int id) { mParticleID = id; }
 
   void print() const;
   std::string asString() const;
@@ -89,7 +87,6 @@ class NA6PVerTelDigit
  protected:
   uint16_t mDetectorID = 0; // the detector/sensor id
   VTPixID mPixID;           // pixel identifier
-  int mParticleID = -1;     // Particle ID
 
   ClassDefNV(NA6PVerTelDigit, 1);
 };

--- a/sim/include/NA6PVerTelDigit.h
+++ b/sim/include/NA6PVerTelDigit.h
@@ -1,0 +1,92 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_VERTEL_DIGIT_H
+#define NA6P_VERTEL_DIGIT_H
+
+#include <Rtypes.h>
+
+// object for VT digits
+
+struct VTPixID {
+
+  static constexpr int kColBits = 10; // 0-161,  max 1023
+  static constexpr int kRowBits = 10; // 0-459,  max 1023
+  static constexpr int kTileBits = 4; // 0-11,   max 15
+  static constexpr int kRsuBits = 6;  // 0-41,   max 63
+
+  static_assert(kColBits + kRowBits + kTileBits + kRsuBits == 30,
+                "VTPixID fields must fit in 32 bits");
+
+  uint32_t col : kColBits = 0;
+  uint32_t row : kRowBits = 0;
+  uint32_t tile : kTileBits = 0;
+  uint32_t rsu : kRsuBits = 0;
+
+  uint32_t pack() const
+  {
+    return uint32_t(col) |
+           (uint32_t(row) << kColBits) |
+           (uint32_t(tile) << (kColBits + kRowBits)) |
+           (uint32_t(rsu) << (kColBits + kRowBits + kTileBits));
+  }
+
+  static VTPixID unpack(uint32_t val)
+  {
+    VTPixID id;
+    id.col = val & ((1 << kColBits) - 1);
+    id.row = (val >> kColBits) & ((1 << kRowBits) - 1);
+    id.tile = (val >> (kColBits + kRowBits)) & ((1 << kTileBits) - 1);
+    id.rsu = (val >> (kColBits + kRowBits + kTileBits)) & ((1 << kRsuBits) - 1);
+    return id;
+  }
+
+  ClassDefNV(VTPixID, 1);
+};
+
+class NA6PVerTelDigit
+{
+ public:
+  NA6PVerTelDigit() = default;
+  NA6PVerTelDigit(UShort_t detID, UShort_t rsu, UShort_t tile,
+                  UShort_t row, UShort_t col, int pid = -1);
+
+  UShort_t getDetectorID() const { return mDetectorID; }
+  const VTPixID& getPixID() const { return mPixID; }
+  UShort_t getRSU() const { return mPixID.rsu; }
+  UShort_t getTile() const { return mPixID.tile; }
+  UShort_t getRow() const { return mPixID.row; }
+  UShort_t getCol() const { return mPixID.col; }
+  int getParticleID() const { return mParticleID; }
+
+  void setDetectorID(int id) { mDetectorID = id; }
+  void setPixID(const VTPixID& id) { mPixID = id; }
+  void setRSU(int id) { mPixID.rsu = id; }
+  void setTile(int id) { mPixID.tile = id; }
+  void setRow(int id) { mPixID.row = id; }
+  void setCol(int id) { mPixID.col = id; }
+  void setParticleID(int id) { mParticleID = id; }
+
+  void print() const;
+  std::string asString() const;
+
+ protected:
+  UShort_t mDetectorID = 0; // the detector/sensor id
+  VTPixID mPixID;           // pixel identifier
+  int mParticleID = -1;     // Particle ID
+
+  ClassDefNV(NA6PVerTelDigit, 1);
+};
+
+#endif

--- a/sim/include/NA6PVerTelDigit.h
+++ b/sim/include/NA6PVerTelDigit.h
@@ -25,8 +25,8 @@
 
 struct VTPixID {
 
-  static constexpr int kColBits = 10; // 0-161,  max 1023
-  static constexpr int kRowBits = 10; // 0-459,  max 1023
+  static constexpr int kColBits = 10; // 0-155,  max 1023
+  static constexpr int kRowBits = 10; // 0-443,  max 1023
   static constexpr int kTileBits = 4; // 0-11,   max 15
   static constexpr int kRsuBits = 6;  // 0-41,   max 63
 

--- a/sim/include/NA6PVerTelDigitizer.h
+++ b/sim/include/NA6PVerTelDigitizer.h
@@ -46,7 +46,7 @@ class NA6PVerTelDigitizer
 
   void init(const char* filename = "geometry.root", const char* geoname = "NA6P");
   void process(const std::vector<NA6PVerTelHit>& hits, int layer = -1);
-  void processHit(NA6PVerTelHit hit);
+  void processHit(const NA6PVerTelHit& hit);
   void finalizeDigits();
 
   size_t getNDigits() const { return mDigits.size(); }
@@ -60,7 +60,7 @@ class NA6PVerTelDigitizer
   }
   const auto& getDigits() const { return mDigits; }
 
-  void getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3], double xyzLocE[3]);
+  void getHitLocalCoord(const NA6PVerTelHit& hit, double xyzLocS[3], double xyzLocE[3]);
 
   void SetThreshold(int modID, float thr)
   {

--- a/sim/include/NA6PVerTelDigitizer.h
+++ b/sim/include/NA6PVerTelDigitizer.h
@@ -74,7 +74,7 @@ class NA6PVerTelDigitizer
   std::vector<TGeoHMatrix> mMatrices{};              ///< local-to-global transforms
   std::vector<float> mModuleHalfX;                   ///< Module half length along x
   std::vector<float> mModuleHalfY;                   ///< Module half length along y
-  std::vector<float> mThresholds;                    ///< Module threshold
+  std::vector<float> mThresholds;                    ///< Threshold (per tile)
   std::vector<NA6PVerTelDigit> mDigits, *hDigitsPtr = &mDigits;
   TFile* mDigitsFile = nullptr;
   TTree* mDigitsTree = nullptr;

--- a/sim/include/NA6PVerTelDigitizer.h
+++ b/sim/include/NA6PVerTelDigitizer.h
@@ -19,6 +19,7 @@
 #include "NA6PVerTelDigit.h"
 #include "NA6PVerTelSegmentation.h"
 #include "NA6PGeometryManager.h"
+#include "NA6PMCTruthContainer.h"
 #include <Rtypes.h>
 #include <TGeoMatrix.h>
 
@@ -52,7 +53,11 @@ class NA6PVerTelDigitizer
   void createDigitsOutput();
   void closeDigitsOutput();
   void writeDigits();
-  void clearDigits() { mDigits.clear(); }
+  void clearDigits()
+  {
+    mDigits.clear();
+    mMCLabels.clear_andfreememory();
+  }
   const auto& getDigits() const { return mDigits; }
 
   void getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3], double xyzLocE[3]);
@@ -74,6 +79,7 @@ class NA6PVerTelDigitizer
   NA6PGeometryManager mGeoManager;                   ///< geometry manager
   std::vector<float> mThresholds;                    ///< Threshold (per tile)
   std::vector<NA6PVerTelDigit> mDigits, *hDigitsPtr = &mDigits;
+  NA6PMCTruthContainer mMCLabels, *hMCLabelsPtr = &mMCLabels;
   TFile* mDigitsFile = nullptr;
   TTree* mDigitsTree = nullptr;
 

--- a/sim/include/NA6PVerTelDigitizer.h
+++ b/sim/include/NA6PVerTelDigitizer.h
@@ -30,6 +30,10 @@ class NA6PVerTelDigitizer
 {
  public:
   static constexpr int kNModulesPerLayer = 4;
+  static constexpr float kDefaultThresholdkeV = 0.4f;
+  static constexpr float kDefaultThresholdEl = 100.f;
+  static constexpr float kGeVTokeV = 1.e6;
+  static constexpr float kGeVToEl = 2.76e8;
 
   NA6PVerTelDigitizer() = default;
   NA6PVerTelDigitizer(const std::string& name) : mName(name) {}
@@ -42,6 +46,7 @@ class NA6PVerTelDigitizer
   void init(const char* filename = "geometry.root", const char* geoname = "NA6P");
   void process(const std::vector<NA6PVerTelHit>& hits, int layer = -1);
   void processHit(NA6PVerTelHit hit);
+  void finalizeDigits();
 
   size_t getNDigits() const { return mDigits.size(); }
   void createDigitsOutput();
@@ -52,6 +57,15 @@ class NA6PVerTelDigitizer
 
   void getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3], double xyzLocE[3]);
 
+  void SetThreshold(int modID, float thr)
+  {
+    if (modID < 0 || modID >= mNumberOfModules) {
+      LOGP(error, "Module ID [] out of range", modID);
+    } else {
+      mThresholds[modID] = thr;
+    }
+  }
+
  protected:
   std::string mName{"VerTel"};                       ///< detector name
   int mNumberOfModules = 0;                          ///< number of modules
@@ -60,6 +74,7 @@ class NA6PVerTelDigitizer
   std::vector<TGeoHMatrix> mMatrices{};              ///< local-to-global transforms
   std::vector<float> mModuleHalfX;                   ///< Module half length along x
   std::vector<float> mModuleHalfY;                   ///< Module half length along y
+  std::vector<float> mThresholds;                    ///< Module threshold
   std::vector<NA6PVerTelDigit> mDigits, *hDigitsPtr = &mDigits;
   TFile* mDigitsFile = nullptr;
   TTree* mDigitsTree = nullptr;

--- a/sim/include/NA6PVerTelDigitizer.h
+++ b/sim/include/NA6PVerTelDigitizer.h
@@ -16,9 +16,13 @@
 #define NA6P_VERTEL_DIGITIZER_H
 
 #include "NA6PVerTelPreDigitContainer.h"
+#include "NA6PVerTelDigit.h"
 #include "NA6PVerTelSegmentation.h"
 #include <Rtypes.h>
 #include <TGeoMatrix.h>
+
+class TFile;
+class TTree;
 
 // steers hits -> digits step
 
@@ -28,7 +32,10 @@ class NA6PVerTelDigitizer
   static constexpr int kNModulesPerLayer = 4;
 
   NA6PVerTelDigitizer() = default;
+  NA6PVerTelDigitizer(const std::string& name) : mName(name) {}
   ~NA6PVerTelDigitizer() = default;
+
+  const std::string& getName() const { return mName; }
 
   static int detID2Layer(int detID) { return detID / kNModulesPerLayer; }
 
@@ -36,15 +43,27 @@ class NA6PVerTelDigitizer
   void process(const std::vector<NA6PVerTelHit>& hits, int layer = -1);
   void processHit(NA6PVerTelHit hit);
 
+  size_t getNDigits() const { return mDigits.size(); }
+  void createDigitsOutput();
+  void closeDigitsOutput();
+  void writeDigits();
+  void clearDigits() { mDigits.clear(); }
+  const auto& getDigits() const { return mDigits; }
+
   void getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3], double xyzLocE[3]);
 
  protected:
+  std::string mName{"VerTel"};                       ///< detector name
   int mNumberOfModules = 0;                          ///< number of modules
   std::vector<NA6PVerTelPreDigitContainer> mModules; ///< Array of module pre-digits containers
   NA6PVerTelSegmentation mSegmentation;              ///< segmentation class
   std::vector<TGeoHMatrix> mMatrices{};              ///< local-to-global transforms
   std::vector<float> mModuleHalfX;                   ///< Module half length along x
   std::vector<float> mModuleHalfY;                   ///< Module half length along y
+  std::vector<NA6PVerTelDigit> mDigits, *hDigitsPtr = &mDigits;
+  TFile* mDigitsFile = nullptr;
+  TTree* mDigitsTree = nullptr;
+
   ClassDefNV(NA6PVerTelDigitizer, 1);
 };
 

--- a/sim/include/NA6PVerTelDigitizer.h
+++ b/sim/include/NA6PVerTelDigitizer.h
@@ -18,6 +18,7 @@
 #include "NA6PVerTelPreDigitContainer.h"
 #include "NA6PVerTelDigit.h"
 #include "NA6PVerTelSegmentation.h"
+#include "NA6PGeometryManager.h"
 #include <Rtypes.h>
 #include <TGeoMatrix.h>
 
@@ -29,7 +30,6 @@ class TTree;
 class NA6PVerTelDigitizer
 {
  public:
-  static constexpr int kNModulesPerLayer = 4;
   static constexpr float kDefaultThresholdkeV = 0.4f;
   static constexpr float kDefaultThresholdEl = 100.f;
   static constexpr float kGeVTokeV = 1.e6;
@@ -41,7 +41,7 @@ class NA6PVerTelDigitizer
 
   const std::string& getName() const { return mName; }
 
-  static int detID2Layer(int detID) { return detID / kNModulesPerLayer; }
+  static int detID2Layer(int detID) { return detID / NA6PGeometryManager::kNVTModulesPerLayer; }
 
   void init(const char* filename = "geometry.root", const char* geoname = "NA6P");
   void process(const std::vector<NA6PVerTelHit>& hits, int layer = -1);
@@ -71,9 +71,7 @@ class NA6PVerTelDigitizer
   int mNumberOfModules = 0;                          ///< number of modules
   std::vector<NA6PVerTelPreDigitContainer> mModules; ///< Array of module pre-digits containers
   NA6PVerTelSegmentation mSegmentation;              ///< segmentation class
-  std::vector<TGeoHMatrix> mMatrices{};              ///< local-to-global transforms
-  std::vector<float> mModuleHalfX;                   ///< Module half length along x
-  std::vector<float> mModuleHalfY;                   ///< Module half length along y
+  NA6PGeometryManager mGeoManager;                   ///< geometry manager
   std::vector<float> mThresholds;                    ///< Threshold (per tile)
   std::vector<NA6PVerTelDigit> mDigits, *hDigitsPtr = &mDigits;
   TFile* mDigitsFile = nullptr;

--- a/sim/include/NA6PVerTelDigitizer.h
+++ b/sim/include/NA6PVerTelDigitizer.h
@@ -1,0 +1,47 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_VERTEL_DIGITIZER_H
+#define NA6P_VERTEL_DIGITIZER_H
+
+#include "NA6PVerTelPreDigitContainer.h"
+#include <Rtypes.h>
+#include <TGeoMatrix.h>
+
+// steers hits -> digits step
+
+class NA6PVerTelDigitizer
+{
+ public:
+  static constexpr int kNModulesPerLayer = 4;
+
+  NA6PVerTelDigitizer() = default;
+  ~NA6PVerTelDigitizer() = default;
+
+  static int detID2Layer(int detID) { return detID / kNModulesPerLayer; }
+
+  void init(const char* filename = "geometry.root", const char* geoname = "NA6P");
+  void process(const std::vector<NA6PVerTelHit>& hits, int layer = -1);
+  void processHit(NA6PVerTelHit hit);
+
+ protected:
+  int mNumberOfModules = 0;                          ///< number of modules
+  std::vector<NA6PVerTelPreDigitContainer> mModules; ///< Array of module pre-digits containers
+  std::vector<TGeoHMatrix> mMatrices{};              ///< local-to-global transforms
+  std::vector<float> mModuleHalfX;                   ///< Module half length along x
+  std::vector<float> mModuleHalfY;                   ///< Module half length along y
+  ClassDefNV(NA6PVerTelDigitizer, 1);
+};
+
+#endif

--- a/sim/include/NA6PVerTelDigitizer.h
+++ b/sim/include/NA6PVerTelDigitizer.h
@@ -16,6 +16,7 @@
 #define NA6P_VERTEL_DIGITIZER_H
 
 #include "NA6PVerTelPreDigitContainer.h"
+#include "NA6PVerTelSegmentation.h"
 #include <Rtypes.h>
 #include <TGeoMatrix.h>
 
@@ -35,9 +36,12 @@ class NA6PVerTelDigitizer
   void process(const std::vector<NA6PVerTelHit>& hits, int layer = -1);
   void processHit(NA6PVerTelHit hit);
 
+  void getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3], double xyzLocE[3]);
+
  protected:
   int mNumberOfModules = 0;                          ///< number of modules
   std::vector<NA6PVerTelPreDigitContainer> mModules; ///< Array of module pre-digits containers
+  NA6PVerTelSegmentation mSegmentation;              ///< segmentation class
   std::vector<TGeoHMatrix> mMatrices{};              ///< local-to-global transforms
   std::vector<float> mModuleHalfX;                   ///< Module half length along x
   std::vector<float> mModuleHalfY;                   ///< Module half length along y

--- a/sim/include/NA6PVerTelDigitizer.h
+++ b/sim/include/NA6PVerTelDigitizer.h
@@ -16,6 +16,7 @@
 #define NA6P_VERTEL_DIGITIZER_H
 
 #include "NA6PVerTelPreDigitContainer.h"
+#include "NA6PVerTelHit.h"
 #include "NA6PVerTelDigit.h"
 #include "NA6PVerTelSegmentation.h"
 #include "NA6PGeometryManager.h"
@@ -45,6 +46,7 @@ class NA6PVerTelDigitizer
   static int detID2Layer(int detID) { return detID / NA6PGeometryManager::kNVTModulesPerLayer; }
 
   void init(const char* filename = "geometry.root", const char* geoname = "NA6P");
+  void initGeometry(const char* filename = "geometry.root", const char* geoname = "NA6P");
   void process(const std::vector<NA6PVerTelHit>& hits, int layer = -1);
   void processHit(const NA6PVerTelHit& hit);
   void finalizeDigits();

--- a/sim/include/NA6PVerTelPreDigitContainer.h
+++ b/sim/include/NA6PVerTelPreDigitContainer.h
@@ -17,20 +17,42 @@
 
 #include <Rtypes.h>
 #include "NA6PVerTelDigit.h"
+#include "NA6PMCComposedLabel.h"
 
 // container of pre-digits per module
 
 struct PreDigit {
-  VTPixID pixID;       ///< pixel identifier from NA6PVerTelDigit
-  float charge = 0.f;  ///< collected charg in pixel
-  int particleID = -1; ///< label of MC particle
+  VTPixID pixID;                                             ///< pixel identifier from NA6PVerTelDigit
+  float charge = 0.f;                                        ///< collected charg in pixel
+  std::vector<std::pair<float, NA6PMCComposedLabel>> labels; ///< <energy, label>, sorted by energy before digitization
 
-  PreDigit(UShort_t rs = 0, UShort_t tl = 0, UShort_t rw = 0, UShort_t cl = 0, float ch = 0.f, int lbl = -1) : charge(ch), particleID(lbl)
+  PreDigit(UShort_t rs = 0, UShort_t tl = 0, UShort_t rw = 0, UShort_t cl = 0, float ch = 0.f, NA6PMCComposedLabel lbl = {}) : charge(ch)
   {
     pixID.rsu = rs;
     pixID.tile = tl;
     pixID.row = rw;
     pixID.col = cl;
+    labels.emplace_back(ch, lbl);
+  }
+
+  void addContribution(float ch, const NA6PMCComposedLabel& lbl)
+  {
+    charge += ch;
+    for (auto& p : labels) {
+      if (p.second == lbl) {
+        p.first += ch;
+        return;
+      }
+    }
+    labels.emplace_back(ch, lbl);
+  }
+
+  void sortLabelsByEnergy()
+  {
+    std::sort(labels.begin(), labels.end(),
+              [](const auto& a, const auto& b) {
+                return a.first > b.first;
+              });
   }
 
   ClassDefNV(PreDigit, 1);
@@ -51,7 +73,7 @@ class NA6PVerTelPreDigitContainer
 
   std::map<ULong64_t, PreDigit>& getPreDigits() { return mPreDigits; }
   PreDigit* findDigit(ULong64_t key);
-  void addDigit(ULong64_t key, UShort_t rs, UShort_t tl, UShort_t rw, UShort_t cl, float ch, int lbl);
+  void addDigit(ULong64_t key, UShort_t rs, UShort_t tl, UShort_t rw, UShort_t cl, float ch, const NA6PMCComposedLabel& lbl);
 
   UShort_t getDetectorIndex() const { return mDetectorIndex; }
   void setDetectorIndex(UShort_t ind) { mDetectorIndex = ind; }
@@ -108,7 +130,7 @@ inline PreDigit* NA6PVerTelPreDigitContainer::findDigit(ULong64_t key)
   return digitentry != mPreDigits.end() ? &(digitentry->second) : nullptr;
 }
 //_______________________________________________________________________
-inline void NA6PVerTelPreDigitContainer::addDigit(ULong64_t key, UShort_t rs, UShort_t tl, UShort_t rw, UShort_t cl, float ch, int lbl)
+inline void NA6PVerTelPreDigitContainer::addDigit(ULong64_t key, UShort_t rs, UShort_t tl, UShort_t rw, UShort_t cl, float ch, const NA6PMCComposedLabel& lbl)
 {
   mPreDigits.emplace(std::make_pair(key, PreDigit(rs, tl, rw, cl, ch, lbl)));
 }

--- a/sim/include/NA6PVerTelPreDigitContainer.h
+++ b/sim/include/NA6PVerTelPreDigitContainer.h
@@ -16,19 +16,22 @@
 #define NA6P_VERTEL_PREDIGITCONTAINER_H
 
 #include <Rtypes.h>
+#include "NA6PVerTelDigit.h"
 
 // container of pre-digits per module
 
 struct PreDigit {
-  UShort_t rsu = 0;    ///< RSU index in the detector [0, 41]
-  UShort_t tile = 0;   ///< Tile index in the RSU [0, 11]
-  UShort_t row = 0;    ///< Pixel row in the tile [0, 459]
-  UShort_t col = 0;    ///< Pixel column in the tile [0, 161]
+  VTPixID pixID;       ///< pixel identifier from NA6PVerTelDigit
   float charge = 0.f;  ///< collected charg in pixel
   int particleID = -1; ///< label of MC particle
 
-  PreDigit(UShort_t rs = 0, UShort_t tl = 0, UShort_t rw = 0, UShort_t cl = 0, float ch = 0.f, int lbl = 0)
-    : rsu(rs), tile(tl), row(rw), col(cl), charge(ch), particleID(lbl) {}
+  PreDigit(UShort_t rs = 0, UShort_t tl = 0, UShort_t rw = 0, UShort_t cl = 0, float ch = 0.f, int lbl = -1) : charge(ch), particleID(lbl)
+  {
+    pixID.rsu = rs;
+    pixID.tile = tl;
+    pixID.row = rw;
+    pixID.col = cl;
+  }
 
   ClassDefNV(PreDigit, 1);
 };
@@ -36,25 +39,12 @@ struct PreDigit {
 class NA6PVerTelPreDigitContainer
 {
  public:
-  static constexpr int kColBits = 10; // 0-161,  max 1023
-  static constexpr int kRowBits = 10; // 0-459,  max 1023
-  static constexpr int kTileBits = 4; // 0-11,   max 15
-  static constexpr int kRsuBits = 6;  // 0-41,   max 63
-  static constexpr int kRofBits = 34; // reserved for future use
+  static constexpr int kRofShift = 8 * sizeof(uint32_t); // shift by VTPixID size
 
-  static constexpr ULong64_t kColMask = (1ULL << kColBits) - 1;
-  static constexpr ULong64_t kRowMask = (1ULL << kRowBits) - 1;
-  static constexpr ULong64_t kTileMask = (1ULL << kTileBits) - 1;
-  static constexpr ULong64_t kRsuMask = (1ULL << kRsuBits) - 1;
-  static constexpr ULong64_t kRofMask = (1ULL << kRofBits) - 1;
-
-  static constexpr int kRowShift = kColBits;
-  static constexpr int kTileShift = kRowShift + kRowBits;
-  static constexpr int kRsuShift = kTileShift + kTileBits;
-  static constexpr int kRofShift = kRsuShift + kRsuBits;
-
-  static_assert(kColBits + kRowBits + kTileBits + kRsuBits + kRofBits == 64,
-                "Key bit fields must sum to exactly 64 bits");
+  static_assert(VTPixID::kColBits + VTPixID::kRowBits +
+                    VTPixID::kTileBits + VTPixID::kRsuBits <=
+                  kRofShift,
+                "VTPixID bit fields must fit within kRofShift in the 64-bit key");
 
   NA6PVerTelPreDigitContainer(UShort_t idx = 0) : mDetectorIndex(idx){};
   ~NA6PVerTelPreDigitContainer() = default;
@@ -64,29 +54,33 @@ class NA6PVerTelPreDigitContainer
   void addDigit(ULong64_t key, UShort_t rs, UShort_t tl, UShort_t rw, UShort_t cl, float ch, int lbl);
 
   UShort_t getDetectorIndex() const { return mDetectorIndex; }
-
   void setDetectorIndex(UShort_t ind) { mDetectorIndex = ind; }
 
   bool isEmpty() const { return mPreDigits.empty(); }
   static ULong64_t getOrderingKey(UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col)
   {
-    return (static_cast<ULong64_t>(rsu) << kRsuShift) |
-           (static_cast<ULong64_t>(tile) << kTileShift) |
-           (static_cast<ULong64_t>(row) << kRowShift) |
-           static_cast<ULong64_t>(col);
+    VTPixID id;
+    id.rsu = rsu;
+    id.tile = tile;
+    id.row = row;
+    id.col = col;
+    return static_cast<ULong64_t>(id.pack());
   }
-  static UShort_t key2col(ULong64_t key) { return static_cast<UShort_t>(key & kColMask); }
-  static UShort_t key2row(ULong64_t key) { return static_cast<UShort_t>((key >> kRowShift) & kRowMask); }
-  static UShort_t key2tile(ULong64_t key) { return static_cast<UShort_t>((key >> kTileShift) & kTileMask); }
-  static UShort_t key2rsu(ULong64_t key) { return static_cast<UShort_t>((key >> kRsuShift) & kRsuMask); }
+
+  static UShort_t key2col(ULong64_t key) { return key2pixID(key).col; }
+  static UShort_t key2row(ULong64_t key) { return key2pixID(key).row; }
+  static UShort_t key2tile(ULong64_t key) { return key2pixID(key).tile; }
+  static UShort_t key2rsu(ULong64_t key) { return key2pixID(key).rsu; }
+
   static void unpackKey(ULong64_t key,
                         UShort_t& rsu, UShort_t& tile,
                         UShort_t& row, UShort_t& col)
   {
-    col = key2col(key);
-    row = key2row(key);
-    tile = key2tile(key);
-    rsu = key2rsu(key);
+    VTPixID id = key2pixID(key);
+    rsu = id.rsu;
+    tile = id.tile;
+    row = id.row;
+    col = id.col;
   }
 
   bool isDisabled() const { return mDisabled; }
@@ -96,6 +90,12 @@ class NA6PVerTelPreDigitContainer
   UShort_t mDetectorIndex = 0;              ///< Detector index
   bool mDisabled = false;                   ///< flag to disable module
   std::map<ULong64_t, PreDigit> mPreDigits; ///< Map of fired pixels
+
+ private:
+  static VTPixID key2pixID(ULong64_t key)
+  {
+    return VTPixID::unpack(static_cast<uint32_t>(key & 0xFFFFFFFF));
+  }
 
   ClassDefNV(NA6PVerTelPreDigitContainer, 1);
 };

--- a/sim/include/NA6PVerTelPreDigitContainer.h
+++ b/sim/include/NA6PVerTelPreDigitContainer.h
@@ -81,11 +81,7 @@ class NA6PVerTelPreDigitContainer
   bool isEmpty() const { return mPreDigits.empty(); }
   static ULong64_t getOrderingKey(UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col)
   {
-    VTPixID id;
-    id.rsu = rsu;
-    id.tile = tile;
-    id.row = row;
-    id.col = col;
+    VTPixID id{.col = col, .row = row, .tile = tile, .rsu = rsu};
     return static_cast<ULong64_t>(id.pack());
   }
 

--- a/sim/include/NA6PVerTelPreDigitContainer.h
+++ b/sim/include/NA6PVerTelPreDigitContainer.h
@@ -1,0 +1,100 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_VERTEL_PREDIGITCONTAINER_H
+#define NA6P_VERTEL_PREDIGITCONTAINER_H
+
+#include <Rtypes.h>
+
+// container of pre-digits per module
+
+struct PreDigit {
+  UShort_t rsu = 0;    ///< RSU index in the detector [0, 41]
+  UShort_t tile = 0;   ///< Tile index in the RSU [0, 11]
+  UShort_t row = 0;    ///< Pixel row in the tile [0, 459]
+  UShort_t col = 0;    ///< Pixel column in the tile [0, 161]
+  float charge = 0.f;  ///< collected charg in pixel
+  int particleID = -1; ///< label of MC particle
+
+  PreDigit(UShort_t rs = 0, UShort_t tl = 0, UShort_t rw = 0, UShort_t cl = 0, float ch = 0.f, int lbl = 0)
+    : rsu(rs), tile(tl), row(rw), col(cl), charge(ch), particleID(lbl) {}
+
+  ClassDefNV(PreDigit, 1);
+};
+
+class NA6PVerTelPreDigitContainer
+{
+ public:
+  static constexpr int kColBits = 10; // 0-161,  max 1023
+  static constexpr int kRowBits = 10; // 0-459,  max 1023
+  static constexpr int kTileBits = 4; // 0-11,   max 15
+  static constexpr int kRsuBits = 6;  // 0-41,   max 63
+  static constexpr int kRofBits = 34; // reserved for future use
+
+  static constexpr ULong64_t kColMask = (1ULL << kColBits) - 1;
+  static constexpr ULong64_t kRowMask = (1ULL << kRowBits) - 1;
+  static constexpr ULong64_t kTileMask = (1ULL << kTileBits) - 1;
+  static constexpr ULong64_t kRsuMask = (1ULL << kRsuBits) - 1;
+  static constexpr ULong64_t kRofMask = (1ULL << kRofBits) - 1;
+
+  static constexpr int kRowShift = kColBits;
+  static constexpr int kTileShift = kRowShift + kRowBits;
+  static constexpr int kRsuShift = kTileShift + kTileBits;
+  static constexpr int kRofShift = kRsuShift + kRsuBits;
+
+  static_assert(kColBits + kRowBits + kTileBits + kRsuBits + kRofBits == 64,
+                "Key bit fields must sum to exactly 64 bits");
+
+  NA6PVerTelPreDigitContainer(UShort_t idx = 0) : mDetectorIndex(idx){};
+  ~NA6PVerTelPreDigitContainer() = default;
+
+  std::map<ULong64_t, PreDigit>& getPreDigits() { return mPreDigits; }
+  UShort_t getDetectorIndex() const { return mDetectorIndex; }
+
+  void setDetectorIndex(UShort_t ind) { mDetectorIndex = ind; }
+
+  bool isEmpty() const { return mPreDigits.empty(); }
+  static ULong64_t getOrderingKey(UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col)
+  {
+    return (static_cast<ULong64_t>(rsu) << kRsuShift) |
+           (static_cast<ULong64_t>(tile) << kTileShift) |
+           (static_cast<ULong64_t>(row) << kRowShift) |
+           static_cast<ULong64_t>(col);
+  }
+  static UShort_t key2col(ULong64_t key) { return static_cast<UShort_t>(key & kColMask); }
+  static UShort_t key2row(ULong64_t key) { return static_cast<UShort_t>((key >> kRowShift) & kRowMask); }
+  static UShort_t key2tile(ULong64_t key) { return static_cast<UShort_t>((key >> kTileShift) & kTileMask); }
+  static UShort_t key2rsu(ULong64_t key) { return static_cast<UShort_t>((key >> kRsuShift) & kRsuMask); }
+  static void unpackKey(ULong64_t key,
+                        UShort_t& rsu, UShort_t& tile,
+                        UShort_t& row, UShort_t& col)
+  {
+    col = key2col(key);
+    row = key2row(key);
+    tile = key2tile(key);
+    rsu = key2rsu(key);
+  }
+
+  bool isDisabled() const { return mDisabled; }
+  void disable(bool v) { mDisabled = v; }
+
+ protected:
+  UShort_t mDetectorIndex = 0;              ///< Detector index
+  bool mDisabled = false;                   ///< flag to disable module
+  std::map<ULong64_t, PreDigit> mPreDigits; ///< Map of fired pixels
+
+  ClassDefNV(NA6PVerTelPreDigitContainer, 1);
+};
+
+#endif

--- a/sim/include/NA6PVerTelPreDigitContainer.h
+++ b/sim/include/NA6PVerTelPreDigitContainer.h
@@ -60,6 +60,9 @@ class NA6PVerTelPreDigitContainer
   ~NA6PVerTelPreDigitContainer() = default;
 
   std::map<ULong64_t, PreDigit>& getPreDigits() { return mPreDigits; }
+  PreDigit* findDigit(ULong64_t key);
+  void addDigit(ULong64_t key, UShort_t rs, UShort_t tl, UShort_t rw, UShort_t cl, float ch, int lbl);
+
   UShort_t getDetectorIndex() const { return mDetectorIndex; }
 
   void setDetectorIndex(UShort_t ind) { mDetectorIndex = ind; }
@@ -96,5 +99,18 @@ class NA6PVerTelPreDigitContainer
 
   ClassDefNV(NA6PVerTelPreDigitContainer, 1);
 };
+
+//_______________________________________________________________________
+inline PreDigit* NA6PVerTelPreDigitContainer::findDigit(ULong64_t key)
+{
+  // finds the digit corresponding to global key
+  auto digitentry = mPreDigits.find(key);
+  return digitentry != mPreDigits.end() ? &(digitentry->second) : nullptr;
+}
+//_______________________________________________________________________
+inline void NA6PVerTelPreDigitContainer::addDigit(ULong64_t key, UShort_t rs, UShort_t tl, UShort_t rw, UShort_t cl, float ch, int lbl)
+{
+  mPreDigits.emplace(std::make_pair(key, PreDigit(rs, tl, rw, cl, ch, lbl)));
+}
 
 #endif

--- a/sim/include/NA6PVerTelSegmentation.h
+++ b/sim/include/NA6PVerTelSegmentation.h
@@ -58,7 +58,7 @@ class NA6PVerTelSegmentation
   void setStaggered(bool val);
 
   bool localToIndices(float xloc, float yloc, UShort_t& rsu, UShort_t& tile, UShort_t& row, UShort_t& col) const;
-  int isInAcc(float xglo, float yglo) const;
+  int isInAcc(float xloc, float yloc) const;
   bool indicesToLocal(UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col, float& xloc, float& yloc) const;
   static int getTileId(uint32_t mod, uint32_t rsu, uint32_t tile)
   {

--- a/sim/include/NA6PVerTelSegmentation.h
+++ b/sim/include/NA6PVerTelSegmentation.h
@@ -27,13 +27,15 @@ class NA6PVerTelSegmentation
   static constexpr float DeadYBottom = 0.0525;                        // bottom dead zone
   static constexpr float DeadYTop = 0.0525;                           // top dead zone
   static constexpr float DeadTopBotHalves = 0.012;                    // dead space between top and bottom halves
-  static constexpr float DeadXTile = 0.002;                           // dead space between tiles in X
+  static constexpr float DeadXTile = 0.002;                           // dead space between tiles in X (power swicthes)
   static constexpr float DeadXDataBackbone = 0.006;                   // dead space between every segment (triplet of tiles)
   static constexpr float XSizeTot = 12.9996 + DeadXShort + DeadXLong; // 13.5996;
   static constexpr float YSizeTot = 13.5898 + DeadYBottom + DeadYTop; // 13.6948; // readout side
   static constexpr int NXSegments = 12;                               // number of segments per row
   static constexpr int NTilesPerSegment = 3;                          // number of tiles per segment
   static constexpr int NSegmentsPerRSU = 2;                           // segments per RSU (along x)
+  static constexpr int NHalfSensorUnitsPerRSU = 2;                    // top and bottom
+  static constexpr int NTilesPerRSU = NTilesPerSegment * NSegmentsPerRSU * NHalfSensorUnitsPerRSU;
   static constexpr int NXTiles = NXSegments * NTilesPerSegment;       // tiles per row
   static constexpr int NYSensors = 7;                                 // number of rows along y
   static constexpr float DXSegment = (XSizeTot - DeadXShort - DeadXLong) / NXSegments;
@@ -43,8 +45,8 @@ class NA6PVerTelSegmentation
   static constexpr float ActiveDYSens = DYSens - DeadYBottom - DeadYTop;
   static constexpr float ActiveDYHalf = ActiveDYSens / 2;
   static constexpr float ActiveDYTile = ActiveDYHalf - DeadTopBotHalves / 2;
-  static constexpr int NRowsPerTile = 460;
-  static constexpr int NColsPerTile = 162;
+  static constexpr int NRowsPerTile = 444;
+  static constexpr int NColsPerTile = 156;
 
   NA6PVerTelSegmentation() = default;
 
@@ -64,8 +66,8 @@ class NA6PVerTelSegmentation
                            UShort_t& row, UShort_t& col) const;
 
  protected:
-  float mOffsX = 0.3;
-  float mOffsY = -0.3;
+  float mOffsX = 0.29;
+  float mOffsY = -0.31;
   float mInterChipGap = 0.02;
   bool mStaggered = false;
   float mDeadXLongEff = DeadXLong;

--- a/sim/include/NA6PVerTelSegmentation.h
+++ b/sim/include/NA6PVerTelSegmentation.h
@@ -53,15 +53,15 @@ class NA6PVerTelSegmentation
   void setInterChipGap(float val) { mInterChipGap = val; }
   void setStaggered(bool val);
 
-  bool localToIndices(float xloc, float yloc, int& rsu, int& tile, int& row, int& col) const;
+  bool localToIndices(float xloc, float yloc, UShort_t& rsu, UShort_t& tile, UShort_t& row, UShort_t& col) const;
   int isInAcc(float xglo, float yglo) const;
-  bool indicesToLocal(int rsu, int tile, int row, int col, float& xloc, float& yloc) const;
+  bool indicesToLocal(UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col, float& xloc, float& yloc) const;
 
  private:
   bool computePixelIndices(float xloc, float yloc,
                            float deadYBottom, float deadYTop,
-                           int& rsu, int& tile,
-                           int& row, int& col) const;
+                           UShort_t& rsu, UShort_t& tile,
+                           UShort_t& row, UShort_t& col) const;
 
  protected:
   float mOffsX = 0.3;

--- a/sim/include/NA6PVerTelSegmentation.h
+++ b/sim/include/NA6PVerTelSegmentation.h
@@ -31,12 +31,20 @@ class NA6PVerTelSegmentation
   static constexpr float DeadXDataBackbone = 0.006;                   // dead space between every segment (triplet of tiles)
   static constexpr float XSizeTot = 12.9996 + DeadXShort + DeadXLong; // 13.5996;
   static constexpr float YSizeTot = 13.5898 + DeadYBottom + DeadYTop; // 13.6948; // readout side
-  static constexpr int NXTiles = 36;                                  // tiles (3 tiles per segment)
-  static constexpr int NXSegments = 12;                               // group of 3 tiles
+  static constexpr int NXSegments = 12;                               // number of segments per row
+  static constexpr int NTilesPerSegment = 3;                          // number of tiles per segment
+  static constexpr int NSegmentsPerRSU = 2;                           // segments per RSU (along x)
+  static constexpr int NXTiles = NXSegments * NTilesPerSegment;       // tiles per row
   static constexpr int NYSensors = 7;                                 // number of rows along y
   static constexpr float DXSegment = (XSizeTot - DeadXShort - DeadXLong) / NXSegments;
-  static constexpr float DXTile = (DXSegment - DeadXDataBackbone) / 3;
+  static constexpr float DXTile = (DXSegment - DeadXDataBackbone) / NTilesPerSegment;
   static constexpr float DYSens = YSizeTot / NYSensors;
+  static constexpr float ActiveDX = DXTile - DeadXTile;
+  static constexpr float ActiveDYSens = DYSens - DeadYBottom - DeadYTop;
+  static constexpr float ActiveDYHalf = ActiveDYSens / 2;
+  static constexpr float ActiveDYTile = ActiveDYHalf - DeadTopBotHalves / 2;
+  static constexpr int NRowsPerTile = 460;
+  static constexpr int NColsPerTile = 162;
 
   NA6PVerTelSegmentation() = default;
 
@@ -45,7 +53,15 @@ class NA6PVerTelSegmentation
   void setInterChipGap(float val) { mInterChipGap = val; }
   void setStaggered(bool val);
 
-  int isInAcc(float x, float y) const;
+  bool localToIndices(float xloc, float yloc, int& rsu, int& tile, int& row, int& col) const;
+  int isInAcc(float xglo, float yglo) const;
+  bool indicesToLocal(int rsu, int tile, int row, int col, float& xloc, float& yloc) const;
+
+ private:
+  bool computePixelIndices(float xloc, float yloc,
+                           float deadYBottom, float deadYTop,
+                           int& rsu, int& tile,
+                           int& row, int& col) const;
 
  protected:
   float mOffsX = 0.3;

--- a/sim/include/NA6PVerTelSegmentation.h
+++ b/sim/include/NA6PVerTelSegmentation.h
@@ -16,6 +16,7 @@
 #define NA6P_VERTEL_SEGMENTATION_H
 
 #include <Rtypes.h>
+#include <fairlogger/Logger.h>
 
 // define dead areas and segmentation of the VT modules
 
@@ -36,8 +37,9 @@ class NA6PVerTelSegmentation
   static constexpr int NSegmentsPerRSU = 2;                           // segments per RSU (along x)
   static constexpr int NHalfSensorUnitsPerRSU = 2;                    // top and bottom
   static constexpr int NTilesPerRSU = NTilesPerSegment * NSegmentsPerRSU * NHalfSensorUnitsPerRSU;
-  static constexpr int NXTiles = NXSegments * NTilesPerSegment;       // tiles per row
-  static constexpr int NYSensors = 7;                                 // number of rows along y
+  static constexpr int NXTiles = NXSegments * NTilesPerSegment; // tiles per row
+  static constexpr int NYSensors = 7;                           // number of rows along y
+  static constexpr int NTilesPerModule = NXTiles * NHalfSensorUnitsPerRSU * NYSensors;
   static constexpr float DXSegment = (XSizeTot - DeadXShort - DeadXLong) / NXSegments;
   static constexpr float DXTile = (DXSegment - DeadXDataBackbone) / NTilesPerSegment;
   static constexpr float DYSens = YSizeTot / NYSensors;
@@ -58,6 +60,14 @@ class NA6PVerTelSegmentation
   bool localToIndices(float xloc, float yloc, UShort_t& rsu, UShort_t& tile, UShort_t& row, UShort_t& col) const;
   int isInAcc(float xglo, float yglo) const;
   bool indicesToLocal(UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col, float& xloc, float& yloc) const;
+  static int getTileId(uint32_t mod, uint32_t rsu, uint32_t tile)
+  {
+    if (rsu >= NYSensors * (NXSegments / NSegmentsPerRSU) || tile >= NTilesPerRSU) {
+      LOGP(error, "getTileId: invalid indices mod={} rsu={} tile={}", mod, rsu, tile);
+      return -1;
+    }
+    return mod * NTilesPerModule + rsu * NTilesPerRSU + tile;
+  }
 
  private:
   bool computePixelIndices(float xloc, float yloc,

--- a/sim/src/NA6PVerTelDigit.cxx
+++ b/sim/src/NA6PVerTelDigit.cxx
@@ -1,0 +1,24 @@
+// NA6PCCopyright
+
+#include "NA6PVerTelDigit.h"
+#include <fmt/format.h>
+#include <fairlogger/Logger.h>
+
+NA6PVerTelDigit::NA6PVerTelDigit(UShort_t detID, UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col, int pid) : mDetectorID(detID), mParticleID(pid)
+{
+  mPixID.rsu = rsu;
+  mPixID.tile = tile;
+  mPixID.row = row;
+  mPixID.col = col;
+}
+
+std::string NA6PVerTelDigit::asString() const
+{
+  return fmt::format("Digit: Det:{} RSU:{} Tile:{} Row:{} Col:{} PartId:{}",
+                     mDetectorID, getRSU(), getTile(), getRow(), getCol(), mParticleID);
+}
+
+void NA6PVerTelDigit::print() const
+{
+  LOGP(info, "{}", asString());
+}

--- a/sim/src/NA6PVerTelDigit.cxx
+++ b/sim/src/NA6PVerTelDigit.cxx
@@ -4,12 +4,11 @@
 #include <fmt/format.h>
 #include <fairlogger/Logger.h>
 
-NA6PVerTelDigit::NA6PVerTelDigit(uint16_t detID, const VTPixID& id, int pid)
-  : mDetectorID(detID), mPixID(id), mParticleID(pid)
+NA6PVerTelDigit::NA6PVerTelDigit(uint16_t detID, const VTPixID& id) : mDetectorID(detID), mPixID(id)
 {
 }
 
-NA6PVerTelDigit::NA6PVerTelDigit(uint16_t detID, uint32_t rsu, uint32_t tile, uint32_t row, uint32_t col, int pid) : mDetectorID(detID), mParticleID(pid)
+NA6PVerTelDigit::NA6PVerTelDigit(uint16_t detID, uint32_t rsu, uint32_t tile, uint32_t row, uint32_t col) : mDetectorID(detID)
 {
   mPixID.rsu = rsu;
   mPixID.tile = tile;
@@ -19,8 +18,8 @@ NA6PVerTelDigit::NA6PVerTelDigit(uint16_t detID, uint32_t rsu, uint32_t tile, ui
 
 std::string NA6PVerTelDigit::asString() const
 {
-  return fmt::format("Digit: Det:{} RSU:{} Tile:{} Row:{} Col:{} PartId:{}",
-                     mDetectorID, getRSU(), getTile(), getRow(), getCol(), mParticleID);
+  return fmt::format("Digit: Det:{} RSU:{} Tile:{} Row:{} Col:{}",
+                     mDetectorID, getRSU(), getTile(), getRow(), getCol());
 }
 
 void NA6PVerTelDigit::print() const

--- a/sim/src/NA6PVerTelDigit.cxx
+++ b/sim/src/NA6PVerTelDigit.cxx
@@ -4,7 +4,12 @@
 #include <fmt/format.h>
 #include <fairlogger/Logger.h>
 
-NA6PVerTelDigit::NA6PVerTelDigit(UShort_t detID, UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col, int pid) : mDetectorID(detID), mParticleID(pid)
+NA6PVerTelDigit::NA6PVerTelDigit(uint16_t detID, const VTPixID& id, int pid)
+  : mDetectorID(detID), mPixID(id), mParticleID(pid)
+{
+}
+
+NA6PVerTelDigit::NA6PVerTelDigit(uint16_t detID, uint32_t rsu, uint32_t tile, uint32_t row, uint32_t col, int pid) : mDetectorID(detID), mParticleID(pid)
 {
   mPixID.rsu = rsu;
   mPixID.tile = tile;

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -31,7 +31,8 @@ void NA6PVerTelDigitizer::createDigitsOutput()
   mDigitsFile = TFile::Open(nm.c_str(), "recreate");
   mDigitsTree = new TTree(fmt::format("digits{}", getName()).c_str(), fmt::format("{} Digits", getName()).c_str());
   mDigitsTree->Branch(getName().c_str(), &hDigitsPtr);
-  LOGP(info, "Will store {} hits in {}", getName(), nm);
+  mDigitsTree->Branch(fmt::format("{}MCTruth", getName()).c_str(), &hMCLabelsPtr);
+  LOGP(info, "Will store {} digits in {}", getName(), nm);
 }
 
 void NA6PVerTelDigitizer::closeDigitsOutput()
@@ -138,12 +139,12 @@ void NA6PVerTelDigitizer::processHit(NA6PVerTelHit hit)
     bool digOk = mSegmentation.localToIndices(x, y, rsu, tile, row, col);
     if (digOk) {
       auto key = mod.getOrderingKey(rsu, tile, row, col);
+      NA6PMCComposedLabel lbl(hit.getTrackID(), 0, 0);
       PreDigit* pd = mod.findDigit(key);
       if (!pd) {
-        mod.addDigit(key, rsu, tile, row, col, chargePerStep, hit.getTrackID());
+        mod.addDigit(key, rsu, tile, row, col, chargePerStep, lbl);
       } else { // there is already a digit at this slot, account as PreDigitExtra contribution
-        pd->charge += chargePerStep;
-        // to be added: treat multiple particles (getTrackID) in the same pre-digit
+        pd->addContribution(chargePerStep, lbl);
       }
     }
     x += stepX;
@@ -166,11 +167,17 @@ void NA6PVerTelDigitizer::finalizeDigits()
     auto itBeg = buffer.begin();
     auto iter = itBeg;
     for (; iter != buffer.end(); ++iter) {
-      const auto& preDig = iter->second;
+      auto& preDig = iter->second;
       int jTile = NA6PVerTelSegmentation::getTileId(jMod, preDig.pixID.rsu, preDig.pixID.tile);
       if (jTile >= 0 && preDig.charge >= mThresholds[jTile]) {
-        mDigits.emplace_back(static_cast<uint16_t>(jMod), preDig.pixID, preDig.particleID);
-        // auto& dig = mDigits.back();
+        preDig.sortLabelsByEnergy();
+        int digID = mDigits.size();
+        mDigits.emplace_back(static_cast<uint16_t>(jMod), preDig.pixID);
+        for (auto& plab : preDig.labels) {
+          // here we can add selections on the labels to be stored in case of multiple labels per digit
+          // e.g. remove delta electrons, remove particles contributing with much smaller energy than the others, etc.
+          mMCLabels.addElement(digID, plab.second);
+        }
       }
     }
     buffer.erase(itBeg, iter); // erase processed entries; iter == end() for now

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -1,0 +1,124 @@
+// NA6PCCopyright
+
+#include <ranges>
+#include <numeric>
+#include <fairlogger/Logger.h>
+#include <TGeoNode.h>
+#include <TGeoBBox.h>
+#include <TGeoManager.h>
+
+#include "NA6PLayoutParam.h"
+#include "NA6PVerTelHit.h"
+#include "NA6PVerTelDigitizer.h"
+
+ClassImp(NA6PVerTelDigitizer)
+
+  void NA6PVerTelDigitizer::init(const char* filename, const char* geoname)
+{
+  const auto& param = NA6PLayoutParam::Instance();
+  mNumberOfModules = param.nVerTelPlanes * kNModulesPerLayer;
+  mModules.resize(mNumberOfModules);
+  mMatrices.resize(mNumberOfModules);
+
+  if (!gGeoManager) {
+    TFile* f = TFile::Open(filename);
+    if (!f || f->IsZombie()) {
+      LOGP(error, "Cannot open geometry file {}", filename);
+      return;
+    }
+    gGeoManager = (TGeoManager*)f->Get(geoname);
+    if (!gGeoManager) {
+      LOGP(error, "No geometry with name {} found in file {}", geoname, filename);
+      f->Close();
+      return;
+    }
+    f->Close();
+  }
+
+  std::vector<bool> isMatrixLoaded;
+  isMatrixLoaded.assign(mNumberOfModules, false);
+  mModuleHalfX.assign(mNumberOfModules, 0.);
+  mModuleHalfY.assign(mNumberOfModules, 0.);
+  TGeoIterator next(gGeoManager->GetTopVolume());
+  TGeoNode* node = nullptr;
+  while ((node = next())) {
+    TString name = node->GetName();
+    if (name.BeginsWith("PixelSensor_")) {
+      Int_t currentLevel = next.GetLevel();
+      if (currentLevel <= 0)
+        continue;
+      TGeoVolume* vol = node->GetVolume();
+      if (!vol) {
+        LOGP(error, "Volume null pointer");
+        continue;
+      }
+      TGeoShape* shape = vol->GetShape();
+      if (!shape) {
+        LOGP(error, "Shape null pointer");
+        continue;
+      }
+      if (shape->IsA() != TGeoBBox::Class()) {
+        LOGP(error, "Module shape is not a TGeoBBox");
+        continue;
+      }
+      TGeoNode* motherNode = next.GetNode(currentLevel - 1);
+      int layer = motherNode->GetNumber() % 10;
+      int modNum = node->GetNumber() % 10;
+      int modIndex = kNModulesPerLayer * layer + modNum;
+      if (modIndex < 0 || modIndex >= mNumberOfModules) {
+        LOGP(error, "Wrong module index {} (layer={}, modNum={})", modIndex, layer, modNum);
+        continue;
+      }
+      mMatrices[modIndex] = *(next.GetCurrentMatrix());
+      TGeoBBox* box = static_cast<TGeoBBox*>(shape);
+      mModuleHalfX[modIndex] = static_cast<float>(box->GetDX());
+      mModuleHalfY[modIndex] = static_cast<float>(box->GetDY());
+      isMatrixLoaded[modIndex] = true;
+    }
+  }
+  for (int im = 0; im < mNumberOfModules; ++im) {
+    if (!isMatrixLoaded[im]) {
+      LOGP(error, "Matrix not loaded for module {}", im);
+    }
+  }
+}
+
+void NA6PVerTelDigitizer::process(const std::vector<NA6PVerTelHit>& hits, int layer)
+{
+  int nHits = hits.size();
+  std::vector<int> hitIdx(nHits);
+  std::iota(std::begin(hitIdx), std::end(hitIdx), 0);
+  // sort hits to improve memory access
+  std::sort(hitIdx.begin(), hitIdx.end(), [&hits](auto lhs, auto rhs) {
+    return hits[lhs].getDetectorID() < hits[rhs].getDetectorID();
+  });
+  for (int i : hitIdx | std::views::filter([&](int idx) {
+                 if (layer < 0)
+                   return true;
+                 return detID2Layer(hits[idx].getDetectorID()) == layer;
+               })) {
+    processHit(hits[i]);
+  }
+}
+
+void NA6PVerTelDigitizer::processHit(NA6PVerTelHit hit)
+{
+  auto modID = hit.getDetectorID();
+  printf("modID = %d\n", modID);
+  auto& mod = mModules[modID];
+  if (mod.isDisabled()) {
+    LOGP(info, "Skipping disabled module {}", modID);
+    return;
+  }
+  auto& matrix = mMatrices[modID];
+
+  double xyzGloS[3] = {hit.getXIn(), hit.getYIn(), hit.getZIn()};
+  double xyzGloE[3] = {hit.getXOut(), hit.getYOut(), hit.getZOut()};
+  printf("Global coordinates = %f %f %f\n", xyzGloS[0], xyzGloS[1], xyzGloS[2]);
+
+  double xyzLocS[3], xyzLocE[3];
+  matrix.MasterToLocal(xyzGloS, xyzLocS);
+  xyzLocS[0] += mModuleHalfX[modID];
+  xyzLocS[1] += mModuleHalfY[modID];
+  printf("Local coordinates: %f %f %f\n", xyzLocS[0], xyzLocS[1], xyzLocS[2]);
+}

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -19,7 +19,7 @@ void NA6PVerTelDigitizer::init(const char* filename, const char* geoname)
   mNumberOfModules = param.nVerTelPlanes * NA6PGeometryManager::kNVTModulesPerLayer;
   mModules.resize(mNumberOfModules);
   mThresholds.assign(mNumberOfModules * NA6PVerTelSegmentation::NXTiles * NA6PVerTelSegmentation::NYSensors, kDefaultThresholdEl);
-  if(!mGeoManager.loadGeometry(filename, geoname)) {
+  if (!mGeoManager.loadGeometry(filename, geoname)) {
     LOGP(fatal, "Load of geometry not successful");
   }
   createDigitsOutput();
@@ -124,8 +124,10 @@ void NA6PVerTelDigitizer::processHit(NA6PVerTelHit hit)
   float pitchX = NA6PVerTelSegmentation::ActiveDX / NA6PVerTelSegmentation::NColsPerTile;
   float pitchY = NA6PVerTelSegmentation::ActiveDYTile / NA6PVerTelSegmentation::NRowsPerTile;
   int nSteps = std::max(std::abs(deltaX) / pitchX, std::abs(deltaY) / pitchY);
-  if (nSteps < 1) nSteps = 1;
-  if (nSteps > 100) nSteps = 100;
+  if (nSteps < 1)
+    nSteps = 1;
+  if (nSteps > 100)
+    nSteps = 100;
   float chargePerStep = hit.getHitValue() * kGeVToEl / nSteps;
   float stepX = deltaX / nSteps;
   float stepY = deltaY / nSteps;
@@ -165,10 +167,10 @@ void NA6PVerTelDigitizer::finalizeDigits()
     auto iter = itBeg;
     for (; iter != buffer.end(); ++iter) {
       const auto& preDig = iter->second;
-      int jTile = jMod * NA6PVerTelSegmentation::NXTiles * NA6PVerTelSegmentation::NYSensors + NA6PVerTelSegmentation::NTilesPerRSU * preDig.pixID.rsu +  preDig.pixID.tile;
-      if (preDig.charge >= mThresholds[jTile]) {
+      int jTile = NA6PVerTelSegmentation::getTileId(jMod, preDig.pixID.rsu, preDig.pixID.tile);
+      if (jTile >= 0 && preDig.charge >= mThresholds[jTile]) {
         mDigits.emplace_back(static_cast<uint16_t>(jMod), preDig.pixID, preDig.particleID);
-        auto dig = mDigits.back();
+        // auto& dig = mDigits.back();
       }
     }
     buffer.erase(itBeg, iter); // erase processed entries; iter == end() for now

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -101,24 +101,57 @@ void NA6PVerTelDigitizer::process(const std::vector<NA6PVerTelHit>& hits, int la
   }
 }
 
+void NA6PVerTelDigitizer::getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3], double xyzLocE[3])
+{
+  auto modID = hit.getDetectorID();
+  auto& matrix = mMatrices[modID];
+
+  double xyzGloS[3] = {hit.getXIn(), hit.getYIn(), hit.getZIn()};
+  double xyzGloE[3] = {hit.getXOut(), hit.getYOut(), hit.getZOut()};
+
+  matrix.MasterToLocal(xyzGloS, xyzLocS);
+  xyzLocS[0] += mModuleHalfX[modID];
+  xyzLocS[1] += mModuleHalfY[modID];
+  matrix.MasterToLocal(xyzGloE, xyzLocE);
+  xyzLocE[0] += mModuleHalfX[modID];
+  xyzLocE[1] += mModuleHalfY[modID];
+  if (modID % kNModulesPerLayer == 1) {
+    // swap x
+    xyzLocS[0] = mModuleHalfX[modID] * 2. - xyzLocS[0];
+    xyzLocE[0] = mModuleHalfX[modID] * 2. - xyzLocE[0];
+  } else if (modID % kNModulesPerLayer == 2) {
+    // swap x and y
+    xyzLocS[0] = mModuleHalfX[modID] * 2. - xyzLocS[0];
+    xyzLocS[1] = mModuleHalfY[modID] * 2. - xyzLocS[1];
+    xyzLocE[0] = mModuleHalfX[modID] * 2. - xyzLocE[0];
+    xyzLocE[1] = mModuleHalfY[modID] * 2. - xyzLocE[1];
+  } else if (modID % kNModulesPerLayer == 3) {
+    // swap y
+    xyzLocS[1] = mModuleHalfY[modID] * 2. - xyzLocS[1];
+    xyzLocE[1] = mModuleHalfY[modID] * 2. - xyzLocE[1];
+  }
+}
+
 void NA6PVerTelDigitizer::processHit(NA6PVerTelHit hit)
 {
   auto modID = hit.getDetectorID();
-  printf("modID = %d\n", modID);
   auto& mod = mModules[modID];
   if (mod.isDisabled()) {
     LOGP(info, "Skipping disabled module {}", modID);
     return;
   }
-  auto& matrix = mMatrices[modID];
-
-  double xyzGloS[3] = {hit.getXIn(), hit.getYIn(), hit.getZIn()};
-  double xyzGloE[3] = {hit.getXOut(), hit.getYOut(), hit.getZOut()};
-  printf("Global coordinates = %f %f %f\n", xyzGloS[0], xyzGloS[1], xyzGloS[2]);
-
   double xyzLocS[3], xyzLocE[3];
-  matrix.MasterToLocal(xyzGloS, xyzLocS);
-  xyzLocS[0] += mModuleHalfX[modID];
-  xyzLocS[1] += mModuleHalfY[modID];
-  printf("Local coordinates: %f %f %f\n", xyzLocS[0], xyzLocS[1], xyzLocS[2]);
+  getHitLocalCoord(hit, xyzLocS, xyzLocE);
+  int rsu, tile, row, col;
+  bool digOk = mSegmentation.localToIndices(xyzLocS[0], xyzLocS[1], rsu, tile, row, col);
+  if (digOk) {
+    auto key = mod.getOrderingKey(rsu, tile, row, col);
+    PreDigit* pd = mod.findDigit(key);
+    if (!pd) {
+      mod.addDigit(key, rsu, tile, row, col, hit.getHitValue(), hit.getTrackID());
+    } else { // there is already a digit at this slot, account as PreDigitExtra contribution
+      pd->charge += hit.getHitValue();
+      // to be added: treat multiple particles (getTrackID) in the same pre-digit
+    }
+  }
 }

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -19,7 +19,7 @@ void NA6PVerTelDigitizer::init(const char* filename, const char* geoname)
   mNumberOfModules = param.nVerTelPlanes * kNModulesPerLayer;
   mModules.resize(mNumberOfModules);
   mMatrices.resize(mNumberOfModules);
-  mThresholds.assign(mNumberOfModules, kDefaultThresholdEl);
+  mThresholds.assign(mNumberOfModules * NA6PVerTelSegmentation::NXTiles * NA6PVerTelSegmentation::NYSensors, kDefaultThresholdEl);
 
   if (!gGeoManager) {
     TFile* f = TFile::Open(filename);
@@ -177,17 +177,35 @@ void NA6PVerTelDigitizer::processHit(NA6PVerTelHit hit)
   }
   double xyzLocS[3], xyzLocE[3];
   getHitLocalCoord(hit, xyzLocS, xyzLocE);
-  UShort_t rsu, tile, row, col;
-  bool digOk = mSegmentation.localToIndices(xyzLocS[0], xyzLocS[1], rsu, tile, row, col);
-  if (digOk) {
-    auto key = mod.getOrderingKey(rsu, tile, row, col);
-    PreDigit* pd = mod.findDigit(key);
-    if (!pd) {
-      mod.addDigit(key, rsu, tile, row, col, hit.getHitValue() * kGeVToEl, hit.getTrackID());
-    } else { // there is already a digit at this slot, account as PreDigitExtra contribution
-      pd->charge += hit.getHitValue() * kGeVToEl;
-      // to be added: treat multiple particles (getTrackID) in the same pre-digit
+  // we assume for the time being that the charge is deposited uniformly along all the 50 um Si thickness
+  // -> to be improved once we have a better knowledge of charge collection in MOSAIX
+  double deltaX = xyzLocE[0] - xyzLocS[0];
+  double deltaY = xyzLocE[1] - xyzLocS[1];
+  float pitchX = NA6PVerTelSegmentation::ActiveDX / NA6PVerTelSegmentation::NColsPerTile;
+  float pitchY = NA6PVerTelSegmentation::ActiveDYTile / NA6PVerTelSegmentation::NRowsPerTile;
+  int nSteps = std::max(std::abs(deltaX) / pitchX, std::abs(deltaY) / pitchY);
+  if (nSteps < 1) nSteps = 1;
+  if (nSteps > 100) nSteps = 100;
+  float chargePerStep = hit.getHitValue() * kGeVToEl / nSteps;
+  float stepX = deltaX / nSteps;
+  float stepY = deltaY / nSteps;
+  float x = static_cast<float>(xyzLocS[0]) + 0.5f * stepX;
+  float y = static_cast<float>(xyzLocS[1]) + 0.5f * stepY;
+  for (int iStep = 0; iStep < nSteps; ++iStep) {
+    UShort_t rsu, tile, row, col;
+    bool digOk = mSegmentation.localToIndices(x, y, rsu, tile, row, col);
+    if (digOk) {
+      auto key = mod.getOrderingKey(rsu, tile, row, col);
+      PreDigit* pd = mod.findDigit(key);
+      if (!pd) {
+        mod.addDigit(key, rsu, tile, row, col, chargePerStep, hit.getTrackID());
+      } else { // there is already a digit at this slot, account as PreDigitExtra contribution
+        pd->charge += chargePerStep;
+        // to be added: treat multiple particles (getTrackID) in the same pre-digit
+      }
     }
+    x += stepX;
+    y += stepY;
   }
 }
 
@@ -207,7 +225,8 @@ void NA6PVerTelDigitizer::finalizeDigits()
     auto iter = itBeg;
     for (; iter != buffer.end(); ++iter) {
       const auto& preDig = iter->second;
-      if (preDig.charge >= mThresholds[jMod]) {
+      int jTile = jMod * NA6PVerTelSegmentation::NXTiles * NA6PVerTelSegmentation::NYSensors + NA6PVerTelSegmentation::NTilesPerRSU * preDig.pixID.rsu +  preDig.pixID.tile;
+      if (preDig.charge >= mThresholds[jTile]) {
         mDigits.emplace_back(static_cast<uint16_t>(jMod), preDig.pixID, preDig.particleID);
         auto dig = mDigits.back();
       }

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -16,71 +16,11 @@
 void NA6PVerTelDigitizer::init(const char* filename, const char* geoname)
 {
   const auto& param = NA6PLayoutParam::Instance();
-  mNumberOfModules = param.nVerTelPlanes * kNModulesPerLayer;
+  mNumberOfModules = param.nVerTelPlanes * NA6PGeometryManager::kNVTModulesPerLayer;
   mModules.resize(mNumberOfModules);
-  mMatrices.resize(mNumberOfModules);
   mThresholds.assign(mNumberOfModules * NA6PVerTelSegmentation::NXTiles * NA6PVerTelSegmentation::NYSensors, kDefaultThresholdEl);
-
-  if (!gGeoManager) {
-    TFile* f = TFile::Open(filename);
-    if (!f || f->IsZombie()) {
-      LOGP(error, "Cannot open geometry file {}", filename);
-      return;
-    }
-    gGeoManager = (TGeoManager*)f->Get(geoname);
-    if (!gGeoManager) {
-      LOGP(error, "No geometry with name {} found in file {}", geoname, filename);
-      f->Close();
-      return;
-    }
-    f->Close();
-  }
-
-  std::vector<bool> isMatrixLoaded;
-  isMatrixLoaded.assign(mNumberOfModules, false);
-  mModuleHalfX.assign(mNumberOfModules, 0.);
-  mModuleHalfY.assign(mNumberOfModules, 0.);
-  TGeoIterator next(gGeoManager->GetTopVolume());
-  TGeoNode* node = nullptr;
-  while ((node = next())) {
-    TString name = node->GetName();
-    if (name.BeginsWith("PixelSensor_")) {
-      Int_t currentLevel = next.GetLevel();
-      if (currentLevel <= 0)
-        continue;
-      TGeoVolume* vol = node->GetVolume();
-      if (!vol) {
-        LOGP(error, "Volume null pointer");
-        continue;
-      }
-      TGeoShape* shape = vol->GetShape();
-      if (!shape) {
-        LOGP(error, "Shape null pointer");
-        continue;
-      }
-      if (shape->IsA() != TGeoBBox::Class()) {
-        LOGP(error, "Module shape is not a TGeoBBox");
-        continue;
-      }
-      TGeoNode* motherNode = next.GetNode(currentLevel - 1);
-      int layer = motherNode->GetNumber() % 10;
-      int modNum = node->GetNumber() % 10;
-      int modIndex = kNModulesPerLayer * layer + modNum;
-      if (modIndex < 0 || modIndex >= mNumberOfModules) {
-        LOGP(error, "Wrong module index {} (layer={}, modNum={})", modIndex, layer, modNum);
-        continue;
-      }
-      mMatrices[modIndex] = *(next.GetCurrentMatrix());
-      TGeoBBox* box = static_cast<TGeoBBox*>(shape);
-      mModuleHalfX[modIndex] = static_cast<float>(box->GetDX());
-      mModuleHalfY[modIndex] = static_cast<float>(box->GetDY());
-      isMatrixLoaded[modIndex] = true;
-    }
-  }
-  for (int im = 0; im < mNumberOfModules; ++im) {
-    if (!isMatrixLoaded[im]) {
-      LOGP(error, "Matrix not loaded for module {}", im);
-    }
+  if(!mGeoManager.loadGeometry(filename, geoname)) {
+    LOGP(fatal, "Load of geometry not successful");
   }
   createDigitsOutput();
 }
@@ -139,31 +79,31 @@ void NA6PVerTelDigitizer::process(const std::vector<NA6PVerTelHit>& hits, int la
 void NA6PVerTelDigitizer::getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3], double xyzLocE[3])
 {
   auto modID = hit.getDetectorID();
-  auto& matrix = mMatrices[modID];
+  auto& matrix = mGeoManager.getMatrix(modID);
 
   double xyzGloS[3] = {hit.getXIn(), hit.getYIn(), hit.getZIn()};
   double xyzGloE[3] = {hit.getXOut(), hit.getYOut(), hit.getZOut()};
 
   matrix.MasterToLocal(xyzGloS, xyzLocS);
-  xyzLocS[0] += mModuleHalfX[modID];
-  xyzLocS[1] += mModuleHalfY[modID];
+  xyzLocS[0] += mGeoManager.getModuleHalfX(modID);
+  xyzLocS[1] += mGeoManager.getModuleHalfY(modID);
   matrix.MasterToLocal(xyzGloE, xyzLocE);
-  xyzLocE[0] += mModuleHalfX[modID];
-  xyzLocE[1] += mModuleHalfY[modID];
-  if (modID % kNModulesPerLayer == 1) {
+  xyzLocE[0] += mGeoManager.getModuleHalfX(modID);
+  xyzLocE[1] += mGeoManager.getModuleHalfY(modID);
+  if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 1) {
     // swap x
-    xyzLocS[0] = mModuleHalfX[modID] * 2. - xyzLocS[0];
-    xyzLocE[0] = mModuleHalfX[modID] * 2. - xyzLocE[0];
-  } else if (modID % kNModulesPerLayer == 2) {
+    xyzLocS[0] = mGeoManager.getModuleFullX(modID) - xyzLocS[0];
+    xyzLocE[0] = mGeoManager.getModuleFullX(modID) - xyzLocE[0];
+  } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 2) {
     // swap x and y
-    xyzLocS[0] = mModuleHalfX[modID] * 2. - xyzLocS[0];
-    xyzLocS[1] = mModuleHalfY[modID] * 2. - xyzLocS[1];
-    xyzLocE[0] = mModuleHalfX[modID] * 2. - xyzLocE[0];
-    xyzLocE[1] = mModuleHalfY[modID] * 2. - xyzLocE[1];
-  } else if (modID % kNModulesPerLayer == 3) {
+    xyzLocS[0] = mGeoManager.getModuleFullX(modID) - xyzLocS[0];
+    xyzLocS[1] = mGeoManager.getModuleFullY(modID) - xyzLocS[1];
+    xyzLocE[0] = mGeoManager.getModuleFullX(modID) - xyzLocE[0];
+    xyzLocE[1] = mGeoManager.getModuleFullY(modID) - xyzLocE[1];
+  } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 3) {
     // swap y
-    xyzLocS[1] = mModuleHalfY[modID] * 2. - xyzLocS[1];
-    xyzLocE[1] = mModuleHalfY[modID] * 2. - xyzLocE[1];
+    xyzLocS[1] = mGeoManager.getModuleFullY(modID) - xyzLocS[1];
+    xyzLocE[1] = mGeoManager.getModuleFullY(modID) - xyzLocE[1];
   }
 }
 

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -10,7 +10,6 @@
 #include <TTree.h>
 
 #include "NA6PLayoutParam.h"
-#include "NA6PVerTelHit.h"
 #include "NA6PVerTelDigitizer.h"
 
 void NA6PVerTelDigitizer::init(const char* filename, const char* geoname)
@@ -19,10 +18,15 @@ void NA6PVerTelDigitizer::init(const char* filename, const char* geoname)
   mNumberOfModules = param.nVerTelPlanes * NA6PGeometryManager::kNVTModulesPerLayer;
   mModules.resize(mNumberOfModules);
   mThresholds.assign(mNumberOfModules * NA6PVerTelSegmentation::NXTiles * NA6PVerTelSegmentation::NYSensors, kDefaultThresholdEl);
+  initGeometry(filename, geoname);
+  createDigitsOutput();
+}
+
+void NA6PVerTelDigitizer::initGeometry(const char* filename, const char* geoname)
+{
   if (!mGeoManager.loadGeometry(filename, geoname)) {
     LOGP(fatal, "Load of geometry not successful");
   }
-  createDigitsOutput();
 }
 
 void NA6PVerTelDigitizer::createDigitsOutput()

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -19,6 +19,7 @@ void NA6PVerTelDigitizer::init(const char* filename, const char* geoname)
   mNumberOfModules = param.nVerTelPlanes * kNModulesPerLayer;
   mModules.resize(mNumberOfModules);
   mMatrices.resize(mNumberOfModules);
+  mThresholds.assign(mNumberOfModules, kDefaultThresholdEl);
 
   if (!gGeoManager) {
     TFile* f = TFile::Open(filename);
@@ -111,7 +112,7 @@ void NA6PVerTelDigitizer::writeDigits()
   if (mDigitsTree) {
     mDigitsTree->Fill();
   }
-  LOGP(info, "Saved {} clustersdigits in tree with {} entries", mDigits.size(), mDigitsTree->GetEntries());
+  LOGP(info, "Saved {} digits in tree with {} entries", mDigits.size(), mDigitsTree->GetEntries());
 }
 
 void NA6PVerTelDigitizer::process(const std::vector<NA6PVerTelHit>& hits, int layer)
@@ -131,6 +132,8 @@ void NA6PVerTelDigitizer::process(const std::vector<NA6PVerTelHit>& hits, int la
                })) {
     processHit(hits[i]);
   }
+  finalizeDigits();
+  writeDigits();
 }
 
 void NA6PVerTelDigitizer::getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3], double xyzLocE[3])
@@ -180,10 +183,35 @@ void NA6PVerTelDigitizer::processHit(NA6PVerTelHit hit)
     auto key = mod.getOrderingKey(rsu, tile, row, col);
     PreDigit* pd = mod.findDigit(key);
     if (!pd) {
-      mod.addDigit(key, rsu, tile, row, col, hit.getHitValue(), hit.getTrackID());
+      mod.addDigit(key, rsu, tile, row, col, hit.getHitValue() * kGeVToEl, hit.getTrackID());
     } else { // there is already a digit at this slot, account as PreDigitExtra contribution
-      pd->charge += hit.getHitValue();
+      pd->charge += hit.getHitValue() * kGeVToEl;
       // to be added: treat multiple particles (getTrackID) in the same pre-digit
     }
+  }
+}
+
+void NA6PVerTelDigitizer::finalizeDigits()
+{
+  for (int jMod = 0; jMod < mNumberOfModules; ++jMod) {
+    auto& mod = mModules[jMod];
+    if (mod.isDisabled()) {
+      LOGP(info, "Skipping disabled module {}", jMod);
+      continue;
+    }
+    auto& buffer = mod.getPreDigits();
+    if (buffer.empty()) {
+      continue;
+    }
+    auto itBeg = buffer.begin();
+    auto iter = itBeg;
+    for (; iter != buffer.end(); ++iter) {
+      const auto& preDig = iter->second;
+      if (preDig.charge >= mThresholds[jMod]) {
+        mDigits.emplace_back(static_cast<uint16_t>(jMod), preDig.pixID, preDig.particleID);
+        auto dig = mDigits.back();
+      }
+    }
+    buffer.erase(itBeg, iter); // erase processed entries; iter == end() for now
   }
 }

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -6,14 +6,14 @@
 #include <TGeoNode.h>
 #include <TGeoBBox.h>
 #include <TGeoManager.h>
+#include <TFile.h>
+#include <TTree.h>
 
 #include "NA6PLayoutParam.h"
 #include "NA6PVerTelHit.h"
 #include "NA6PVerTelDigitizer.h"
 
-ClassImp(NA6PVerTelDigitizer)
-
-  void NA6PVerTelDigitizer::init(const char* filename, const char* geoname)
+void NA6PVerTelDigitizer::init(const char* filename, const char* geoname)
 {
   const auto& param = NA6PLayoutParam::Instance();
   mNumberOfModules = param.nVerTelPlanes * kNModulesPerLayer;
@@ -81,10 +81,42 @@ ClassImp(NA6PVerTelDigitizer)
       LOGP(error, "Matrix not loaded for module {}", im);
     }
   }
+  createDigitsOutput();
+}
+
+void NA6PVerTelDigitizer::createDigitsOutput()
+{
+  auto nm = fmt::format("Digits{}.root", getName());
+  mDigitsFile = TFile::Open(nm.c_str(), "recreate");
+  mDigitsTree = new TTree(fmt::format("digits{}", getName()).c_str(), fmt::format("{} Digits", getName()).c_str());
+  mDigitsTree->Branch(getName().c_str(), &hDigitsPtr);
+  LOGP(info, "Will store {} hits in {}", getName(), nm);
+}
+
+void NA6PVerTelDigitizer::closeDigitsOutput()
+{
+  if (mDigitsTree && mDigitsFile) {
+    mDigitsFile->cd();
+    mDigitsTree->Write();
+    delete mDigitsTree;
+    mDigitsTree = nullptr;
+    mDigitsFile->Close();
+    delete mDigitsFile;
+    mDigitsFile = nullptr;
+  }
+}
+
+void NA6PVerTelDigitizer::writeDigits()
+{
+  if (mDigitsTree) {
+    mDigitsTree->Fill();
+  }
+  LOGP(info, "Saved {} clustersdigits in tree with {} entries", mDigits.size(), mDigitsTree->GetEntries());
 }
 
 void NA6PVerTelDigitizer::process(const std::vector<NA6PVerTelHit>& hits, int layer)
 {
+  clearDigits();
   int nHits = hits.size();
   std::vector<int> hitIdx(nHits);
   std::iota(std::begin(hitIdx), std::end(hitIdx), 0);
@@ -142,7 +174,7 @@ void NA6PVerTelDigitizer::processHit(NA6PVerTelHit hit)
   }
   double xyzLocS[3], xyzLocE[3];
   getHitLocalCoord(hit, xyzLocS, xyzLocE);
-  int rsu, tile, row, col;
+  UShort_t rsu, tile, row, col;
   bool digOk = mSegmentation.localToIndices(xyzLocS[0], xyzLocS[1], rsu, tile, row, col);
   if (digOk) {
     auto key = mod.getOrderingKey(rsu, tile, row, col);

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -77,7 +77,7 @@ void NA6PVerTelDigitizer::process(const std::vector<NA6PVerTelHit>& hits, int la
   writeDigits();
 }
 
-void NA6PVerTelDigitizer::getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3], double xyzLocE[3])
+void NA6PVerTelDigitizer::getHitLocalCoord(const NA6PVerTelHit& hit, double xyzLocS[3], double xyzLocE[3])
 {
   auto modID = hit.getDetectorID();
   auto& matrix = mGeoManager.getMatrix(modID);
@@ -108,7 +108,7 @@ void NA6PVerTelDigitizer::getHitLocalCoord(NA6PVerTelHit hit, double xyzLocS[3],
   }
 }
 
-void NA6PVerTelDigitizer::processHit(NA6PVerTelHit hit)
+void NA6PVerTelDigitizer::processHit(const NA6PVerTelHit& hit)
 {
   auto modID = hit.getDetectorID();
   auto& mod = mModules[modID];

--- a/sim/src/NA6PVerTelSegmentation.cxx
+++ b/sim/src/NA6PVerTelSegmentation.cxx
@@ -20,8 +20,8 @@ void NA6PVerTelSegmentation::setStaggered(bool val)
 
 bool NA6PVerTelSegmentation::computePixelIndices(float xloc, float yloc,
                                                  float deadYBottom, float deadYTop,
-                                                 int& rsu, int& tile,
-                                                 int& row, int& col) const
+                                                 UShort_t& rsu, UShort_t& tile,
+                                                 UShort_t& row, UShort_t& col) const
 {
   int sens = int(yloc / DYSens);
   yloc -= sens * DYSens;
@@ -47,10 +47,10 @@ bool NA6PVerTelSegmentation::computePixelIndices(float xloc, float yloc,
   // map segm [0-11] and topbot [0-1] and tileIdx [0-2] to rsu [0-41] and tile [0-11]
   int rsuX = segm / NSegmentsPerRSU;
   int segInRsu = segm % NSegmentsPerRSU;
-  rsu = sens * (NXSegments / NSegmentsPerRSU) + rsuX;
-  tile = topbot * (NSegmentsPerRSU * NTilesPerSegment) + segInRsu * NTilesPerSegment + tileIdx;
-  col = static_cast<int>(xloc / ActiveDX * NColsPerTile);
-  row = static_cast<int>(yloc / ActiveDYTile * NRowsPerTile);
+  rsu = static_cast<UShort_t>(sens * (NXSegments / NSegmentsPerRSU) + rsuX);
+  tile = static_cast<UShort_t>(topbot * (NSegmentsPerRSU * NTilesPerSegment) + segInRsu * NTilesPerSegment + tileIdx);
+  col = static_cast<UShort_t>(xloc / ActiveDX * NColsPerTile);
+  row = static_cast<UShort_t>(yloc / ActiveDYTile * NRowsPerTile);
   return true;
 }
 
@@ -84,11 +84,11 @@ int NA6PVerTelSegmentation::isInAcc(float xglo, float yglo) const
 
   float xloc = xglo;
   float yloc = yglo;
-  int rsu, tile, row, col;
+  UShort_t rsu, tile, row, col;
   return computePixelIndices(xloc, yloc, mDeadYBottomEff, mDeadYTopEff, rsu, tile, row, col) ? 1 : -1;
 }
 
-bool NA6PVerTelSegmentation::localToIndices(float xloc, float yloc, int& rsu, int& tile, int& row, int& col) const
+bool NA6PVerTelSegmentation::localToIndices(float xloc, float yloc, UShort_t& rsu, UShort_t& tile, UShort_t& row, UShort_t& col) const
 {
   rsu = tile = row = col = -1;
   if (xloc < 0 || xloc > XSizeTot || yloc < 0 || yloc > YSizeTot)
@@ -100,22 +100,22 @@ bool NA6PVerTelSegmentation::localToIndices(float xloc, float yloc, int& rsu, in
   xloc -= DeadXShort;
 
   bool isOk = computePixelIndices(xloc, yloc, DeadYBottom, DeadYTop, rsu, tile, row, col);
-  if (!isOk || col < 0 || col >= NColsPerTile || row < 0 || row >= NRowsPerTile) {
+  if (!isOk || col >= NColsPerTile || row >= NRowsPerTile) {
     return false;
   }
   return true;
 }
 
-bool NA6PVerTelSegmentation::indicesToLocal(int rsu, int tile, int row, int col, float& xloc, float& yloc) const
+bool NA6PVerTelSegmentation::indicesToLocal(UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col, float& xloc, float& yloc) const
 {
   xloc = yloc = -9999.f;
-  if (rsu < 0 || rsu >= NYSensors * (NXSegments / NSegmentsPerRSU))
+  if (rsu >= NYSensors * (NXSegments / NSegmentsPerRSU))
     return false;
-  if (tile < 0 || tile >= NTilesPerSegment * NSegmentsPerRSU * 2)
+  if (tile >= NTilesPerSegment * NSegmentsPerRSU * 2)
     return false;
-  if (row < 0 || row >= NRowsPerTile)
+  if (row >= NRowsPerTile)
     return false;
-  if (col < 0 || col >= NColsPerTile)
+  if (col >= NColsPerTile)
     return false;
 
   float xInTile = (col + 0.5f) * ActiveDX / NColsPerTile;

--- a/sim/src/NA6PVerTelSegmentation.cxx
+++ b/sim/src/NA6PVerTelSegmentation.cxx
@@ -4,12 +4,14 @@
 
 void NA6PVerTelSegmentation::setStaggered(bool val)
 {
+  // emulate the configuration with sensor acceptance overlaps
   mStaggered = val;
   if (val) {
     mDeadXLongEff = DeadXLong + DeadXShort;
     mDeadXShortEff = 0.f;
     mDeadYTopEff = DeadYTop + DeadYBottom;
     mDeadYBottomEff = 0.f;
+    mInterChipGap = 0.f;
   } else {
     mDeadXLongEff = DeadXLong;
     mDeadXShortEff = DeadXShort;
@@ -54,36 +56,20 @@ bool NA6PVerTelSegmentation::computePixelIndices(float xloc, float yloc,
   return true;
 }
 
-int NA6PVerTelSegmentation::isInAcc(float xglo, float yglo) const
+int NA6PVerTelSegmentation::isInAcc(float xloc, float yloc) const
 {
+  // method used in hitsToRecPoints to account for inactive regions of MOSAIX
 
-  float absOffX = std::abs(mOffsX) - mInterChipGap / 2;
-  float absOffY = std::abs(mOffsY) - mInterChipGap / 2;
-  if ((xglo < -absOffX && yglo < absOffY) ||
-      (xglo > -absOffX && yglo < -absOffY)) {
-    // flip signs for Q3 and Q4
-    xglo = -xglo;
-    yglo = -yglo;
-  }
+  xloc -= mInterChipGap / 2;
+  yloc -= mInterChipGap / 2;
 
-  xglo -= mOffsX;
-  if (xglo < 0.) { // Q2 + Q4
-    yglo += mOffsY - mInterChipGap / 2;
-    xglo += XSizeTot + mInterChipGap / 2; // relate to chip local left/bottom corner
-  } else {                                // Q1 + Q3
-    yglo -= mOffsY + mInterChipGap / 2;
-    xglo = (XSizeTot + mInterChipGap / 2) - xglo; // relate to chip local left/bottom corner
-  }
-
-  if (xglo < 0 || xglo > XSizeTot || yglo < 0 || yglo > YSizeTot)
+  if (xloc < 0 || xloc > XSizeTot || yloc < 0 || yloc > YSizeTot)
     return 0;
 
-  if (xglo < mDeadXLongEff || xglo > XSizeTot - mDeadXShortEff || yglo < mDeadYBottomEff || yglo > YSizeTot - mDeadYTopEff)
+  if (xloc < mDeadXShortEff || xloc > XSizeTot - mDeadXLongEff || yloc < mDeadYBottomEff || yloc > YSizeTot - mDeadYTopEff)
     return -1;
-  xglo -= mDeadXLongEff;
+  xloc -= mDeadXShortEff;
 
-  float xloc = xglo;
-  float yloc = yglo;
   UShort_t rsu, tile, row, col;
   return computePixelIndices(xloc, yloc, mDeadYBottomEff, mDeadYTopEff, rsu, tile, row, col) ? 1 : -1;
 }

--- a/sim/src/NA6PVerTelSegmentation.cxx
+++ b/sim/src/NA6PVerTelSegmentation.cxx
@@ -18,49 +18,117 @@ void NA6PVerTelSegmentation::setStaggered(bool val)
   }
 }
 
-int NA6PVerTelSegmentation::isInAcc(float x, float y) const
+bool NA6PVerTelSegmentation::computePixelIndices(float xloc, float yloc,
+                                                 float deadYBottom, float deadYTop,
+                                                 int& rsu, int& tile,
+                                                 int& row, int& col) const
+{
+  int sens = int(yloc / DYSens);
+  yloc -= sens * DYSens;
+  if (yloc < deadYBottom || yloc > DYSens - deadYTop)
+    return false;
+  yloc -= deadYBottom;
+
+  int topbot = int(yloc / ActiveDYHalf);
+  yloc -= topbot * ActiveDYHalf;
+  if (yloc < DeadTopBotHalves / 2)
+    return false;
+  yloc -= DeadTopBotHalves / 2;
+  int segm = int(xloc / DXSegment);
+  xloc -= segm * DXSegment;
+  if (xloc > DXSegment - DeadXDataBackbone)
+    return false;
+  int tileIdx = int(xloc / DXTile);
+  xloc -= tileIdx * DXTile;
+  if (xloc < DeadXTile)
+    return false;
+  xloc -= DeadXTile;
+
+  // map segm [0-11] and topbot [0-1] and tileIdx [0-2] to rsu [0-41] and tile [0-11]
+  int rsuX = segm / NSegmentsPerRSU;
+  int segInRsu = segm % NSegmentsPerRSU;
+  rsu = sens * (NXSegments / NSegmentsPerRSU) + rsuX;
+  tile = topbot * (NSegmentsPerRSU * NTilesPerSegment) + segInRsu * NTilesPerSegment + tileIdx;
+  col = static_cast<int>(xloc / ActiveDX * NColsPerTile);
+  row = static_cast<int>(yloc / ActiveDYTile * NRowsPerTile);
+  return true;
+}
+
+int NA6PVerTelSegmentation::isInAcc(float xglo, float yglo) const
 {
 
   float absOffX = std::abs(mOffsX) - mInterChipGap / 2;
   float absOffY = std::abs(mOffsY) - mInterChipGap / 2;
-  if ((x < -absOffX && y < absOffY) ||
-      (x > -absOffX && y < -absOffY)) {
+  if ((xglo < -absOffX && yglo < absOffY) ||
+      (xglo > -absOffX && yglo < -absOffY)) {
     // flip signs for Q3 and Q4
-    x = -x;
-    y = -y;
+    xglo = -xglo;
+    yglo = -yglo;
   }
 
-  x -= mOffsX;
-  if (x < 0.) { // Q2 + Q4
-    y += mOffsY - mInterChipGap / 2;
-    x += XSizeTot + mInterChipGap / 2; // relate to chip local left/bottom corner
-  } else {                             // Q1 + Q3
-    y -= mOffsY + mInterChipGap / 2;
-    x = (XSizeTot + mInterChipGap / 2) - x; // relate to chip local left/bottom corner
+  xglo -= mOffsX;
+  if (xglo < 0.) { // Q2 + Q4
+    yglo += mOffsY - mInterChipGap / 2;
+    xglo += XSizeTot + mInterChipGap / 2; // relate to chip local left/bottom corner
+  } else {                                // Q1 + Q3
+    yglo -= mOffsY + mInterChipGap / 2;
+    xglo = (XSizeTot + mInterChipGap / 2) - xglo; // relate to chip local left/bottom corner
   }
 
-  if (x < 0 || x > XSizeTot || y < 0 || y > YSizeTot)
+  if (xglo < 0 || xglo > XSizeTot || yglo < 0 || yglo > YSizeTot)
     return 0;
 
-  if (x < mDeadXLongEff || x > XSizeTot - mDeadXShortEff || y < mDeadYBottomEff || y > YSizeTot - mDeadYTopEff)
+  if (xglo < mDeadXLongEff || xglo > XSizeTot - mDeadXShortEff || yglo < mDeadYBottomEff || yglo > YSizeTot - mDeadYTopEff)
     return -1;
-  x -= mDeadXLongEff;
-  int sens = int(y / DYSens);
-  y -= sens * DYSens;
-  if (y < mDeadYBottomEff || y > DYSens - mDeadYTopEff)
-    return -1;
-  int topbot = int(y / (DYSens / 2));
-  y -= topbot * (DYSens / 2);
-  if (y < DeadTopBotHalves / 2)
-    return -1;
-  int segm = int(x / DXSegment);
-  x -= segm * DXSegment;
-  if (x > DXSegment - DeadXDataBackbone)
-    return -1;
-  int tile = int(x / DXTile);
-  x -= tile * DXTile;
-  if (x < DeadXTile)
-    return -1;
+  xglo -= mDeadXLongEff;
 
-  return 1;
+  float xloc = xglo;
+  float yloc = yglo;
+  int rsu, tile, row, col;
+  return computePixelIndices(xloc, yloc, mDeadYBottomEff, mDeadYTopEff, rsu, tile, row, col) ? 1 : -1;
+}
+
+bool NA6PVerTelSegmentation::localToIndices(float xloc, float yloc, int& rsu, int& tile, int& row, int& col) const
+{
+  rsu = tile = row = col = -1;
+  if (xloc < 0 || xloc > XSizeTot || yloc < 0 || yloc > YSizeTot)
+    return false;
+
+  if (xloc < DeadXShort || xloc > XSizeTot - DeadXLong || yloc < DeadYBottom || yloc > YSizeTot - DeadYTop)
+    return false;
+
+  xloc -= DeadXShort;
+
+  bool isOk = computePixelIndices(xloc, yloc, DeadYBottom, DeadYTop, rsu, tile, row, col);
+  if (!isOk || col < 0 || col >= NColsPerTile || row < 0 || row >= NRowsPerTile) {
+    return false;
+  }
+  return true;
+}
+
+bool NA6PVerTelSegmentation::indicesToLocal(int rsu, int tile, int row, int col, float& xloc, float& yloc) const
+{
+  xloc = yloc = -9999.f;
+  if (rsu < 0 || rsu >= NYSensors * (NXSegments / NSegmentsPerRSU))
+    return false;
+  if (tile < 0 || tile >= NTilesPerSegment * NSegmentsPerRSU * 2)
+    return false;
+  if (row < 0 || row >= NRowsPerTile)
+    return false;
+  if (col < 0 || col >= NColsPerTile)
+    return false;
+
+  float xInTile = (col + 0.5f) * ActiveDX / NColsPerTile;
+  float yInTile = (row + 0.5f) * ActiveDYTile / NRowsPerTile;
+  int tileIdx = tile % NTilesPerSegment;
+  int segInRsu = (tile / NTilesPerSegment) % NSegmentsPerRSU;
+  int topbot = tile / (NTilesPerSegment * NSegmentsPerRSU);
+  float xInSegm = xInTile + DeadXTile + tileIdx * DXTile;
+  int rsuX = rsu % (NXSegments / NSegmentsPerRSU);
+  int segm = NSegmentsPerRSU * rsuX + segInRsu;
+  xloc = xInSegm + segm * DXSegment + DeadXShort;
+  float yinRsu = yInTile + DeadTopBotHalves / 2 + topbot * ActiveDYHalf;
+  int rsuY = rsu / (NXSegments / NSegmentsPerRSU);
+  yloc = yinRsu + rsuY * DYSens + DeadYBottom;
+  return true;
 }

--- a/sim/src/simLinkDef.h
+++ b/sim/src/simLinkDef.h
@@ -24,6 +24,7 @@
 #pragma link C++ class NA6PMuonSpecModularHit + ;
 #pragma link C++ class std::vector < NA6PMuonSpecModularHit> + ;
 
+#pragma link C++ struct VTPixID+;
 #pragma link C++ class NA6PVerTelDigit + ;
 #pragma link C++ class std::vector < NA6PVerTelDigit> + ;
 

--- a/sim/src/simLinkDef.h
+++ b/sim/src/simLinkDef.h
@@ -18,9 +18,6 @@
 #pragma link C++ class NA6PVerTelHit + ;
 #pragma link C++ class std::vector < NA6PVerTelHit> + ;
 
-#pragma link C++ class NA6PVerTelSegmentation + ;
-#pragma link C++ class std::vector < NA6PVerTelSegmentation> + ;
-
 #pragma link C++ class NA6PMuonSpecHit + ;
 #pragma link C++ class std::vector < NA6PMuonSpecHit> + ;
 
@@ -40,6 +37,9 @@
 #pragma link C++ class NA6PGenHepMC + ;
 #pragma link C++ class NA6PGenHisto + ;
 #pragma link C++ class NA6PGenCocktail + ;
+
+#pragma link C++ class NA6PVerTelSegmentation + ;
+#pragma link C++ class NA6PVerTelDigitizer + ;
 
 #pragma link C++ class std::vector < TParticle> + ;
 

--- a/sim/src/simLinkDef.h
+++ b/sim/src/simLinkDef.h
@@ -24,6 +24,9 @@
 #pragma link C++ class NA6PMuonSpecModularHit + ;
 #pragma link C++ class std::vector < NA6PMuonSpecModularHit> + ;
 
+#pragma link C++ class NA6PVerTelDigit + ;
+#pragma link C++ class std::vector < NA6PVerTelDigit> + ;
+
 #pragma link C++ class std::unordered_map < std::string, float> + ;
 
 #pragma link C++ class NA6PMCEventHeader + ;

--- a/test/hitsToDigits.C
+++ b/test/hitsToDigits.C
@@ -1,0 +1,79 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <Riostream.h>
+#include <TTree.h>
+#include <TFile.h>
+#include <TH2F.h>
+#include <TCanvas.h>
+#include <TParticle.h>
+#include <TParticlePDG.h>
+#include <TVector3.h>
+#include <TRandom3.h>
+#include "NA6PVerTelHit.h"
+#include "NA6PMuonSpecHit.h"
+#include "ConfigurableParam.h"
+#include <fairlogger/Logger.h>
+#include "NA6PVerTelDigitizer.h"
+#endif
+
+void hitsToDigits()
+{
+
+  // control histos
+  TH2F** hLocX = new TH2F*[5];
+  TH2F** hLocY = new TH2F*[5];
+  TH2F** hModID = new TH2F*[5];
+  for (int jl = 0; jl < 5; jl++) {
+    hLocX[jl] = new TH2F(Form("hLocX%d", jl), Form("Local x vs. global coord. Layer %d;x_{glo} (cm);y_{glo} (cm); x_{loc} (cm)", jl), 81, -15., 15., 81, -15., 15.);
+    hLocY[jl] = new TH2F(Form("hLocY%d", jl), Form("Local y vs. global coord. Layer %d;x_{glo} (cm);y_{glo} (cm); y_{loc} (cm)", jl), 81, -15., 15., 81, -15., 15.);
+    hModID[jl] = new TH2F(Form("hModId%d", jl), Form("Module ID vs. global coord. Layer %d;x_{glo} (cm);y_{glo} (cm)", jl), 8, -15., 15., 8, -15., 15.);
+    hLocX[jl]->SetStats(0);
+    hLocY[jl]->SetStats(0);
+    hModID[jl]->SetStats(0);
+  }
+
+  // Process VerTel hits
+  TFile* fhVT = TFile::Open("HitsVerTel.root");
+  if (!fhVT || fhVT->IsZombie()) {
+    LOGP(error, "Cannot open HitsVerTel.root");
+    if (fhVT)
+      delete fhVT;
+  } else {
+    TTree* thVT = (TTree*)fhVT->Get("hitsVerTel");
+    if (!thVT) {
+      LOGP(error, "Cannot find tree 'hitsVerTel' in HitsVerTel.root");
+    } else {
+      std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
+      thVT->SetBranchAddress("VerTel", &vtHitsPtr);
+      int nEvVT = thVT->GetEntriesFast();
+      NA6PVerTelDigitizer dig;
+      dig.init("geometry.root");
+      for (int jEv = 0; jEv < nEvVT; jEv++) {
+        thVT->GetEvent(jEv);
+        for (const auto& hit : vtHits) {
+          double xyzLocS[3], xyzLocE[3];
+          dig.getHitLocalCoord(hit, xyzLocS, xyzLocE);
+          int lay = dig.detID2Layer(hit.getDetectorID());
+          double xg = hit.getXIn();
+          double yg = hit.getYIn();
+          double zg = hit.getZIn();
+          hLocX[lay]->SetBinContent(hLocX[lay]->FindBin(xg, yg), xyzLocS[0]);
+          hLocY[lay]->SetBinContent(hLocY[lay]->FindBin(xg, yg), xyzLocS[1]);
+          hModID[lay]->SetBinContent(hModID[lay]->FindBin(xg, yg), hit.getDetectorID());
+        }
+        dig.process(vtHits);
+      }
+      dig.closeDigitsOutput();
+    }
+  }
+
+  TCanvas* c = new TCanvas("c", "", 1400, 800);
+  c->Divide(5, 2);
+  for (int jl = 0; jl < 5; jl++) {
+    c->cd(jl + 1);
+    gPad->SetRightMargin(0.14);
+    hLocX[jl]->Draw("colz");
+    c->cd(jl + 6);
+    gPad->SetRightMargin(0.14);
+    hLocY[jl]->Draw("colz");
+  }
+}

--- a/test/plotVerTelDigits.C
+++ b/test/plotVerTelDigits.C
@@ -37,8 +37,8 @@ void plotVerTelDigits(const char* dirSimu = ".")
   td->SetBranchAddress("VerTelMCTruth", &vtMCLabelsPtr);
 
   TH1F* hMCLabelsPerDigit = new TH1F("hMCLabelsPerDigit", ";n MC labels per digit; counts", 11, -0.5, 10.5);
-  TH1F* hMCFirstLabels = new TH1F("hMCFirstLabels", "MC label; counts", 200, 0., 4000.);
-  TH1F* hMCAllLabels = new TH1F("hMCAllLabels", "MC label; counts", 200, 0., 4000.);
+  TH1F* hMCFirstLabels = new TH1F("hMCFirstLabels", "First label only;MC label; counts", 200, 0., 4000.);
+  TH1F* hMCAllLabels = new TH1F("hMCAllLabels", "All labels;MC label; counts", 200, 0., 4000.);
   TH1F* hDigitsPerHitAll = new TH1F("hDigitsPerHitAll", "All particles;n digits per hit; counts", 11, -0.5, 10.5);
   TH1F* hDigitsPerHitPrim = new TH1F("hDigitsPerHitPrim", "Primary particles;n digits per hit; counts", 11, -0.5, 10.5);
   TH2F** hDigitsPerHitPrimVsX = new TH2F*[5];

--- a/test/plotVerTelDigits.C
+++ b/test/plotVerTelDigits.C
@@ -1,0 +1,239 @@
+#include <TFile.h>
+#include <TTree.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TStyle.h>
+#include <TProfile.h>
+#include <TCanvas.h>
+#include <TParticle.h>
+#include "NA6PVerTelHit.h"
+#include "NA6PMCTruthContainer.h"
+#include "NA6PVerTelDigit.h"
+#include "NA6PVerTelSegmentation.h"
+#include "NA6PGeometryManager.h"
+
+void plotVerTelDigits(const char* dirSimu = ".")
+{
+
+  NA6PGeometryManager geoMan;
+  geoMan.loadGeometry(Form("%s/geometry.root", dirSimu));
+  NA6PVerTelSegmentation vt;
+
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+
+  TFile* fh = new TFile(Form("%s/HitsVerTel.root", dirSimu));
+  TTree* th = (TTree*)fh->Get("hitsVerTel");
+  std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
+  th->SetBranchAddress("VerTel", &vtHitsPtr);
+
+  TFile* fd = TFile::Open(Form("%s/DigitsVerTel.root", dirSimu));
+  TTree* td = (TTree*)fd->Get("digitsVerTel");
+  std::vector<NA6PVerTelDigit> vtDigits, *vtDigitsPtr = &vtDigits;
+  NA6PMCTruthContainer vtMCLabels, *vtMCLabelsPtr = &vtMCLabels;
+  td->SetBranchAddress("VerTel", &vtDigitsPtr);
+  td->SetBranchAddress("VerTelMCTruth", &vtMCLabelsPtr);
+
+  TH1F* hMCLabelsPerDigit = new TH1F("hMCLabelsPerDigit", ";n MC labels per digit; counts", 11, -0.5, 10.5);
+  TH1F* hMCFirstLabels = new TH1F("hMCFirstLabels", "MC label; counts", 200, 0., 4000.);
+  TH1F* hMCAllLabels = new TH1F("hMCAllLabels", "MC label; counts", 200, 0., 4000.);
+  TH1F* hDigitsPerHitAll = new TH1F("hDigitsPerHitAll", "All particles;n digits per hit; counts", 11, -0.5, 10.5);
+  TH1F* hDigitsPerHitPrim = new TH1F("hDigitsPerHitPrim", "Primary particles;n digits per hit; counts", 11, -0.5, 10.5);
+  TH2F** hDigitsPerHitPrimVsX = new TH2F*[5];
+  TH2F** hDigitsPerHitPrimVsY = new TH2F*[5];
+  TProfile* pDigitsPerHitPrimVsX[5];
+  TProfile* pDigitsPerHitPrimVsY[5];
+  for (int jLay = 0; jLay < 5; ++jLay) {
+    hDigitsPerHitPrimVsX[jLay] = new TH2F(Form("hDigitsPerHitPrimVsX%d", jLay), "Primary particles;x (cm);n digits per hit; counts", 30, -15., 15., 8, -0.5, 7.5);
+    hDigitsPerHitPrimVsY[jLay] = new TH2F(Form("hDigitsPerHitPrimVsY%d", jLay), "Primary particles;y (cm);n digits per hit; counts", 30, -15., 15., 8, -0.5, 7.5);
+  }
+
+  TH1F* hRSU = new TH1F("hRSU", ";rsu;counts", 42, -0.5, 41.5);
+  TH1F* hTile = new TH1F("hTile", ";tile;counts", 12, -0.5, 11.5);
+  TH1F* hRow = new TH1F("hRow", ";row;counts", 444, -0.5, 443.5);
+  TH1F* hCol = new TH1F("hCol", ";col;counts", 156, -0.5, 155.5);
+  TH1F* hDeltaXloc1 = new TH1F("hDeltaXloc1", "1-digit hits;x_{loc}^{digit}-x_{loc}^{hit} (#mum);counts", 100, -30, 30);
+  TH1F* hDeltaYloc1 = new TH1F("hDeltaYloc1", "1-digit hits;y_{loc}^{digit}-y_{loc}^{hit} (#mum);counts", 100, -30, 30);
+  TH1F* hDeltaXloc2 = new TH1F("hDeltaXloc2", "2-digit hits;x_{loc}^{digit}-x_{loc}^{hit} (#mum);counts", 100, -30, 30);
+  TH1F* hDeltaYloc2 = new TH1F("hDeltaYloc2", "2-digit hits;y_{loc}^{digit}-y_{loc}^{hit} (#mum);counts", 100, -30, 30);
+
+  int nEv = mcTree->GetEntries();
+  printf("Number of events = %d\n", nEv);
+  int countEx5 = 0;
+  for (int jEv = 0; jEv < nEv; jEv++) {
+    mcTree->GetEvent(jEv);
+    th->GetEvent(jEv);
+    td->GetEvent(jEv);
+    int nPart = mcArr->size();
+    int nHits = vtHits.size();
+    int nDigits = vtDigits.size();
+    int nMClabels = vtMCLabels.getNElements();
+    printf("Event %d particles = %d hits = %d digits = %d MClabels = %d\n", jEv, nPart, nHits, nDigits, nMClabels);
+    for (int jDig = 0; jDig < nDigits; ++jDig) {
+      const auto& dig = vtDigits.at(jDig);
+      hRSU->Fill(dig.getRSU());
+      hTile->Fill(dig.getTile());
+      hRow->Fill(dig.getRow());
+      hCol->Fill(dig.getCol());
+      std::span labels = vtMCLabels.getLabels(jDig);
+      int nLabels = labels.size();
+      hMCLabelsPerDigit->Fill(nLabels);
+      for (int jLab = 0; jLab < nLabels; jLab++) {
+        NA6PMCComposedLabel lbl = labels[jLab];
+        if (jLab == 0)
+          hMCFirstLabels->Fill(lbl.getTrackID());
+        hMCAllLabels->Fill(lbl.getTrackID());
+      }
+    }
+    for (int jHit = 0; jHit < nHits; ++jHit) {
+      const auto& hit = vtHits.at(jHit);
+      int idPartH = hit.getTrackID();
+      auto curPart = mcArr->at(idPartH);
+      int sensH = hit.getDetectorID();
+      int digperhit = 0;
+      float sumx = 0.;
+      float sumy = 0.;
+      float sumgooddigs = 0.;
+      for (int jDig = 0; jDig < nDigits; ++jDig) {
+        const auto& dig = vtDigits.at(jDig);
+        int sensD = dig.getDetectorID();
+        if (sensH == sensD) {
+          //          int idPartD = dig.getParticleID();
+          std::span labels = vtMCLabels.getLabels(jDig);
+          int nLabels = labels.size();
+          for (int jLab = 0; jLab < nLabels; jLab++) {
+            NA6PMCComposedLabel lbl = labels[jLab];
+            int idPartD = lbl.getTrackID();
+            if (idPartD == idPartH) {
+              digperhit++;
+              int rsu = dig.getRSU();
+              int tile = dig.getTile();
+              int row = dig.getRow();
+              int col = dig.getCol();
+              float xpix, ypix;
+              bool locOk = vt.indicesToLocal(rsu, tile, row, col, xpix, ypix);
+              if (locOk) {
+                sumgooddigs += 1.;
+                sumx += xpix;
+                sumy += ypix;
+              }
+            }
+          }
+        }
+      }
+      hDigitsPerHitAll->Fill(digperhit);
+      float xdig = sumx / sumgooddigs;
+      float ydig = sumy / sumgooddigs;
+      auto modID = hit.getDetectorID();
+      auto& matrix = geoMan.getMatrix(modID);
+      double xyzGloS[3] = {hit.getXIn(), hit.getYIn(), hit.getZIn()};
+      double xyzGloE[3] = {hit.getXOut(), hit.getYOut(), hit.getZOut()};
+      double xyzLocS[3], xyzLocE[3];
+      matrix.MasterToLocal(xyzGloS, xyzLocS);
+      xyzLocS[0] += geoMan.getModuleHalfX(modID);
+      xyzLocS[1] += geoMan.getModuleHalfY(modID);
+      matrix.MasterToLocal(xyzGloE, xyzLocE);
+      xyzLocE[0] += geoMan.getModuleHalfX(modID);
+      xyzLocE[1] += geoMan.getModuleHalfY(modID);
+      if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 1) {
+        // swap x
+        xyzLocS[0] = geoMan.getModuleFullX(modID) - xyzLocS[0];
+        xyzLocE[0] = geoMan.getModuleFullX(modID) - xyzLocE[0];
+      } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 2) {
+        // swap x and y
+        xyzLocS[0] = geoMan.getModuleFullX(modID) - xyzLocS[0];
+        xyzLocS[1] = geoMan.getModuleFullY(modID) - xyzLocS[1];
+        xyzLocE[0] = geoMan.getModuleFullX(modID) - xyzLocE[0];
+        xyzLocE[1] = geoMan.getModuleFullY(modID) - xyzLocE[1];
+      } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 3) {
+        // swap y
+        xyzLocS[1] = geoMan.getModuleFullY(modID) - xyzLocS[1];
+        xyzLocE[1] = geoMan.getModuleFullY(modID) - xyzLocE[1];
+      }
+      double xhit = 0.5f * (xyzLocS[0] + xyzLocE[0]);
+      double yhit = 0.5f * (xyzLocS[1] + xyzLocE[1]);
+      if (digperhit == 1) {
+        hDeltaXloc1->Fill((xdig - xhit) * 1e4);
+        hDeltaYloc1->Fill((ydig - yhit) * 1e4);
+      } else if (digperhit == 2) {
+        hDeltaXloc2->Fill((xdig - xhit) * 1e4);
+        hDeltaYloc2->Fill((ydig - yhit) * 1e4);
+      }
+
+      int layH = sensH / 4;
+      if (curPart.IsPrimary()) {
+        hDigitsPerHitPrim->Fill(digperhit);
+        hDigitsPerHitPrimVsX[layH]->Fill(hit.getX(), digperhit);
+        hDigitsPerHitPrimVsY[layH]->Fill(hit.getY(), digperhit);
+      }
+    }
+  }
+
+  gStyle->SetOptStat(11111111);
+
+  TCanvas* cdig = new TCanvas("cdig", "", 1400, 800);
+  cdig->Divide(2, 2);
+  cdig->cd(1);
+  hRSU->Draw();
+  cdig->cd(2);
+  hTile->Draw();
+  cdig->cd(3);
+  hRow->Draw();
+  cdig->cd(4);
+  hCol->Draw();
+
+  TCanvas* clab = new TCanvas("clab", "labels", 1400, 500);
+  clab->Divide(3, 1);
+  clab->cd(1);
+  gPad->SetLogy();
+  hMCLabelsPerDigit->Draw();
+  clab->cd(2);
+  hMCFirstLabels->Draw();
+  clab->cd(3);
+  hMCAllLabels->Draw();
+
+  TCanvas* chd = new TCanvas("chd", "", 1400, 800);
+  chd->Divide(2, 1);
+  chd->cd(1);
+  gPad->SetLogy();
+  hDigitsPerHitAll->Draw();
+  chd->cd(2);
+  gPad->SetLogy();
+  hDigitsPerHitPrim->Draw();
+
+  TCanvas* cres = new TCanvas("cres", "", 1400, 800);
+  cres->Divide(2, 2);
+  cres->cd(1);
+  hDeltaXloc1->Draw();
+  cres->cd(2);
+  hDeltaYloc1->Draw();
+  cres->cd(3);
+  hDeltaXloc2->Draw();
+  cres->cd(4);
+  hDeltaYloc2->Draw();
+
+  TCanvas* clay = new TCanvas("clay", "", 1400, 800);
+  clay->Divide(5, 2);
+  for (int jLay = 0; jLay < 5; ++jLay) {
+    pDigitsPerHitPrimVsX[jLay] = hDigitsPerHitPrimVsX[jLay]->ProfileX(Form("profileXlay%d\n", jLay));
+    pDigitsPerHitPrimVsY[jLay] = hDigitsPerHitPrimVsY[jLay]->ProfileX(Form("profileYlay%d\n", jLay));
+    clay->cd(jLay + 1);
+    gPad->SetLogz();
+    hDigitsPerHitPrimVsX[jLay]->SetStats(0);
+    hDigitsPerHitPrimVsX[jLay]->Draw("colz");
+    pDigitsPerHitPrimVsX[jLay]->SetMarkerStyle(20);
+    pDigitsPerHitPrimVsX[jLay]->SetMarkerSize(0.5);
+    pDigitsPerHitPrimVsX[jLay]->SetLineWidth(2);
+    pDigitsPerHitPrimVsX[jLay]->Draw("psame");
+    clay->cd(jLay + 6);
+    gPad->SetLogz();
+    hDigitsPerHitPrimVsY[jLay]->SetStats(0);
+    hDigitsPerHitPrimVsY[jLay]->Draw("colz");
+    pDigitsPerHitPrimVsY[jLay]->SetMarkerStyle(20);
+    pDigitsPerHitPrimVsY[jLay]->SetMarkerSize(0.5);
+    pDigitsPerHitPrimVsY[jLay]->SetLineWidth(2);
+    pDigitsPerHitPrimVsY[jLay]->Draw("psame");
+  }
+}


### PR DESCRIPTION
This is a PR for the digitization of the Vertex Telescope.
In the first commit, only some basic features are implemented. Others will be added in the next days, but I thought it was useful to start discussing some aspects before moving ahead too much.

In NA6PVerTelSegmentation I added the methods needed to convert local coordinates on the sensor into a set of indices that identify uniquely a pixel in a sensor plane (up to 6x7 RSU).
I chose to use 4 indices: an rsu index (ranging from 0 to 41), a tile index (ranging from 0 to 11), row and column in each tile. These 4 indices identify uniquely a pixel on a sensor.

NA6PVerTelPreDigitContainer.h: this new class defines the "predigit" (or "summable digit") object, which is a float value per pixel that will store the deposited energy (or number of electrons in the pixel). The identification of a pixel is based on the 4 indices described above (rsu, tile, row, col).
Note, this is an intermediate format in the digitization process: the digits will be a list of fired pixels and will be obtained from the predigits in the finalization step of the digitization by applying the thresholds on the pixel energies.

NA6PVerTelDigitizer: this new class will steer the digitization step by running over the hits and converting them into digits. Currently the method processHit is just sketched and just reaches the point of converting the coordinates of the hit into the local coordinates on the sensor. However, before continuing with the implementation, I thought it was better to have a checkpoint on the structure I chose for the predigit (pixel indices) and for the segmentation.

@shahor02, @scompar, @galocco: any feedback is welcome!
