### PR TITLE
Rotate local reference systems of VT modules

### DIFF
--- a/sim/src/NA6PVerTel.cxx
+++ b/sim/src/NA6PVerTel.cxx
@@ -521,9 +521,13 @@ void NA6PVerTel::createGeometry(TGeoVolume* world)
                                 -pixChipDX / 2 - pixChipOffsX, pixChipDX / 2 - pixChipOffsX};
     std::vector<float> alpdy = {pixChipDYlayer / 2 - pixChipOffsY, pixChipDYlayer / 2 + pixChipOffsY,
                                 -pixChipDYlayer / 2 + pixChipOffsY, -pixChipDYlayer / 2 - pixChipOffsY};
+    std::vector<float> phi = {0., 90., 180., 0.};
+    std::vector<float> theta = {0., 180., 0., 180.};
+    std::vector<float> psi = {0., -90., 0., 0.};
+      
     for (size_t ii = 0; ii < alpdx.size(); ++ii) {
       pixelStationVol->AddNode(pixelSensor, composeSensorVolID(ii),
-                               new TGeoTranslation(alpdx[ii], alpdy[ii], 0));
+                               new TGeoCombiTrans(alpdx[ii], alpdy[ii], 0, new TGeoRotation(Form("rotQ%d", ii + 1), phi[ii], theta[ii], psi[ii])));
     }
     pixelStationVol->AddNode(cbPlate, composeNonSensorVolID(20),
                              new TGeoCombiTrans(0., 0.,

--- a/sim/src/NA6PVerTelDigitizer.cxx
+++ b/sim/src/NA6PVerTelDigitizer.cxx
@@ -95,21 +95,6 @@ void NA6PVerTelDigitizer::getHitLocalCoord(const NA6PVerTelHit& hit, double xyzL
   matrix.MasterToLocal(xyzGloE, xyzLocE);
   xyzLocE[0] += mGeoManager.getModuleHalfX(modID);
   xyzLocE[1] += mGeoManager.getModuleHalfY(modID);
-  if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 1) {
-    // swap x
-    xyzLocS[0] = mGeoManager.getModuleFullX(modID) - xyzLocS[0];
-    xyzLocE[0] = mGeoManager.getModuleFullX(modID) - xyzLocE[0];
-  } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 2) {
-    // swap x and y
-    xyzLocS[0] = mGeoManager.getModuleFullX(modID) - xyzLocS[0];
-    xyzLocS[1] = mGeoManager.getModuleFullY(modID) - xyzLocS[1];
-    xyzLocE[0] = mGeoManager.getModuleFullX(modID) - xyzLocE[0];
-    xyzLocE[1] = mGeoManager.getModuleFullY(modID) - xyzLocE[1];
-  } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 3) {
-    // swap y
-    xyzLocS[1] = mGeoManager.getModuleFullY(modID) - xyzLocS[1];
-    xyzLocE[1] = mGeoManager.getModuleFullY(modID) - xyzLocE[1];
-  }
 }
 
 void NA6PVerTelDigitizer::processHit(const NA6PVerTelHit& hit)

--- a/test/plotVerTelDigits.C
+++ b/test/plotVerTelDigits.C
@@ -16,24 +16,9 @@ void getGlobalCoord(const NA6PGeometryManager& geoMan, int modID, float xloc, fl
 {
   auto& matrix = geoMan.getMatrix(modID);
 
-  double x = xloc;
-  double y = yloc;
-  int modType = modID % NA6PGeometryManager::kNVTModulesPerLayer;
-
-  if (modType == 1) {
-    // swap x
-    x = geoMan.getModuleFullX(modID) - x;
-  } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 2) {
-    // swap x and y
-    x = geoMan.getModuleFullX(modID) - x;
-    y = geoMan.getModuleFullY(modID) - y;
-  } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 3) {
-    // swap y
-    y = geoMan.getModuleFullY(modID) - y;
-  }
   double xyzLoc[3];
-  xyzLoc[0] = x - geoMan.getModuleHalfX(modID);
-  xyzLoc[1] = y - geoMan.getModuleHalfY(modID);
+  xyzLoc[0] = xloc - geoMan.getModuleHalfX(modID);
+  xyzLoc[1] = yloc - geoMan.getModuleHalfY(modID);
   xyzLoc[2] = 0.;
   matrix.LocalToMaster(xyzLoc, xyzGlo);
 }
@@ -208,21 +193,6 @@ void plotVerTelDigits(const char* dirSimu = ".")
       matrix.MasterToLocal(xyzGloE, xyzLocE);
       xyzLocE[0] += geoMan.getModuleHalfX(modID);
       xyzLocE[1] += geoMan.getModuleHalfY(modID);
-      if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 1) {
-        // swap x
-        xyzLocS[0] = geoMan.getModuleFullX(modID) - xyzLocS[0];
-        xyzLocE[0] = geoMan.getModuleFullX(modID) - xyzLocE[0];
-      } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 2) {
-        // swap x and y
-        xyzLocS[0] = geoMan.getModuleFullX(modID) - xyzLocS[0];
-        xyzLocS[1] = geoMan.getModuleFullY(modID) - xyzLocS[1];
-        xyzLocE[0] = geoMan.getModuleFullX(modID) - xyzLocE[0];
-        xyzLocE[1] = geoMan.getModuleFullY(modID) - xyzLocE[1];
-      } else if (modID % NA6PGeometryManager::kNVTModulesPerLayer == 3) {
-        // swap y
-        xyzLocS[1] = geoMan.getModuleFullY(modID) - xyzLocS[1];
-        xyzLocE[1] = geoMan.getModuleFullY(modID) - xyzLocE[1];
-      }
       double xhit = 0.5f * (xyzLocS[0] + xyzLocE[0]);
       double yhit = 0.5f * (xyzLocS[1] + xyzLocE[1]);
       if (digperhit == 1) {


### PR DESCRIPTION
With these modifications the local reference systems of the 4 modules of each VT plane are defined so as to match the orientation of the MOSAIX in the final arrangement, i.e. with the shortest end cap close to x = 0 (beam line) and the longest end cap on the outside.
With this change in the geometry, we do not need anymore to swap the coordinates in NA6PVerTelDigitizer::getHitLocalCoord and in the digit plotting macros.
