### PR TITLE
Fix NIDs typo

### DIFF
--- a/rec/src/PID.cxx
+++ b/rec/src/PID.cxx
@@ -24,7 +24,7 @@
 PID::PID(const char* name) : mID(nameToID(name, First))
 {
   // construct from the name
-  assert(mID < NID);
+  assert(mID < NIDs);
 }
 
 //_______________________________


### PR DESCRIPTION
With the current code, while compiling, I get:
In file included from /home/giacomo/aliceo2/sw/ubuntu2204_x86-64/GCC-Toolchain/v14.2.0-alice2-1/include/c++/14.2.0/cassert:44,
                 from /home/giacomo/aliceo2/sw/ubuntu2204_x86-64/FairLogger/v2.1.0-5/include/fairlogger/Logger.h:35,
                 from /home/giacomo/NA6PRoot/rec/src/PID.cxx:21:
/home/giacomo/NA6PRoot/rec/src/PID.cxx: In constructor 'PID::PID(const char)':
/home/giacomo/NA6PRoot/rec/src/PID.cxx:27:16: error: 'NID' was not declared in this scope; did you mean 'NIDs'?
   27 |   assert(mID < NID);
      |                ^~~
make[2]: ** [rec/CMakeFiles/recLib.dir/build.make:328: rec/CMakeFiles/recLib.dir/src/PID.cxx.o] Error 1
make[1]: * [CMakeFiles/Makefile2:383: rec/CMakeFiles/recLib.dir/all] Error 2
make: * [Makefile:136: all] Error 2

I suspect NID is a typo.