### PR TITLE
First implementation of VT cluster finder 

### DIFF
--- a/NA6PRec.cxx
+++ b/NA6PRec.cxx
@@ -18,6 +18,7 @@
 #include "NA6PVerTelReconstruction.h"
 #include "NA6PMuonSpecReconstruction.h"
 #include "NA6PMatching.h"
+#include "NA6PMCTruthContainer.h"
 
 class TreeFromFile
 {
@@ -85,7 +86,8 @@ int main(int argc, char** argv)
     add_option("geometry,g", bpo::value<std::string>()->default_value("geometry.root"), "geometry file name");
     add_option("firstevent,f", bpo::value<int32_t>()->default_value(0), "first event");
     add_option("lastevent,l", bpo::value<int32_t>()->default_value(-1), "last event");
-    add_option("doHitsToRecPoints,cl", bpo::value<bool>()->default_value(true), "run hits->clusters");
+    add_option("doHitsToRecPoints,hitcl", bpo::value<bool>()->default_value(true), "run hits->clusters");
+    add_option("doDigitsToRecPoints,cl", bpo::value<bool>()->default_value(false), "run digits->clusters");
     add_option("doTrackletVertex,vert", bpo::value<bool>()->default_value(true), "run tracklet vertexer");
     add_option("doVTTracking,vt", bpo::value<bool>()->default_value(true), "run VT tracker");
     add_option("doMSTracking,ms", bpo::value<bool>()->default_value(true), "run MS tracker");
@@ -122,6 +124,7 @@ int main(int argc, char** argv)
   na6p::conf::ConfigurableParam::printAllKeyValuePairs();
 
   const bool doHitsToRecPoints = vm["doHitsToRecPoints"].as<bool>();
+  const bool doDigitsToRecPoints = vm["doDigitsToRecPoints"].as<bool>();
   const bool doTrackletVertex = vm["doTrackletVertex"].as<bool>();
   const bool doVTTracking = vm["doVTTracking"].as<bool>();
   const bool doMSTracking = vm["doMSTracking"].as<bool>();
@@ -134,27 +137,33 @@ int main(int argc, char** argv)
     return -1;
   }
 
