### PR TITLE
Fix macOS build issues

### DIFF
--- a/dependencies/Dependencies.cmake
+++ b/dependencies/Dependencies.cmake
@@ -46,7 +46,7 @@ include(${Geant4_USE_FILE})
 
 #----------------------------------------------------------------------------
 find_package(HDF5 REQUIRED COMPONENTS C CXX HL)
-find_package(ROOT REQUIRED COMPONENTS Core RIO Tree)
+find_package(ROOT REQUIRED COMPONENTS Core RIO Tree Geom)
 find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(fmt REQUIRED)
 find_package(FairLogger REQUIRED)

--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(${LIB_NAME}
     FairLogger::FairLogger
     baseLib
     utilsLib
+    simLib
 )
 
 # Installation instructions

--- a/sim/src/NA6PMC.cxx
+++ b/sim/src/NA6PMC.cxx
@@ -353,8 +353,8 @@ void NA6PMC::setupUserVertex(const std::string& s)
 void NA6PMC::setRandomSeed(Long64_t r)
 {
   if (r < 0) {
-    std::chrono::system_clock::time_point t0, t = std::chrono::high_resolution_clock::now();
-    mRandomSeed = std::chrono::duration_cast<std::chrono::nanoseconds>(t - t0).count();
+    auto t = std::chrono::system_clock::now().time_since_epoch();
+    mRandomSeed = std::chrono::duration_cast<std::chrono::nanoseconds>(t).count();
   } else {
     mRandomSeed = r;
   }


### PR DESCRIPTION
Fix macOS build issues
[ 35%] Linking CXX shared library libbaseLib.dylib Undefined symbols for architecture arm64: "TGeoHMatrix::TGeoHMatrix(TGeoMatrix const&)", referenced from: std::__1::vector<TGeoHMatrix, std::__1::allocator<TGeoHMatrix>>::__append(unsigned long) in NA6PGeometryManager.cxx.o

sim/src/NA6PMC.cxx:356:47: error: no viable conversion from 'time_point<steady_clock, duration<[...], ratio<[...], 1000000000>>>' to 'time_point<system_clock, duration<[...], ratio<[...], 1000000>>>' 356 | std::chrono::system_clock::time_point t0, t = std::chrono::high_resolution_clock::now();

NA6PVerTelReconstruction::hitsToRecPoints(std::__1::vector<NA6PVerTelHit, std::__1::allocator<NA6PVerTelHit>> const&) in NA6PVerTelReconstruction.cxx.o "NA6PVerTelSegmentation::isInAcc(float, float) const", referenced from: NA6PVerTelReconstruction::hitsToRecPoints(std::__1::vector<NA6PVerTelHit, std::__1::allocator<NA6PVerTelHit>> const&) in NA6PVerTelReconstruction.cxx.o ld: symbol(s) not found for architecture arm64 clang++: error: linker command failed with exit code 1 (use -v to see invocation)