### PR TITLE
Fix for root streaming issue of VTPixID objects into TTree

### DIFF
--- a/sim/include/NA6PVerTelDigit.h
+++ b/sim/include/NA6PVerTelDigit.h
@@ -18,45 +18,39 @@
 #include <Rtypes.h>
 
 // object for VT digits
-// NOTE: VTPixID uses C++ bit fields which ROOT cannot stream correctly.
-// Do not access mPixID branches directly via TTree::Scan() or TTree::Draw().
-// Always use the getters (getRSU(), getTile(), getRow(), getCol())
-// to access pixel indices.
+// VTPixID stores rsu/tile/row/col packed into a single uint32_t,
+// to ensure correct ROOT streaming.
+// Always use the getters/setters to access pixel indices.
 
 struct VTPixID {
-
   static constexpr int kColBits = 10; // 0-155,  max 1023
   static constexpr int kRowBits = 10; // 0-443,  max 1023
   static constexpr int kTileBits = 4; // 0-11,   max 15
   static constexpr int kRsuBits = 6;  // 0-41,   max 63
-
   static_assert(kColBits + kRowBits + kTileBits + kRsuBits == 30,
                 "VTPixID fields must fit in 32 bits");
 
-  uint32_t col : kColBits = 0;
-  uint32_t row : kRowBits = 0;
-  uint32_t tile : kTileBits = 0;
-  uint32_t rsu : kRsuBits = 0;
+  uint32_t mPacked = 0; // the ONLY streamed member
 
-  uint32_t pack() const
-  {
-    return uint32_t(col) |
-           (uint32_t(row) << kColBits) |
-           (uint32_t(tile) << (kColBits + kRowBits)) |
-           (uint32_t(rsu) << (kColBits + kRowBits + kTileBits));
-  }
+  uint32_t getCol() const { return mPacked & ((1u << kColBits) - 1); }
+  uint32_t getRow() const { return (mPacked >> kColBits) & ((1u << kRowBits) - 1); }
+  uint32_t getTile() const { return (mPacked >> (kColBits + kRowBits)) & ((1u << kTileBits) - 1); }
+  uint32_t getRsu() const { return (mPacked >> (kColBits + kRowBits + kTileBits)) & ((1u << kRsuBits) - 1); }
 
+  void setCol(uint32_t v) { mPacked = (mPacked & ~(((1u << kColBits) - 1))) | (v & ((1u << kColBits) - 1)); }
+  void setRow(uint32_t v) { mPacked = (mPacked & ~(((1u << kRowBits) - 1) << kColBits)) | ((v & ((1u << kRowBits) - 1)) << kColBits); }
+  void setTile(uint32_t v) { mPacked = (mPacked & ~(((1u << kTileBits) - 1) << (kColBits + kRowBits))) | ((v & ((1u << kTileBits) - 1)) << (kColBits + kRowBits)); }
+  void setRsu(uint32_t v) { mPacked = (mPacked & ~(((1u << kRsuBits) - 1) << (kColBits + kRowBits + kTileBits))) | ((v & ((1u << kRsuBits) - 1)) << (kColBits + kRowBits + kTileBits)); }
+
+  uint32_t pack() const { return mPacked; }
   static VTPixID unpack(uint32_t val)
   {
     VTPixID id;
-    id.col = val & ((1 << kColBits) - 1);
-    id.row = (val >> kColBits) & ((1 << kRowBits) - 1);
-    id.tile = (val >> (kColBits + kRowBits)) & ((1 << kTileBits) - 1);
-    id.rsu = (val >> (kColBits + kRowBits + kTileBits)) & ((1 << kRsuBits) - 1);
+    id.mPacked = val;
     return id;
   }
 
-  ClassDefNV(VTPixID, 1);
+  ClassDefNV(VTPixID, 2);
 };
 
 class NA6PVerTelDigit
@@ -69,17 +63,17 @@ class NA6PVerTelDigit
 
   uint16_t getDetectorID() const { return mDetectorID; }
   const VTPixID& getPixID() const { return mPixID; }
-  uint32_t getRSU() const { return mPixID.rsu; }
-  uint32_t getTile() const { return mPixID.tile; }
-  uint32_t getRow() const { return mPixID.row; }
-  uint32_t getCol() const { return mPixID.col; }
+  uint32_t getRSU() const { return mPixID.getRsu(); }
+  uint32_t getTile() const { return mPixID.getTile(); }
+  uint32_t getRow() const { return mPixID.getRow(); }
+  uint32_t getCol() const { return mPixID.getCol(); }
 
   void setDetectorID(uint16_t id) { mDetectorID = id; }
   void setPixID(const VTPixID& id) { mPixID = id; }
-  void setRSU(uint32_t id) { mPixID.rsu = id; }
-  void setTile(uint32_t id) { mPixID.tile = id; }
-  void setRow(uint32_t id) { mPixID.row = id; }
-  void setCol(uint32_t id) { mPixID.col = id; }
+  void setRSU(uint32_t id) { mPixID.setRsu(id); }
+  void setTile(uint32_t id) { mPixID.setTile(id); }
+  void setRow(uint32_t id) { mPixID.setRow(id); }
+  void setCol(uint32_t id) { mPixID.setCol(id); }
 
   void print() const;
   std::string asString() const;