+  if (doHitsToRecPoints && doDigitsToRecPoints) {
+    LOGP(info, "Will do digits to recpoints for VT instead of hits to recpoints");
+  }
+
   std::unique_ptr<NA6PVerTelReconstruction> vtrec = std::make_unique<NA6PVerTelReconstruction>();
   std::unique_ptr<NA6PMuonSpecReconstruction> msrec = std::make_unique<NA6PMuonSpecReconstruction>();
   std::unique_ptr<NA6PMatching> matching = std::make_unique<NA6PMatching>();
 
   if (doHitsToRecPoints) {
-    { // VTHist
-      TreeFromFile tfVT("HitsVerTel.root", "hitsVerTel");
-      std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
-      tfVT.getTree()->SetBranchAddress("VerTel", &vtHitsPtr);
-      int nEvVT = tfVT.getTree()->GetEntriesFast();
+    { // VTHits
+      if (!doDigitsToRecPoints) {
+        TreeFromFile tfVT("HitsVerTel.root", "hitsVerTel");
+        std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
+        tfVT.getTree()->SetBranchAddress("VerTel", &vtHitsPtr);
+        int nEvVT = tfVT.getTree()->GetEntriesFast();
 
-      vtrec->createClustersOutput();
-      for (int jEv = 0; jEv < nEvVT; jEv++) {
-        tfVT.getTree()->GetEvent(jEv);
-        int nHits = vtHits.size();
-        LOGP(info, "VerTel Event {} nHits= {}", jEv, nHits);
-        vtrec->clearClusters();
-        vtrec->hitsToRecPoints(vtHits);
-        vtrec->writeClusters();
+        vtrec->createClustersOutput();
+        for (int jEv = 0; jEv < nEvVT; jEv++) {
+          tfVT.getTree()->GetEvent(jEv);
+          int nHits = vtHits.size();
+          LOGP(info, "VerTel Event {} nHits= {}", jEv, nHits);
+          vtrec->clearClusters();
+          vtrec->hitsToRecPoints(vtHits);
+          vtrec->writeClusters();
+        }
+        vtrec->closeClustersOutput();
       }
-      vtrec->closeClustersOutput();
     }
     { // Muon Spectrometer hits -> clusters
       TreeFromFile tfMS("HitsMuonSpecModular.root", "hitsMuonSpecModular");
@@ -176,6 +185,26 @@ int main(int argc, char** argv)
   } else {
     LOGP(info, "Hits -> Recpoints disabled from input options");
   }
+  if (doDigitsToRecPoints) {
+    TreeFromFile tfVT("DigitsVerTel.root", "digitsVerTel");
+    std::vector<NA6PVerTelDigit> vtDigits, *vtDigitsPtr = &vtDigits;
+    NA6PMCTruthContainer digMCLabels, *digMCLabelsPtr = &digMCLabels;
+    tfVT.getTree()->SetBranchAddress("VerTel", &vtDigitsPtr);
+    tfVT.getTree()->SetBranchAddress("VerTelMCTruth", &digMCLabelsPtr);
+    int nEvVT = tfVT.getTree()->GetEntriesFast();
+    vtrec->createClustersOutput();
+    for (int jEv = 0; jEv < nEvVT; jEv++) {
+      tfVT.getTree()->GetEvent(jEv);
+      int nDigits = vtDigits.size();
+      int nMClabels = digMCLabels.getNElements();
+      LOGP(info, "VerTel Event {} nDigits = {} nDigMClabels = {}", jEv, nDigits, nMClabels);
+      vtrec->clearClusters();
+      vtrec->digitsToRecPoints(vtDigits, digMCLabels);
+      vtrec->writeClusters();
+    }
+    vtrec->closeClustersOutput();
+  }
+
   const bool needsMCKine = doTrackletVertex || doVTTracking || doMSTracking || doMatching;
   std::unique_ptr<TreeFromFile> tfKine;
   std::vector<TParticle>* mcArr = nullptr;

--- a/base/include/NA6PMCTruthContainer.h
+++ b/base/include/NA6PMCTruthContainer.h
@@ -17,6 +17,7 @@
 
 #include "NA6PMCComposedLabel.h"
 #include <span>
+#include <stdexcept>
 
 class NA6PMCTruthContainer
 {

--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -25,6 +25,7 @@ set(DICTIONARY_HEADERS
   NA6PBaseCluster.h
   NA6PMuonSpecCluster.h
   NA6PVerTelCluster.h
+  NA6PVerTelClusterizer.h
   NA6PTrackPar.h
   NA6PTrackParCov.h
   NA6PTrack.h

--- a/rec/include/NA6PVerTelClusterizer.h
+++ b/rec/include/NA6PVerTelClusterizer.h
@@ -1,0 +1,153 @@
+// NA6PCCopyright
+
+// Based on:
+// Copyright 2019-2030 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef NA6P_VERTEL_CLUSTERIZER_H
+#define NA6P_VERTEL_CLUSTERIZER_H
+
+#include "NA6PVerTelSegmentation.h"
+#include "NA6PGeometryManager.h"
+#include "NA6PVerTelDigit.h"
+#include "NA6PVerTelCluster.h"
+#include "NA6PMCTruthContainer.h"
+#include <Rtypes.h>
+
+struct DigitProxy {
+  int originalIndex;
+  int chipID;
+  uint32_t col;
+  uint32_t row;
+};
+
+struct ChipSlice {
+  int chipID;
+  size_t startIdx;
+  size_t endIdx;
+};
+
+struct PreCluster {
+  int head = 0; // index of precluster head in the pixels
+  int index = 0;
+};
+
+struct BBox {
+  uint32_t rowMin = 0xffffffff;
+  uint32_t rowMax = 0;
+  uint32_t colMin = 0xffffffff;
+  uint32_t colMax = 0;
+
+  bool isInside(uint32_t row, uint32_t col) const { return row >= rowMin && row <= rowMax && col >= colMin && col <= colMax; }
+  auto rowSpan() const { return rowMax - rowMin + 1; }
+  auto colSpan() const { return colMax - colMin + 1; }
+  bool isAcceptableSize() const
+  {
+    // Always returns true for now since we are skipping the huge cluster treatment
+    return true;
+  }
+  void clear()
+  {
+    rowMin = colMin = 0xffffffff;
+    rowMax = colMax = 0;
+  }
+  void adjust(uint32_t row, uint32_t col)
+  {
+    if (row < rowMin)
+      rowMin = row;
+    if (row > rowMax)
+      rowMax = row;
+    if (col < colMin)
+      colMin = col;
+    if (col > colMax)
+      colMax = col;
+  }
+};
+
+class NA6PVerTelClusterizer
+{
+ public:
+  NA6PVerTelClusterizer();
+  ~NA6PVerTelClusterizer() = default;
+
+  void initGeometry(const char* filename = "geometry.root", const char* geoname = "NA6P");
+
+  void resetColumn(int* buff)
+  {
+    std::fill_n(buff, NA6PVerTelSegmentation::NRowsPerTile, -1);
+  }
+
+  ///< swap current and previous column buffers
+  void swapColumnBuffers() { std::swap(mPrevColDataPtr, mCurrColDataPtr); }
+
+  ///< add new precluster at given row of current column for the fired pixel with index ip in chipdigits
+  void addNewPrecluster(uint32_t jPix, uint32_t row)
+  {
+    int lastIndex = mPreClusters.size();
+    mPreClusters.emplace_back(mPixels.size(), lastIndex);
+    // new head does not point yet (-1) on other pixels, store just the entry of the pixel in chipdigits
+    mPixels.emplace_back(-1, jPix);
+    mCurrColDataPtr[row] = lastIndex; // store index of the new precluster in the current column buffer
+  }
+
+  ///< add pixel at row (entry jPix in chipdigits) to the precluster with given index
+  void expandPreCluster(uint32_t jPix, uint32_t row, int preClusIndex)
+  {
+    int masterIndex = mPreClusters[preClusIndex].index;
+    int firstIndex = mPreClusters[masterIndex].head;
+    mPixels.emplace_back(firstIndex, jPix);
+    mPreClusters[masterIndex].head = mPixels.size() - 1;
+    mCurrColDataPtr[row] = preClusIndex;
+  }
+
+  void process(const std::vector<NA6PVerTelDigit>& vtDigits, const NA6PMCTruthContainer& mcDigLabels, std::vector<NA6PVerTelCluster>& outClusters, NA6PMCTruthContainer& mcCluLabels);
+  void processChip(size_t first, size_t last);
+  void initChip(uint32_t jPix);
+  void updateChip(uint32_t jPix);
+  void finishChip();
+  bool pixelsToRecPoint();
+  void getClusterGlobalCoord(int modID, float xloc, float yloc, double xyzGlo[3]) const;
+
+ protected:
+  static constexpr int nRSU = NA6PVerTelSegmentation::NYSensors * NA6PVerTelSegmentation::NXSegments / NA6PVerTelSegmentation::NSegmentsPerRSU;
+  static constexpr int nTilesPerRSU = NA6PVerTelSegmentation::NTilesPerRSU;
+  static constexpr int nTilesPerModule = NA6PVerTelSegmentation::NTilesPerModule;
+  static constexpr float pitchX = NA6PVerTelSegmentation::ActiveDX / NA6PVerTelSegmentation::NColsPerTile;
+  static constexpr float pitchY = NA6PVerTelSegmentation::ActiveDYTile / NA6PVerTelSegmentation::NRowsPerTile;
+  static constexpr int MaxLabels = 10;
+
+  const std::vector<NA6PVerTelDigit>* mDigitsPtr = nullptr; // transient pointer to digits
+  const NA6PMCTruthContainer* mDigMCLabelsPtr = nullptr;    // transient pointer to MC truth of digits
+  std::vector<NA6PVerTelCluster>* mClustersPtr = nullptr;   // transient pointer to output clusters
+  NA6PMCTruthContainer* mCluMCLabelsPtr = nullptr;          // transient pointer to MC truth of clusters
+  NA6PVerTelSegmentation mSegmentation;                     ///< segmentation class
+  NA6PGeometryManager mGeoManager;                          ///< geometry manager
+  std::vector<DigitProxy> mChipDigits;                      // vector to store compacted digits during clusterization
+  std::vector<ChipSlice> mChipSlices;                       // vector to store limits of chips inside mChipDigits
+  // buffers for entries in preClusterIndices in 2 columns, to avoid boundary checks, we reserve
+  // extra elements in the beginning and the end
+  std::array<int, NA6PVerTelSegmentation::NRowsPerTile + 2> mColumn1;
+  std::array<int, NA6PVerTelSegmentation::NRowsPerTile + 2> mColumn2;
+  int* mCurrColDataPtr = nullptr; // pointer on the 1st row of currently processed columnsX
+  int* mPrevColDataPtr = nullptr; // pointer on the 1st row of previously processed columnsX
+  bool mNoLeftCol = true;         ///< flag that there is no column on the left to check
+  uint32_t mCurrCol = 0xffff;     ///< Column being processed
+  // mPixels[].first is the index of the next pixel of the same precluster in the pixels
+  // mPixels[].second is the index of the referred pixel in the chipdigits vector
+  std::vector<std::pair<int, uint32_t>> mPixels;
+  std::vector<PreCluster> mPreClusters;                   //! preclusters info
+  std::vector<DigitProxy> mPixArrBuff;                    //! temporary buffer for pattern calc.
+  std::array<NA6PMCComposedLabel, MaxLabels> mLabelsBuff; //! temporary buffer for building cluster labels
+
+  ClassDefNV(NA6PVerTelClusterizer, 1);
+};
+
+#endif

--- a/rec/include/NA6PVerTelReconstruction.h
+++ b/rec/include/NA6PVerTelReconstruction.h
@@ -22,6 +22,7 @@
 // Class to steer the VT reconstruction
 
 #include "NA6PVerTelCluster.h"
+#include "NA6PVerTelClusterizer.h"
 #include "NA6PTrack.h"
 #include "NA6PVertex.h"
 #include "NA6PVerTelSegmentation.h"
@@ -31,6 +32,7 @@
 class TFile;
 class TTree;
 class NA6PVerTelHit;
+class NA6PVerTelDigit;
 class NA6PVertexerTracklets;
 class NA6PTrackerCA;
 
@@ -45,13 +47,19 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   bool initTracker();
   // methods to steer cluster reconstruction
   void createClustersOutput() override;
-  void clearClusters() override { mClusters.clear(); }
+  void clearClusters() override
+  {
+    mClusters.clear();
+    mCluMCLabels.clear_andfreememory();
+  }
   void writeClusters() override;
   void closeClustersOutput() override;
   // fast method to smear the hits bypassing digitization and cluster finder
   void setClusterSpaceResolution(double clures) { mCluRes = clures; }
   void setEmulateNoGaps(bool val = true) { mSegmentation.setStaggered(true); }
   void hitsToRecPoints(const std::vector<NA6PVerTelHit>& hits);
+  void digitsToRecPoints(const std::vector<NA6PVerTelDigit>& vtDigits, const NA6PMCTruthContainer& digMCLabels);
+
   NA6PTrackerCA* getTracker() const { return mVTTracker.get(); }
 
   // methods to steer tracking
@@ -70,20 +78,23 @@ class NA6PVerTelReconstruction : public NA6PReconstruction
   void runTracking();
 
  private:
-  std::vector<NA6PVerTelCluster> mClusters, *hClusPtr = &mClusters; // vector of clusters
-  TFile* mClusFile = nullptr;                                       // file with clusters
-  TTree* mClusTree = nullptr;                                       // tree of clusters
-  double mCluRes = 5.e-4;                                           // cluster resolution, cm (for fast simu)
-  std::vector<NA6PVertex> mVertices, *hVerticesPtr = &mVertices;    // vector of vertices
-  TFile* mVertexFile = nullptr;                                     // file with vertices
-  TTree* mVertexTree = nullptr;                                     // tree of vertices
-  std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;            // vector of tracks
-  TFile* mTrackFile = nullptr;                                      // file with tracks
-  TTree* mTrackTree = nullptr;                                      // tree of tracks
-  std::unique_ptr<NA6PVertexerTracklets> mVTTrackletVertexer;       // vertexer
-  std::unique_ptr<NA6PTrackerCA> mVTTracker;                        // tracker
-  NA6PVerTelSegmentation mSegmentation;                             // segmentation class
-  NA6PVerTelDigitizer mDigitizer;                                   // digitizer class
+  std::vector<NA6PVerTelCluster> mClusters, *hClusPtr = &mClusters;    // vector of clusters
+  NA6PMCTruthContainer mCluMCLabels, *hCluMCLabelsPtr = &mCluMCLabels; // MC labels
+  NA6PVerTelClusterizer mClusterizer;                                  // cluster finder
+  TFile* mClusFile = nullptr;                                          // file with clusters
+  TTree* mClusTree = nullptr;                                          // tree of clusters
+  double mCluRes = 5.e-4;                                              // cluster resolution, cm (for fast simu)
+  std::vector<NA6PVertex> mVertices, *hVerticesPtr = &mVertices;       // vector of vertices
+  TFile* mVertexFile = nullptr;                                        // file with vertices
+  TTree* mVertexTree = nullptr;                                        // tree of vertices
+  std::vector<NA6PTrack> mTracks, *hTrackPtr = &mTracks;               // vector of tracks
+  TFile* mTrackFile = nullptr;                                         // file with tracks
+  TTree* mTrackTree = nullptr;                                         // tree of tracks
+  std::unique_ptr<NA6PVertexerTracklets> mVTTrackletVertexer;          // vertexer
+  std::unique_ptr<NA6PTrackerCA> mVTTracker;                           // tracker
+  NA6PVerTelSegmentation mSegmentation;                                // segmentation class
+  NA6PVerTelDigitizer mDigitizer;                                      // digitizer class
+
   ClassDefNV(NA6PVerTelReconstruction, 1);
 };
 

--- a/rec/src/NA6PVerTelClusterizer.cxx
+++ b/rec/src/NA6PVerTelClusterizer.cxx
@@ -1,0 +1,312 @@
+// NA6PCCopyright
+
+#include "NA6PLayoutParam.h"
+#include "NA6PGeometryManager.h"
+#include "NA6PVerTelClusterizer.h"
+
+NA6PVerTelClusterizer::NA6PVerTelClusterizer()
+{
+  mChipDigits.reserve(10000);
+  int nModules = NA6PLayoutParam::Instance().nVerTelPlanes * NA6PGeometryManager::kNVTModulesPerLayer;
+  int totChips = nModules * nTilesPerModule;
+  mChipSlices.reserve(totChips);
+}
+
+void NA6PVerTelClusterizer::initGeometry(const char* filename, const char* geoname)
+{
+  if (!mGeoManager.loadGeometry(filename, geoname)) {
+    LOGP(fatal, "Load of geometry not successful");
+  }
+}
+
+void NA6PVerTelClusterizer::process(const std::vector<NA6PVerTelDigit>& vtDigits,
+                                    const NA6PMCTruthContainer& mcDigLabels,
+                                    std::vector<NA6PVerTelCluster>& outClusters,
+                                    NA6PMCTruthContainer& mcCluLabels)
+{
+  // read digits and store them in the vector mChipDigits in the compact format of DigitProxy
+  mDigitsPtr = &vtDigits;
+  mDigMCLabelsPtr = &mcDigLabels;
+  mClustersPtr = &outClusters;
+  mCluMCLabelsPtr = &mcCluLabels;
+  int nDigits = vtDigits.size();
+  mChipDigits.clear();
+  mChipSlices.clear();
+  for (int jDig = 0; jDig < nDigits; ++jDig) {
+    const auto& dig = vtDigits.at(jDig);
+    uint16_t mod = dig.getDetectorID();
+    uint32_t rsu = dig.getRSU();
+    uint32_t tile = dig.getTile();
+    uint32_t row = dig.getRow();
+    uint32_t col = dig.getCol();
+    int chipID = tile + nTilesPerRSU * rsu + nTilesPerModule * mod;
+    mChipDigits.push_back({jDig, chipID, col, row});
+  }
+  // sort mChipDigits to allow grouping by chip
+  std::sort(mChipDigits.begin(), mChipDigits.end(), [](const DigitProxy& a, const DigitProxy& b) {
+    if (a.chipID != b.chipID)
+      return a.chipID < b.chipID;
+    if (a.col != b.col)
+      return a.col < b.col;
+    return a.row < b.row;
+  });
+  // fill mChipSlices with the first and last index of each chip
+  if (!mChipDigits.empty()) {
+    size_t start = 0;
+    int currentChip = mChipDigits[0].chipID;
+    for (size_t i = 1; i < mChipDigits.size(); ++i) {
+      if (mChipDigits[i].chipID != currentChip) {
+        mChipSlices.push_back({currentChip, start, i - 1});
+        start = i;
+        currentChip = mChipDigits[i].chipID;
+      }
+    }
+    mChipSlices.push_back({currentChip, start, mChipDigits.size() - 1});
+  }
+  // clusterize chip-by-chip
+  for (size_t i = 0; i < mChipSlices.size(); ++i) {
+    const auto& slice = mChipSlices[i];
+    processChip(slice.startIdx, slice.endIdx);
+  }
+}
+
+void NA6PVerTelClusterizer::processChip(size_t first,
+                                        size_t last)
+{
+  initChip(first);
+  for (size_t j = first + 1; j <= last; ++j) {
+    updateChip(j);
+  }
+  finishChip();
+}
+
+void NA6PVerTelClusterizer::initChip(uint32_t jPix)
+{
+  // init chip with the 1st unmasked pixel (entry "from" in the mChipData)
+  mColumn1.fill(-1);
+  mColumn2.fill(-1);
+  mPrevColDataPtr = mColumn1.data() + 1;
+  mCurrColDataPtr = mColumn2.data() + 1;
+  mNoLeftCol = true;
+  const auto& pix = mChipDigits[jPix];
+  mCurrCol = pix.col;
+  // this is the first cluster on this chip, so it takes index 0
+  mCurrColDataPtr[pix.row] = 0;
+  mPixels.clear();
+  mPixels.emplace_back(-1, jPix); // id of current pixel
+  mPreClusters.clear();
+  mPreClusters.emplace_back();
+}
+
+void NA6PVerTelClusterizer::updateChip(uint32_t jPix)
+{
+  const auto& pix = mChipDigits[jPix];
+  int row = pix.row;         // should be int because then we compute row-1, which can be negative
+  if (mCurrCol != pix.col) { // switch the buffers
+    swapColumnBuffers();
+    resetColumn(mCurrColDataPtr);
+    mNoLeftCol = false;
+    if (pix.col > mCurrCol + 1) {
+      // no connection with previous column, this pixel cannot belong to any of the
+      // existing preclusters, create a new precluster and flag to check only the row above for next pixels of this column
+      mCurrCol = pix.col;
+      addNewPrecluster(jPix, row);
+      mNoLeftCol = true;
+      return;
+    }
+    mCurrCol = pix.col;
+  }
+
+  if (mNoLeftCol) { // check only the row above
+    if (mCurrColDataPtr[row - 1] >= 0) {
+      expandPreCluster(jPix, row, mCurrColDataPtr[row - 1]); // attach to the precluster of the previous row
+    } else {
+      addNewPrecluster(jPix, row); // start new precluster
+    }
+  } else {
+    // row above should be always checked
+    int nNeighb = 0, lowestIndex = mCurrColDataPtr[row - 1];
+    int *nbrCol[4], nbrRow[4];
+    if (lowestIndex >= 0) {
+      nbrCol[nNeighb] = mCurrColDataPtr;
+      nbrRow[nNeighb++] = row - 1;
+    } else {
+      lowestIndex = 0x7ffff;
+    }
+    // loop to allow for diagonal clusters
+    for (int i : {-1, 0, 1}) {
+      auto v = mPrevColDataPtr[row + i];
+      if (v >= 0) {
+        nbrCol[nNeighb] = mPrevColDataPtr;
+        nbrRow[nNeighb] = row + i;
+        if (v < lowestIndex) {
+          lowestIndex = v;
+        }
+        nNeighb++;
+      }
+    }
+    if (!nNeighb) {
+      // no neighbours, create new precluster
+      addNewPrecluster(jPix, row);
+    } else {
+      // attach to the adjacent precluster with smallest index
+      expandPreCluster(jPix, row, lowestIndex);
+      if (nNeighb > 1) {
+        for (int jNeighb = 0; jNeighb < nNeighb; jNeighb++) {
+          // reassign precluster index to smallest one, replicating updated values to columns caches
+          int neighborClusterID = (nbrCol[jNeighb])[nbrRow[jNeighb]];
+          mPreClusters[neighborClusterID].index = lowestIndex;
+          (nbrCol[jNeighb])[nbrRow[jNeighb]] = lowestIndex;
+        }
+      }
+    }
+  }
+}
+
+void NA6PVerTelClusterizer::finishChip()
+{
+  int nPreclusters = mPreClusters.size();
+  // account for the eventual reindexing of preClusters: Id2 might have been reindexed to Id1, which later was reindexed to Id0
+  for (int i = 1; i < nPreclusters; i++) {
+    if (mPreClusters[i].index != i) { // reindexing is always done towards smallest index
+      mPreClusters[i].index = mPreClusters[mPreClusters[i].index].index;
+    }
+  }
+  for (int i1 = 0; i1 < nPreclusters; ++i1) {
+    auto& preCluster = mPreClusters[i1];
+    auto ci = preCluster.index;
+    if (ci < 0) {
+      continue;
+    }
+    BBox bbox;
+    int nlab = 0;
+    int next = preCluster.head;
+    mPixArrBuff.clear();
+    while (next >= 0) {
+      const auto& pixEntry = mPixels[next];
+      const auto pix = mChipDigits[pixEntry.second];
+      mPixArrBuff.push_back(pix); // needed for cluster topology
+      bbox.adjust(pix.row, pix.col);
+      next = pixEntry.first;
+    }
+    preCluster.index = -1;
+    for (int i2 = i1 + 1; i2 < nPreclusters; ++i2) {
+      auto& preCluster2 = mPreClusters[i2];
+      if (preCluster2.index != ci) {
+        continue;
+      }
+      next = preCluster2.head;
+      while (next >= 0) {
+        const auto& pixEntry = mPixels[next];
+        const auto pix = mChipDigits[pixEntry.second];
+        mPixArrBuff.push_back(pix); // needed for cluster topology
+        bbox.adjust(pix.row, pix.col);
+        next = pixEntry.first;
+      }
+      preCluster2.index = -1;
+    }
+    if (bbox.isAcceptableSize()) {
+      if (pixelsToRecPoint()) {
+        // save cluster
+        // not doable now because of parallel open Pull Request
+      }
+    } else {
+      // special treatment of large clusters if needed
+    }
+  }
+}
+
+bool NA6PVerTelClusterizer::pixelsToRecPoint()
+{
+  float aveCol = 0.f, aveRow = 0.f;
+  size_t clusiz = mPixArrBuff.size();
+  int refMod = -999;
+  int refRsu = -999;
+  int refTile = -999;
+  for (const auto& pix : mPixArrBuff) {
+    int jDig = pix.originalIndex;
+    const auto& dig = mDigitsPtr->at(jDig);
+    uint16_t mod = dig.getDetectorID();
+    uint32_t rsu = dig.getRSU();
+    uint32_t tile = dig.getTile();
+    uint32_t row = dig.getRow();
+    uint32_t col = dig.getCol();
+    aveCol += col;
+    aveRow += row;
+    if (refMod < 0)
+      refMod = mod;
+    if (mod != refMod) {
+      LOGP(error, "Mismatch in modID {} vs. {}", mod, refMod);
+      return false;
+    }
+    if (refRsu < 0)
+      refRsu = rsu;
+    if (rsu != refRsu) {
+      LOGP(error, "Mismatch in RSU {} vs. {}", rsu, refRsu);
+      return false;
+    }
+    if (refTile < 0)
+      refTile = tile;
+    if (tile != refTile) {
+      LOGP(error, "Mismatch in Tile {} vs. {}", tile, refTile);
+      return false;
+    }
+  }
+  aveCol /= clusiz;
+  aveRow /= clusiz;
+  float xLocClu, yLocClu;
+  UShort_t row0 = static_cast<UShort_t>(std::floor(aveRow));
+  UShort_t col0 = static_cast<UShort_t>(std::floor(aveCol));
+  bool cluOk = mSegmentation.indicesToLocal(refRsu, refTile, row0, col0, xLocClu, yLocClu);
+  xLocClu += (aveCol - col0) * pitchX;
+  yLocClu += (aveRow - row0) * pitchY;
+  double xyzGloClu[3];
+  getClusterGlobalCoord(refMod, xLocClu, yLocClu, xyzGloClu);
+  int layer = refMod / 4;
+  int cluID = mClustersPtr->size();
+
+  mClustersPtr->emplace_back(xyzGloClu[0], xyzGloClu[1], xyzGloClu[2], clusiz, layer);
+  auto& clu = mClustersPtr->back();
+  clu.setDetectorID(refMod);
+  // TODO: add calculation of errors on cluster coordinates
+
+  // add MC labels
+  int nCluLabels = 0;
+  for (const auto& pix : mPixArrBuff) {
+    if (nCluLabels >= MaxLabels)
+      break;
+    int jDig = pix.originalIndex;
+    std::span labels = mDigMCLabelsPtr->getLabels(jDig);
+    int nLabels = labels.size();
+    for (int jLab = 0; jLab < nLabels; jLab++) {
+      NA6PMCComposedLabel lbl = labels[jLab];
+      // Check if this label has already been added to our cluster accumulator
+      bool isDuplicate = false;
+      for (int jLabC = 0; jLabC < nCluLabels; ++jLabC) {
+        if (lbl == mLabelsBuff[jLabC]) {
+          isDuplicate = true;
+          break;
+        }
+      }
+      if (!isDuplicate) {
+        mLabelsBuff[nCluLabels++] = lbl;
+        if (nCluLabels >= MaxLabels)
+          break;
+      }
+    }
+  }
+  for (int jLabC = 0; jLabC < nCluLabels; ++jLabC) {
+    mCluMCLabelsPtr->addElement(cluID, mLabelsBuff[jLabC]);
+  }
+  return true;
+}
+
+void NA6PVerTelClusterizer::getClusterGlobalCoord(int modID, float xloc, float yloc, double xyzGlo[3]) const
+{
+  auto& matrix = mGeoManager.getMatrix(modID);
+  double xyzLoc[3];
+  xyzLoc[0] = xloc - mGeoManager.getModuleHalfX(modID);
+  xyzLoc[1] = yloc - mGeoManager.getModuleHalfY(modID);
+  xyzLoc[2] = 0.;
+  matrix.LocalToMaster(xyzLoc, xyzGlo);
+}

--- a/rec/src/NA6PVerTelClusterizer.cxx
+++ b/rec/src/NA6PVerTelClusterizer.cxx
@@ -268,8 +268,14 @@ bool NA6PVerTelClusterizer::pixelsToRecPoint()
   mClustersPtr->emplace_back(xyzGloClu[0], xyzGloClu[1], xyzGloClu[2], clusiz, layer);
   auto& clu = mClustersPtr->back();
   clu.setDetectorID(refMod);
-  // TODO: add calculation of errors on cluster coordinates
-
+  // Very preliminary definition of cluster uncertainties
+  // -> use pitch / sqrt(12) independently of cluster shape / size
+  //    to avoid penalizing large clusters
+  //    better tuning as a function of cluster shape should be done based
+  //    on MOSAIX characterization measurements
+  float sigX = pitchX / std::sqrt(12);
+  float sigY = pitchY / std::sqrt(12);
+  clu.setErr(sigX * sigX, 0., sigY * sigY);
   // add MC labels
   int nCluLabels = 0;
   for (const auto& pix : mPixArrBuff) {

--- a/rec/src/NA6PVerTelClusterizer.cxx
+++ b/rec/src/NA6PVerTelClusterizer.cxx
@@ -304,6 +304,9 @@ bool NA6PVerTelClusterizer::pixelsToRecPoint()
   for (int jLabC = 0; jLabC < nCluLabels; ++jLabC) {
     mCluMCLabelsPtr->addElement(cluID, mLabelsBuff[jLabC]);
   }
+  if (nCluLabels >= 0) {
+    clu.setParticleID(mLabelsBuff[0].getTrackID());
+  }
   return true;
 }
 

--- a/rec/src/NA6PVerTelReconstruction.cxx
+++ b/rec/src/NA6PVerTelReconstruction.cxx
@@ -5,6 +5,8 @@
 #include <TRandom3.h>
 #include <fairlogger/Logger.h>
 #include "NA6PVerTelHit.h"
+#include "NA6PMCComposedLabel.h"
+#include "NA6PVerTelDigit.h"
 #include "NA6PTrackerCA.h"
 #include "NA6PVertexerTracklets.h"
 #include "NA6PVerTelReconstruction.h"
@@ -13,6 +15,7 @@ NA6PVerTelReconstruction::NA6PVerTelReconstruction() : NA6PReconstruction("VerTe
 {
   initAll();
   mDigitizer.initGeometry();
+  mClusterizer.initGeometry();
 }
 
 NA6PVerTelReconstruction::~NA6PVerTelReconstruction()
@@ -55,6 +58,7 @@ void NA6PVerTelReconstruction::createClustersOutput()
   mClusFile = TFile::Open(nm.c_str(), "recreate");
   mClusTree = new TTree(fmt::format("clusters{}", getName()).c_str(), fmt::format("{} Clusters", getName()).c_str());
   mClusTree->Branch(getName().c_str(), &hClusPtr);
+  mClusTree->Branch(fmt::format("{}MCTruth", getName()).c_str(), &hCluMCLabelsPtr);
   LOGP(info, "Will store {} clusters in {}", getName(), nm);
 }
 
@@ -120,13 +124,27 @@ void NA6PVerTelReconstruction::hitsToRecPoints(const std::vector<NA6PVerTelHit>&
     int nDet = hit.getDetectorID();
     int idPart = hit.getTrackID();
     int layer = nDet / 4;
+    int cluID = mClusters.size();
     mClusters.emplace_back(x, y, z, clusiz, layer);
     auto& clu = mClusters.back();
     clu.setErr(ex2clu, 0., ey2clu);
     clu.setDetectorID(nDet);
     clu.setParticleID(idPart);
     clu.setHitID(jHit);
+    NA6PMCComposedLabel lbl(hit.getTrackID(), 0, 0);
+    mCluMCLabels.addElement(cluID, lbl);
   }
+}
+
+//____________________________________________________________________________________
+void NA6PVerTelReconstruction::digitsToRecPoints(const std::vector<NA6PVerTelDigit>& vtDigits, const NA6PMCTruthContainer& digMCLabels)
+{
+  int nDigits = vtDigits.size();
+  int nMClabels = digMCLabels.getNElements();
+  mClusterizer.process(vtDigits, digMCLabels, mClusters, mCluMCLabels);
+  int nCluMClabels = mCluMCLabels.getNElements();
+  int nClusters = mClusters.size();
+  LOGP(info, " --> nClusters = {} nCluMCLabels = {}", nClusters, nCluMClabels);
 }
 
 //____________________________________________________________________________________

--- a/rec/src/recLinkDef.h
+++ b/rec/src/recLinkDef.h
@@ -33,6 +33,7 @@
 #pragma link C++ class NA6PReconstruction + ;
 #pragma link C++ class NA6PVerTelReconstruction + ;
 #pragma link C++ class NA6PMuonSpecReconstruction + ;
+#pragma link C++ class NA6PVerTelClusterizer + ;
 #pragma link C++ class NA6PMatching + ;
 #pragma link C++ class NA6PVertexerTracklets + ;
 #pragma link C++ class NA6PVertexerTracks + ;

--- a/sim/src/NA6PVerTelSegmentation.cxx
+++ b/sim/src/NA6PVerTelSegmentation.cxx
@@ -108,7 +108,7 @@ bool NA6PVerTelSegmentation::localToIndices(float xloc, float yloc, UShort_t& rs
   xloc -= DeadXShort;
 
   bool isOk = computePixelIndices(xloc, yloc, DeadYBottom, DeadYTop, rsu, tile, row, col);
-  if (!isOk || col >= NColsPerTile || row >= NRowsPerTile) {
+  if (!isOk || col >= NColsPerTile || row >= NRowsPerTile || rsu >= NYSensors * (NXSegments / NSegmentsPerRSU) || tile >= NTilesPerRSU) {
     return false;
   }
   return true;

--- a/test/digitsToClusters.C
+++ b/test/digitsToClusters.C
@@ -1,0 +1,88 @@
+#include "NA6PMCTruthContainer.h"
+#include "NA6PVerTelHit.h"
+#include "NA6PVerTelDigit.h"
+#include "NA6PVerTelClusterizer.h"
+#include <TFile.h>
+#include <TTree.h>
+#include <TParticle.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TCanvas.h>
+#include <TStyle.h>
+
+std::vector<NA6PVerTelCluster> mClusters, *hClusPtr = &mClusters; // vector of clusters
+NA6PMCTruthContainer mMCLabels, *hMCLabelsPtr = &mMCLabels;       // MC labels
+TFile* mClusFile = nullptr;                                       // file with clusters
+TTree* mClusTree = nullptr;                                       // tree of clusters
+
+std::string getName()
+{
+  return "VerTel";
+}
+
+void createClustersOutput()
+{
+  auto nm = fmt::format("Clusters{}.root", getName());
+  mClusFile = TFile::Open(nm.c_str(), "recreate");
+  mClusTree = new TTree(fmt::format("clusters{}", getName()).c_str(), fmt::format("{} Clusters", getName()).c_str());
+  mClusTree->Branch(getName().c_str(), &hClusPtr);
+  mClusTree->Branch(fmt::format("{}MCTruth", getName()).c_str(), &hMCLabelsPtr);
+  LOGP(info, "Will store {} clusters in {}", getName(), nm);
+}
+
+void clearClusters()
+{
+  mClusters.clear();
+  mMCLabels.clear_andfreememory();
+}
+
+void writeClusters()
+{
+  if (mClusTree) {
+    mClusTree->Fill();
+  }
+  LOGP(info, "Saved {} clusters in tree with {} entries", mClusters.size(), mClusTree->GetEntries());
+}
+
+void closeClustersOutput()
+{
+  if (mClusTree && mClusFile) {
+    mClusFile->cd();
+    mClusTree->Write();
+    delete mClusTree;
+    mClusTree = nullptr;
+    mClusFile->Close();
+    delete mClusFile;
+    mClusFile = nullptr;
+  }
+}
+
+void digitsToClusters(const char* dirSimu = ".")
+{
+
+  TFile* fd = TFile::Open(Form("%s/DigitsVerTel.root", dirSimu));
+  TTree* td = (TTree*)fd->Get("digitsVerTel");
+  std::vector<NA6PVerTelDigit> vtDigits, *vtDigitsPtr = &vtDigits;
+  NA6PMCTruthContainer digMCLabels, *digMCLabelsPtr = &digMCLabels;
+  td->SetBranchAddress("VerTel", &vtDigitsPtr);
+  td->SetBranchAddress("VerTelMCTruth", &digMCLabelsPtr);
+  int nEv = td->GetEntries();
+  NA6PVerTelClusterizer cl;
+  cl.initGeometry();
+  createClustersOutput();
+
+  for (int jEv = 0; jEv < nEv; jEv++) {
+    td->GetEvent(jEv);
+    int nDigits = vtDigits.size();
+    int nMClabels = digMCLabels.getNElements();
+    LOGP(info, "Event {} nDigits = {} nDigMClabels = {}", jEv, nDigits, nMClabels);
+    clearClusters();
+    cl.process(vtDigits, digMCLabels, mClusters, mMCLabels);
+    int nCluMClabels = mMCLabels.getNElements();
+    int nClusters = mClusters.size();
+    LOGP(info, " --> nClusters = {} nCluMCLabels = {}", nClusters, nCluMClabels);
+    writeClusters();
+  }
+  closeClustersOutput();
+  fd->Close();
+}

--- a/test/plotVerTelClusters.C
+++ b/test/plotVerTelClusters.C
@@ -1,0 +1,219 @@
+#include "NA6PMCTruthContainer.h"
+#include "NA6PVerTelHit.h"
+#include "NA6PVerTelDigit.h"
+#include "NA6PVerTelClusterizer.h"
+#include <TFile.h>
+#include <TTree.h>
+#include <TParticle.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TCanvas.h>
+#include <TStyle.h>
+
+void plotVerTelClusters(const char* dirSimu = ".")
+{
+
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+
+  TFile* fh = new TFile(Form("%s/HitsVerTel.root", dirSimu));
+  TTree* th = (TTree*)fh->Get("hitsVerTel");
+  std::vector<NA6PVerTelHit> vtHits, *vtHitsPtr = &vtHits;
+  th->SetBranchAddress("VerTel", &vtHitsPtr);
+
+  TFile* fd = TFile::Open(Form("%s/DigitsVerTel.root", dirSimu));
+  TTree* td = (TTree*)fd->Get("digitsVerTel");
+  std::vector<NA6PVerTelDigit> vtDigits, *vtDigitsPtr = &vtDigits;
+  NA6PMCTruthContainer vtDigMCLabels, *vtDigMCLabelsPtr = &vtDigMCLabels;
+  td->SetBranchAddress("VerTel", &vtDigitsPtr);
+  td->SetBranchAddress("VerTelMCTruth", &vtDigMCLabelsPtr);
+
+  TFile* fc = TFile::Open(Form("%s/ClustersVerTel.root", dirSimu));
+  TTree* tc = (TTree*)fc->Get("clustersVerTel");
+  std::vector<NA6PVerTelCluster> vtClusters, *vtClustersPtr = &vtClusters;
+  NA6PMCTruthContainer vtCluMCLabels, *vtCluMCLabelsPtr = &vtCluMCLabels;
+  tc->SetBranchAddress("VerTel", &vtClustersPtr);
+  tc->SetBranchAddress("VerTelMCTruth", &vtCluMCLabelsPtr);
+
+  int nEv = tc->GetEntries();
+
+  TH1F* hMCLabelsPerCluster = new TH1F("hMCLabelsPerCluster", ";n MC labels per cluster; counts", 11, -0.5, 10.5);
+  TH1F* hCluSiz = new TH1F("hCluSiz", ";cluster size; counts", 11, -0.5, 10.5);
+  TH1F* hNCluPerHit = new TH1F("hNCluPerHit", ";n_{clusters}/n_{hits}", 100, 0.5, 1.);
+  TH1F* hNCluPerDigit = new TH1F("hNCluPerDigit", ";n_{clusters}/n_{digits}", 100, 0.5, 1.);
+  TH1F** hNCluPerEvent = new TH1F*[5];
+  TH2F** hXYClu = new TH2F*[5];
+  TH1F** hZClu = new TH1F*[5];
+  TH2F** hXYHit = new TH2F*[5];
+  TH1F** hZHit = new TH1F*[5];
+  for (int jLay = 0; jLay < 5; jLay++) {
+    hNCluPerEvent[jLay] = new TH1F(Form("hNCluPerEventLay%d", jLay), Form(";n_{Clusters, lay %d}/event;counts", jLay), 100, 0., 1000.);
+    hXYClu[jLay] = new TH2F(Form("hXYCluLay%d", jLay), Form("clusters layer %d", jLay), 100, -15., 15., 100, -15., 15.);
+    hZClu[jLay] = new TH1F(Form("hZCluLay%d", jLay), Form("clusters layer %d", jLay), 100, 0., 40.);
+    hXYHit[jLay] = new TH2F(Form("hXYHitLay%d", jLay), Form("hits layer %d", jLay), 100, -15., 15., 100, -15., 15.);
+    hZHit[jLay] = new TH1F(Form("hZHitLay%d", jLay), Form("hits layer %d", jLay), 100, 0., 40.);
+  }
+  TH1F* hDeltaXAll = new TH1F("hDeltaXAll", "All clusters;x_{glo}^{clu}-x_{glo}^{hit} (#mum);counts", 100, -300., 300.);
+  TH1F* hDeltaYAll = new TH1F("hDeltaYAll", "All clusters;y_{glo}^{clu}-y_{glo}^{hit} (#mum);counts", 100, -300., 300.);
+  TH1F* hDeltaXPrim = new TH1F("hDeltaXPrim", "Primary-particle clusters;x_{glo}^{clu}-x_{glo}^{hit} (#mum);counts", 100, -300., 300.);
+  TH1F* hDeltaYPrim = new TH1F("hDeltaYPrim", "Primary-particle clusters;y_{glo}^{clu}-y_{glo}^{hit} (#mum);counts", 100, -300., 300.);
+  TH1F* hDeltaXSingle = new TH1F("hDeltaXSingle", "Single-hit clusters;x_{glo}^{clu}-x_{glo}^{hit} (#mum);counts", 100, -300., 300.);
+  TH1F* hDeltaYSingle = new TH1F("hDeltaYSingle", "Single-hit clusters;y_{glo}^{clu}-y_{glo}^{hit} (#mum);counts", 100, -300., 300.);
+  TH2F** hDeltaXVsX = new TH2F*[20];
+  TH2F** hDeltaXVsY = new TH2F*[20];
+  TH2F** hDeltaYVsX = new TH2F*[20];
+  TH2F** hDeltaYVsY = new TH2F*[20];
+  for (int jMod = 0; jMod < 20; jMod++) {
+    hDeltaXVsX[jMod] = new TH2F(Form("hDeltaXVsXMod%d", jMod), ";x (cm); x_{glo}^{clu}-x_{glo}^{hit} (#mum);counts", 30, -15., 15., 100, -300000, 300000);
+    hDeltaXVsY[jMod] = new TH2F(Form("hDeltaXVsYMod%d", jMod), ";y (cm); x_{glo}^{clu}-x_{glo}^{hit} (#mum);counts", 30, -15., 15., 100, -300000, 300000);
+    hDeltaYVsX[jMod] = new TH2F(Form("hDeltaYVsXMod%d", jMod), ";x (cm); y_{glo}^{clu}-y_{glo}^{hit} (#mum);counts", 30, -15., 15., 100, -300000, 300000);
+    hDeltaYVsY[jMod] = new TH2F(Form("hDeltaYVsYMod%d", jMod), ";y (cm); y_{glo}^{clu}-x_{glo}^{hit} (#mum);counts", 30, -15., 15., 100, -300000, 300000);
+  }
+  for (int jEv = 0; jEv < nEv; jEv++) {
+    mcTree->GetEvent(jEv);
+    td->GetEvent(jEv);
+    th->GetEvent(jEv);
+    tc->GetEvent(jEv);
+    int nPart = mcArr->size();
+    int nHits = vtHits.size();
+    int nDigits = vtDigits.size();
+    int nDigMClabels = vtDigMCLabels.getNElements();
+    int nClusters = vtClusters.size();
+    int nCluMClabels = vtCluMCLabels.getNElements();
+    printf("Event %d particles = %d hits = %d digits = %d digMClabels = %d clusters = %d cluMClabels = %d\n", jEv, nPart, nHits, nDigits, nDigMClabels, nClusters, nCluMClabels);
+    hNCluPerHit->Fill((float)nClusters / (float)nHits);
+    hNCluPerDigit->Fill((float)nClusters / (float)nDigits);
+    for (const auto& hit : vtHits) {
+      int nDet = hit.getDetectorID();
+      int lay = nDet / 4;
+      if (lay < 0 || lay >= 5) {
+        printf("ERROR wrong layer %d\n", lay);
+        continue;
+      }
+      hXYHit[lay]->Fill(hit.getX(), hit.getY());
+      hZHit[lay]->Fill(hit.getZ());
+    }
+    int nCluPerLay[5] = {0, 0, 0, 0, 0};
+    for (int jClu = 0; jClu < nClusters; ++jClu) {
+      const auto& clu = vtClusters.at(jClu);
+      int lay = clu.getLayer();
+      int detID = clu.getDetectorID();
+      if (lay < 0 || lay >= 5) {
+        printf("ERROR wrong layer %d\n", lay);
+        continue;
+      }
+      nCluPerLay[lay]++;
+      hXYClu[lay]->Fill(clu.getX(), clu.getY());
+      hZClu[lay]->Fill(clu.getZ());
+      hCluSiz->Fill(clu.getClusterSize());
+      std::span labels = vtCluMCLabels.getLabels(jClu);
+      int nLabels = labels.size();
+      hMCLabelsPerCluster->Fill(nLabels);
+      if (nLabels == 1 && clu.getClusterSize() == 1) {
+        NA6PMCComposedLabel lbl = labels[0];
+        int trackID = lbl.getTrackID();
+        auto curPart = mcArr->at(trackID);
+        int nFoundHits = 0;
+        for (const auto& hit : vtHits) {
+          int idPart = hit.getTrackID();
+          int nDet = hit.getDetectorID();
+          if (idPart == trackID && detID == nDet) {
+            float dx = (clu.getX() - hit.getX()) * 1e4;
+            float dy = (clu.getY() - hit.getY()) * 1e4;
+            hDeltaXAll->Fill(dx);
+            hDeltaYAll->Fill(dy);
+            if (curPart.IsPrimary()) {
+              hDeltaXPrim->Fill(dx);
+              hDeltaYPrim->Fill(dy);
+            }
+            nFoundHits++;
+          }
+        }
+        if (nFoundHits == 1) {
+          for (const auto& hit : vtHits) {
+            int idPart = hit.getTrackID();
+            int nDet = hit.getDetectorID();
+            if (idPart == trackID && detID == nDet) {
+              float dx = (clu.getX() - hit.getX()) * 1e4;
+              float dy = (clu.getY() - hit.getY()) * 1e4;
+              hDeltaXSingle->Fill(dx);
+              hDeltaYSingle->Fill(dy);
+              hDeltaXVsX[nDet]->Fill(clu.getX(), dx);
+              hDeltaXVsY[nDet]->Fill(clu.getY(), dx);
+              hDeltaYVsX[nDet]->Fill(clu.getX(), dy);
+              hDeltaYVsY[nDet]->Fill(clu.getY(), dy);
+            }
+          }
+        }
+      }
+    }
+    for (int jLay = 0; jLay < 5; jLay++) {
+      hNCluPerEvent[jLay]->Fill(nCluPerLay[jLay]);
+    }
+  }
+
+  TCanvas* cclu = new TCanvas("cclu", "Clusters", 1400, 800);
+  cclu->Divide(3, 2);
+  cclu->cd(1);
+  hNCluPerEvent[0]->Draw();
+  cclu->cd(2);
+  hNCluPerEvent[4]->Draw();
+  cclu->cd(3);
+  hCluSiz->Draw();
+  cclu->cd(4);
+  hNCluPerHit->Draw();
+  cclu->cd(5);
+  hNCluPerDigit->Draw();
+  cclu->cd(6);
+  gPad->SetLogy();
+  hMCLabelsPerCluster->Draw();
+
+  TCanvas* cxyh = new TCanvas("cxyh", "Hits XY", 1400, 800);
+  cxyh->Divide(3, 2);
+  for (int jLay = 0; jLay < 5; jLay++) {
+    cxyh->cd(jLay + 1);
+    hXYHit[jLay]->Draw("colz");
+  }
+  TCanvas* cxyc = new TCanvas("cxyc", "Clusters XY", 1400, 800);
+  cxyc->Divide(3, 2);
+  for (int jLay = 0; jLay < 5; jLay++) {
+    cxyc->cd(jLay + 1);
+    hXYClu[jLay]->Draw("colz");
+  }
+
+  TCanvas* czh = new TCanvas("czh", "Hits Z", 1400, 800);
+  czh->Divide(3, 2);
+  for (int jLay = 0; jLay < 5; jLay++) {
+    czh->cd(jLay + 1);
+    hZHit[jLay]->Draw();
+  }
+  TCanvas* czc = new TCanvas("czc", "Clusters Z", 1400, 800);
+  czc->Divide(3, 2);
+  for (int jLay = 0; jLay < 5; jLay++) {
+    czc->cd(jLay + 1);
+    hZClu[jLay]->Draw("colz");
+  }
+  gStyle->SetOptStat(111111);
+  TCanvas* cdel = new TCanvas("cdel", "Residuals", 1400, 800);
+  cdel->Divide(3, 2);
+  cdel->cd(1);
+  gPad->SetLogy();
+  hDeltaXAll->Draw();
+  cdel->cd(2);
+  gPad->SetLogy();
+  hDeltaXPrim->Draw();
+  cdel->cd(3);
+  gPad->SetLogy();
+  hDeltaXSingle->Draw();
+  cdel->cd(4);
+  gPad->SetLogy();
+  hDeltaYAll->Draw();
+  cdel->cd(5);
+  gPad->SetLogy();
+  hDeltaYPrim->Draw();
+  cdel->cd(6);
+  gPad->SetLogy();
+  hDeltaYSingle->Draw();
+}


### PR DESCRIPTION
Hi,

this is a first implementation of a VT cluster finder.
The algorithm is the one of the ITS clusterizer in O2.
I adapted to the NA60+ case the interface to digits and the calculation of the  cluster position.

It depends on https://github.com/shahor02/NA6PRoot/pull/108 for the proper conversion from local to global coordinates.

I open this PR to start discussing some details of the algorithm and reviewing the code.

There are some features that are still missing:
- finalization of cluster information and storage (which may depend on https://github.com/shahor02/NA6PRoot/pull/99)
- definition of the uncertainties on the cluster (to be discussed)
- do we need the logic of isAcceptableSize to store the clusters if we do not plan to adopt a cluster dictionary as for ITS in O2? (to be discussed)
- inclusion in NA6PReconstruction (not yet done to avoid to clash with https://github.com/shahor02/NA6PRoot/pull/99)

Any feedback is welcome.

Cheers, Francesco