--- a/sim/include/NA6PVerTelDigit.h
+++ b/sim/include/NA6PVerTelDigit.h
@@ -42,14 +42,6 @@ struct VTPixID {
   void setTile(uint32_t v) { mPacked = (mPacked & ~(((1u << kTileBits) - 1) << (kColBits + kRowBits))) | ((v & ((1u << kTileBits) - 1)) << (kColBits + kRowBits)); }
   void setRsu(uint32_t v) { mPacked = (mPacked & ~(((1u << kRsuBits) - 1) << (kColBits + kRowBits + kTileBits))) | ((v & ((1u << kRsuBits) - 1)) << (kColBits + kRowBits + kTileBits)); }
 
-  uint32_t pack() const { return mPacked; }
-  static VTPixID unpack(uint32_t val)
-  {
-    VTPixID id;
-    id.mPacked = val;
-    return id;
-  }
-
   ClassDefNV(VTPixID, 2);
 };
 

--- a/sim/include/NA6PVerTelPreDigitContainer.h
+++ b/sim/include/NA6PVerTelPreDigitContainer.h
@@ -86,7 +86,7 @@ class NA6PVerTelPreDigitContainer
     id.setRow(row);
     id.setTile(tile);
     id.setRsu(rsu);
-    return static_cast<ULong64_t>(id.pack());
+    return static_cast<ULong64_t>(id.mPacked);
   }
 
   static UShort_t key2col(ULong64_t key) { return key2pixID(key).getCol(); }
@@ -116,7 +116,9 @@ class NA6PVerTelPreDigitContainer
  private:
   static VTPixID key2pixID(ULong64_t key)
   {
-    return VTPixID::unpack(static_cast<uint32_t>(key & 0xFFFFFFFF));
+    VTPixID id;
+    id.mPacked = static_cast<uint32_t>(key & 0xFFFFFFFF);
+    return id;
   }
 
   ClassDefNV(NA6PVerTelPreDigitContainer, 1);

--- a/sim/include/NA6PVerTelPreDigitContainer.h
+++ b/sim/include/NA6PVerTelPreDigitContainer.h
@@ -28,10 +28,10 @@ struct PreDigit {
 
   PreDigit(UShort_t rs = 0, UShort_t tl = 0, UShort_t rw = 0, UShort_t cl = 0, float ch = 0.f, NA6PMCComposedLabel lbl = {}) : charge(ch)
   {
-    pixID.rsu = rs;
-    pixID.tile = tl;
-    pixID.row = rw;
-    pixID.col = cl;
+    pixID.setRsu(rs);
+    pixID.setTile(tl);
+    pixID.setRow(rw);
+    pixID.setCol(cl);
     labels.emplace_back(ch, lbl);
   }
 
@@ -81,24 +81,28 @@ class NA6PVerTelPreDigitContainer
   bool isEmpty() const { return mPreDigits.empty(); }
   static ULong64_t getOrderingKey(UShort_t rsu, UShort_t tile, UShort_t row, UShort_t col)
   {
-    VTPixID id{.col = col, .row = row, .tile = tile, .rsu = rsu};
+    VTPixID id;
+    id.setCol(col);
+    id.setRow(row);
+    id.setTile(tile);
+    id.setRsu(rsu);
     return static_cast<ULong64_t>(id.pack());
   }
 
-  static UShort_t key2col(ULong64_t key) { return key2pixID(key).col; }
-  static UShort_t key2row(ULong64_t key) { return key2pixID(key).row; }
-  static UShort_t key2tile(ULong64_t key) { return key2pixID(key).tile; }
-  static UShort_t key2rsu(ULong64_t key) { return key2pixID(key).rsu; }
+  static UShort_t key2col(ULong64_t key) { return key2pixID(key).getCol(); }
+  static UShort_t key2row(ULong64_t key) { return key2pixID(key).getRow(); }
+  static UShort_t key2tile(ULong64_t key) { return key2pixID(key).getTile(); }
+  static UShort_t key2rsu(ULong64_t key) { return key2pixID(key).getRsu(); }
 
   static void unpackKey(ULong64_t key,
                         UShort_t& rsu, UShort_t& tile,
                         UShort_t& row, UShort_t& col)
   {
     VTPixID id = key2pixID(key);
-    rsu = id.rsu;
-    tile = id.tile;
-    row = id.row;
-    col = id.col;
+    rsu = id.getRsu();
+    tile = id.getTile();
+    row = id.getRow();
+    col = id.getCol();
   }
 
   bool isDisabled() const { return mDisabled; }

--- a/sim/src/NA6PVerTelDigit.cxx
+++ b/sim/src/NA6PVerTelDigit.cxx
@@ -10,10 +10,10 @@ NA6PVerTelDigit::NA6PVerTelDigit(uint16_t detID, const VTPixID& id) : mDetectorI
 
 NA6PVerTelDigit::NA6PVerTelDigit(uint16_t detID, uint32_t rsu, uint32_t tile, uint32_t row, uint32_t col) : mDetectorID(detID)
 {
-  mPixID.rsu = rsu;
-  mPixID.tile = tile;
-  mPixID.row = row;
-  mPixID.col = col;
+  mPixID.setRsu(rsu);
+  mPixID.setTile(tile);
+  mPixID.setRow(row);
+  mPixID.setCol(col);
 }
 
 std::string NA6PVerTelDigit::asString() const

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -172,7 +172,7 @@ void NA6PVerTelDigitizer::finalizeDigits()
     auto iter = itBeg;
     for (; iter != buffer.end(); ++iter) {
       auto& preDig = iter->second;
-      int jTile = NA6PVerTelSegmentation::getTileId(jMod, preDig.pixID.rsu, preDig.pixID.tile);
+      int jTile = NA6PVerTelSegmentation::getTileId(jMod, preDig.pixID.getRsu(), preDig.pixID.getTile());
       if (jTile >= 0 && preDig.charge >= mThresholds[jTile]) {
         preDig.sortLabelsByEnergy();
         int digID = mDigits.size();


### PR DESCRIPTION
This modification fixes an issue of double free or corruption (!prev) which I spotted on TTrees of digits when doing larger number of events.
It seems it was due to the streaming of the VTPixID object.

