### PR TITLE
Add class for secondary vertex fitting + test macro

### DIFF
--- a/rec/CMakeLists.txt
+++ b/rec/CMakeLists.txt
@@ -31,6 +31,7 @@ set(DICTIONARY_HEADERS
   NA6PVertex.h
   NA6PLine.h
   NA6PHelixHelper.h
+  NA6PDCAFitterN.h
   NA6PRecoParam.h
   NA6PReconstruction.h
   NA6PVerTelReconstruction.h

--- a/rec/include/NA6PDCAFitterN.h
+++ b/rec/include/NA6PDCAFitterN.h
@@ -1,0 +1,1034 @@
+#ifndef _NA6P_DCA_FITTERN_H
+#define _NA6P_DCA_FITTERN_H
+
+#include <Math/SVector.h>
+#include <Math/SMatrix.h>
+#include <fairlogger/Logger.h>
+#include "NA6PTrack.h"
+#include "NA6PHelixHelper.h"
+
+using CircleXZ = NA6PHelixHelper::CircleXZ;
+
+struct TrackCovI {
+  float sxx, syy, sxy, szz;
+
+  TrackCovI(const NA6PTrack& trc, float zerrFactor = 1.f) { set(trc, zerrFactor); }
+  TrackCovI() = default;
+  bool set(const NA6PTrack& trc, float zerrFactor = 1.f)
+  {
+    float cxx = trc.getSigmaX2(), cyy = trc.getSigmaY2(), cxy = trc.getSigmaYX(), czz = cyy * zerrFactor;
+    float detXY = cxx * cyy - cxy * cxy;
+    bool res = true;
+    if (detXY <= 0.) {
+      cxy = std::sqrt(cxx * cyy) * (cxy > 0 ? 0.98f : -0.98f);
+      detXY = cxx * cyy - cxy * cxy;
+      res = false;
+    }
+    auto detXYI = 1. / detXY;
+    sxx = cyy * detXYI;
+    syy = cxx * detXYI;
+    sxy = -cxy * detXYI;
+    szz = 1. / czz;
+    return res;
+  }
+};
+
+struct TrackDeriv {
+  float dxdz, dydz, d2xdz2, d2ydz2;
+  TrackDeriv() = default;
+  TrackDeriv(const NA6PTrack& trc, float by) { set(trc, by); }
+  void set(const NA6PTrack& trc, float by)
+  {
+    auto pxyz = trc.getPXYZ();
+    if (std::abs(pxyz[2]) < 1e-9)
+      return;
+    dxdz = pxyz[0] / pxyz[2];
+    dydz = pxyz[1] / pxyz[2];
+    // Second derivatives:
+    // d^2x/dz^2 = d/dz(px/pz) = 1/pz * (dpx/dz) - px/pz^2 (dpz/dz)
+    // Tangents to circumference of radius R in two points separated by dz
+    // theta = angle spanned by R
+    // dpx/dz = p_xz/R
+    // dpz = pxz*(1-cos(theta)) = pxz*2*sin^2(theta/2) ~ pxz*2*(theta/2)^2 ~ (p_xz/R)*dz^2 / 2
+    // dpz/dz ~ (p_xz/R)*dz/2 --> negligible
+    // d2xdz2 ~ 1/pz * (dpx/dz) = p_xz/pz * 1/R = sqrt((px/pz)^2 + 1) * 1/R
+    float crv2c = trc.getCurvature(by);
+    d2xdz2 = crv2c * std::sqrt(1.f + dxdz * dxdz);
+    //  d^2y/dz^2 = d/dz(py/pz) = 0 (dipole field, py is conserved, and dpz/dz is negligible)
+    d2ydz2 = 0.f;
+  }
+};
+
+template <int N, typename... Args>
+class NA6PDCAFitterN
+{
+  static constexpr double NMin = 2;
+  static constexpr double NMax = 4;
+  static constexpr double NInv = 1. / N;
+  static constexpr int MAXHYP = 2;
+  static constexpr float ZerrFactor = 5.; // factor for conversion of track covYY to dummy covXX
+  using Vec3D = ROOT::Math::SVector<double, 3>;
+  using VecND = ROOT::Math::SVector<double, N>;
+  using MatSym3D = ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>>;
+  using MatStd3D = ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepStd<double, 3>>;
+  using MatSymND = ROOT::Math::SMatrix<double, N, N, ROOT::Math::MatRepSym<double, N>>;
+  using ArrTrack = std::array<NA6PTrack, N>;     // container for prongs (tracks) at single vertex cand.
+  using ArrTrackCovI = std::array<TrackCovI, N>; // container for inv.cov.matrices at single vertex cand.
+  using ArrTrCoef = std::array<MatStd3D, N>;     // container of TrackCoefVtx coefficients at single vertex cand.
+  using ArrTrDer = std::array<TrackDeriv, N>;    // container of Track 1st and 2nd derivative over their Z param
+  using ArrTrPos = std::array<Vec3D, N>;         // container of Track positions
+
+ public:
+  enum BadCovPolicy : uint8_t { // if encountering non-positive defined cov. matrix, the choice is:
+    Discard = 0,                // stop evaluation
+    Override = 1,               // override correlation coef. to have cov.matrix pos.def and continue
+    OverrideAndFlag = 2         // override correlation coef. to have cov.matrix pos.def, set mPropFailed flag of corresponding candidate to true and continue (up to the user to check the flag)
+  };
+
+  enum FitStatus : uint8_t { // fit status of crossing hypothesis
+    None,                    // no status set (should not be possible!)
+
+    /* Good Conditions */
+    Converged, // fit converged
+    MaxIter,   // max iterations reached before fit convergence
+
+    /* Error Conditions */
+    NoCrossing,      // no reasaonable crossing was found
+    RejFiducialVol,  // postion of crossing was not acceptable
+    RejTrackZ,       // one candidate track x was below the mimimum required radius
+    RejTrackRoughZ,  // rejected by rough cut on tracks Z difference
+    RejChi2Max,      // rejected by maximum chi2 cut
+    FailProp,        // propagation of at least prong to PCA failed
+    FailInvCov,      // inversion of cov.-matrix failed
+    FailInvWeight,   // inversion of Ti weight matrix failed
+    FailInv2ndDeriv, // inversion of 2nd derivatives failed
+    FailCorrTracks,  // correction of tracks to updated x failed
+    FailCloserAlt,   // alternative PCA is closer
+    //
+    NStatusesDefined
+  };
+
+  static constexpr int getNProngs() { return N; }
+
+  NA6PDCAFitterN() = default;
+  NA6PDCAFitterN(float by, bool useAbsDCA, bool prop2DCA) : mBy(by), mUseAbsDCA(useAbsDCA), mPropagateToPCA(prop2DCA)
+  {
+    static_assert(N >= NMin && N <= NMax, "N prongs outside of allowed range");
+  }
+
+  //=========================================================================
+  ///< return PCA candidate, by default best on is provided (no check for the index validity)
+  const Vec3D& getPCACandidate(int cand = 0) const { return mPCA[mOrder[cand]]; }
+  const auto getPCACandidatePos(int cand = 0) const
+  {
+    const auto& vd = mPCA[mOrder[cand]];
+    return std::array<float, 3>{static_cast<float>(vd[0]), static_cast<float>(vd[1]), static_cast<float>(vd[2])};
+  }
+
+  ///< return position of quality-ordered candidate in the internal structures
+  int getCandidatePosition(int cand = 0) const { return mOrder[cand]; }
+
+  ///< return Chi2 at PCA candidate (no check for its validity)
+  float getChi2AtPCACandidate(int cand = 0) const { return mChi2[mOrder[cand]]; }
+
+  ///< prepare copies of tracks at the V0 candidate (no check for the candidate validity)
+  ///  must be called before getTrack(i,cand) query
+  bool propagateTracksToVertex(int cand = 0);
+
+  ///< check if propagation of tracks to candidate vertex was done
+  bool isPropagateTracksToVertexDone(int cand = 0) const { return mTrPropDone[mOrder[cand]]; }
+
+  ///< check if propagation of tracks to candidate vertex failed
+  bool isPropagationFailure(int cand = 0) const { return mPropFailed[mOrder[cand]]; }
+
+  ///< track param propagated to V0 candidate (no check for the candidate validity)
+  ///  propagateTracksToVertex must be called in advance
+  NA6PTrack& getTrack(int i, int cand = 0)
+  {
+    if (!mTrPropDone[mOrder[cand]]) {
+      LOGP(error, "propagateTracksToVertex was not called yet");
+    }
+    return mCandTr[mOrder[cand]][i];
+  }
+
+  const NA6PTrack& getTrack(int i, int cand = 0) const
+  {
+    if (!mTrPropDone[mOrder[cand]]) {
+      LOGP(error, "propagateTracksToVertex was not called yet");
+    }
+    return mCandTr[mOrder[cand]][i];
+  }
+
+  ///< create parent track param with errors for decay vertex
+  NA6PTrack createParentTrackParCov(int cand = 0) const; // TODO: update to use NA6PTRackParCov
+
+  ///< create parent track param w/o errors for decay vertex
+  NA6PTrack createParentTrackPar(int cand = 0) const;
+
+  ///< recalculate PCA as a cov-matrix weighted mean, even if absDCA method was used
+  bool recalculatePCAWithErrors(int cand = 0);
+
+  MatSym3D calcPCACovMatrix(int cand = 0) const;
+
+  std::array<float, 6> calcPCACovMatrixFlat(int cand = 0) const
+  {
+    auto m = calcPCACovMatrix(cand);
+    return {static_cast<float>(m(0, 0)), static_cast<float>(m(1, 0)), static_cast<float>(m(1, 1)), static_cast<float>(m(2, 0)), static_cast<float>(m(2, 1)), static_cast<float>(m(2, 2))};
+  }
+
+  const NA6PTrack* getOrigTrackPtr(int i) const { return mOrigTrPtr[i]; }
+
+  FitStatus getFitStatus(int cand = 0) const noexcept { return mFitStatus[mOrder[cand]]; }
+
+  ///< return number of iterations during minimization (no check for its validity)
+  int getNIterations(int cand = 0) const { return mNIters[mOrder[cand]]; }
+  void setPropagateToPCA(bool v = true) { mPropagateToPCA = v; }
+  void setMaxIter(int n = 20) { mMaxIter = n > 2 ? n : 2; }
+  void setMaxDZIni(float d = 4.) { mMaxDZIni = d; }
+  void setMaxDXZIni(float d = 4.) { mMaxDXZIni = d > 0 ? d : 1e9; }
+  void setMaxChi2(float chi2 = 999.) { mMaxChi2 = chi2; }
+  void setBy(float by) { mBy = std::abs(by) > 1.e-12 ? by : 0.f; }
+  void setMinParamChange(float x = 1e-3) { mMinParamChange = x > 1e-4 ? x : 1.e-4; }
+  void setMinRelChi2Change(float r = 0.9) { mMinRelChi2Change = r > 0.1 ? r : 999.; }
+  void setUseAbsDCA(bool v) { mUseAbsDCA = v; }
+  void setWeightedFinalPCA(bool v) { mWeightedFinalPCA = v; }
+  void setMaxDistance2ToMerge(float v) { mMaxDist2ToMergeSeeds = v; }
+  void setUsePropagator(bool v) { mUsePropagator = v; }
+  void setRefitWithMatCorr(bool v) { mRefitWithMatCorr = v; }
+  void setMaxVertX(float x) { mMaxVertX = x; }
+  void setMinVertZ(float z) { mMinVertZ = z; }
+  void setMaxVertZ(float z) { mMaxVertZ = z; }
+  void setCollinear(bool isCollinear) { mIsCollinear = isCollinear; }
+
+  int getNCandidates() const { return mCurHyp; }
+  int getMaxIter() const { return mMaxIter; }
+  float getMaxDZIni() const { return mMaxDZIni; }
+  float getMaxDXZIni() const { return mMaxDXZIni; }
+  float getMaxChi2() const { return mMaxChi2; }
+  float getMinParamChange() const { return mMinParamChange; }
+  float getBy() const { return mBy; }
+  float getMaxDistance2ToMerge() const { return mMaxDist2ToMergeSeeds; }
+  bool getUseAbsDCA() const { return mUseAbsDCA; }
+  bool getWeightedFinalPCA() const { return mWeightedFinalPCA; }
+  bool getPropagateToPCA() const { return mPropagateToPCA; }
+  bool getUsePropagator() const { return mUsePropagator; }
+  bool getRefitWithMatCorr() const { return mRefitWithMatCorr; }
+  float getMaxVertX() const { return mMaxVertX; }
+  float getMinVertZ() const { return mMinVertZ; }
+  float getMaxVertZ() const { return mMaxVertZ; }
+
+  template <class... Tr>
+  int process(const Tr&... args);
+
+ protected:
+  bool calcPCACoefs();
+  bool calcInverseWeight();
+  void calcResidDerivatives();
+  void calcResidDerivativesNoErr();
+  void calcChi2Derivatives();
+  void calcChi2DerivativesNoErr();
+  void calcPCA();
+  void calcPCANoErr();
+  void calcTrackResiduals();
+  void calcTrackDerivatives();
+  double calcChi2() const;
+  double calcChi2NoErr() const;
+  bool correctTracks(const VecND& corrZ);
+  bool minimizeChi2();
+  bool minimizeChi2NoErr();
+  bool roughDZCut() const;
+  bool closerToAlternative() const;
+  bool propagateToZ(NA6PTrack& t, float z) const;
+  bool propagateParamToZ(NA6PTrack& t, float z) const;
+
+  static double getAbsMax(const VecND& v);
+  ///< track param positions at V0 candidate (no check for the candidate validity)
+  const Vec3D& getTrackPos(int i, int cand = 0) const { return mTrPos[mOrder[cand]][i]; }
+
+  void assign(int) {}
+
+  template <class T, class... Tr>
+  void assign(int i, const T& t, const Tr&... args)
+  {
+    mOrigTrPtr[i] = &t;
+    assign(i + 1, args...);
+  }
+
+  void clear()
+  {
+    mCurHyp = 0;
+    mAllowAltPreference = true;
+    mOrder.fill(0);
+    mPropFailed.fill(false);
+    mTrPropDone.fill(false);
+    mNIters.fill(0);
+    mChi2.fill(-1);
+    mFitStatus.fill(FitStatus::None);
+  }
+
+  static void setTrackPos(Vec3D& pnt, const NA6PTrack& tr)
+  {
+    pnt[0] = tr.getX();
+    pnt[1] = tr.getY();
+    pnt[2] = tr.getZ();
+  }
+
+  void setBadCovPolicy(BadCovPolicy v) { mBadCovPolicy = v; }
+  BadCovPolicy getBadCovPolicy() const { return mBadCovPolicy; }
+
+ private:
+  // vectors of 1st derivatives of track local residuals over Z parameters
+  std::array<std::array<Vec3D, N>, N> mDResidDz;
+  // vectors of 1nd derivatives of track local residuals over Z parameters
+  // (cross-derivatives DR/(dx_j*dx_k) = 0 for j!=k, therefore the hessian is diagonal)
+  std::array<std::array<Vec3D, N>, N> mD2ResidDz2;
+  VecND mDChi2Dz;                             // 1st derivatives of chi2 over tracks X params
+  MatSymND mD2Chi2Dz2;                        // 2nd derivatives of chi2 over tracks Z params (symmetric matrix)
+  std::array<const NA6PTrack*, N> mOrigTrPtr; // Pointers to original tracks
+  std::array<CircleXZ, N> mTrAux;             // Aux track info for each track at each cand. vertex
+  MatSym3D mWeightInv;                        // inverse weight of single track, [sum{M^T E M}]^-1 in EQ.T
+  std::array<int, MAXHYP> mOrder{0};
+  std::array<ArrTrack, MAXHYP> mCandTr;       // tracks at each cond. vertex (Note: Errors are at seed XZ point)
+  std::array<ArrTrCoef, MAXHYP> mTrCFVT;      // TrackCoefVtx for each track at each cand. vertex
+  std::array<ArrTrackCovI, MAXHYP> mTrcEInv;  // errors for each track at each cand. vertex
+  std::array<ArrTrDer, MAXHYP> mTrDer;        // Track derivatives
+  std::array<ArrTrPos, MAXHYP> mTrPos;        // Track positions
+  std::array<ArrTrPos, MAXHYP> mTrRes;        // Track residuals
+  std::array<Vec3D, MAXHYP> mPCA;             // PCA for each vertex candidate
+  std::array<float, MAXHYP> mChi2 = {0};      // Chi2 at PCA candidate
+  std::array<int, MAXHYP> mNIters;            // number of iterations for each seed
+  std::array<bool, MAXHYP> mTrPropDone{};     // Flag that the tracks are fully propagated to PCA
+  std::array<bool, MAXHYP> mPropFailed{};     // Flag that some propagation failed for this PCA candidate
+  std::array<FitStatus, MAXHYP> mFitStatus{}; // fit status of each hypothesis fit
+  NA6PHelixHelper mCrossings;                 // info on track crossing
+  int mCurHyp = 0;
+  int mCrossIDCur = 0;
+  int mCrossIDAlt = -1;
+  BadCovPolicy mBadCovPolicy{BadCovPolicy::Discard}; // what to do in case of non-pos-def. cov. matrix, see BadCovPolicy enum
+  bool mAllowAltPreference = true;                   // if the fit converges to alternative PCA seed, abandon the current one
+  bool mUseAbsDCA = false;                           // use abs. distance minimization rather than chi2
+  bool mWeightedFinalPCA = false;                    // recalculate PCA as a cov-matrix weighted mean, even if absDCA method was used
+  bool mPropagateToPCA = true;                       // create tracks version propagated to PCA
+  bool mUsePropagator = false;                       // use propagator with 3D B-field, set automatically if material correction is requested
+  bool mRefitWithMatCorr = false;                    // when doing propagateTracksToVertex, propagate tracks to V0 with material corrections and rerun minimization again
+  bool mIsCollinear = false;                         // use collinear fits when there 2 crossing points
+  int mMaxIter = 20;                                 // max number of iterations
+  float mBy = 0;                                     // by field, to be set by user
+  float mMaxVertX = 30.;                             // maximum vertex X coordinate
+  float mMinVertZ = -10.;                            // minimum vertex Z coordinate
+  float mMaxVertZ = 40.;                             // maximum vertex Z coordinate
+  float mMaxDZIni = 4.;                              // reject (if>0) PCA candidate if tracks DZ exceeds threshold
+  float mMaxDXZIni = 4.;                             // reject (if>0) PCA candidate if tracks dXY exceeds threshold
+  float mMinParamChange = 1e-3;                      // stop iterations if largest change of any X is smaller than this
+  float mMinRelChi2Change = 0.9;                     // stop iterations is chi2/chi2old > this
+  float mMaxChi2 = 100;                              // abs cut on chi2 or abs distance
+  float mMaxDist2ToMergeSeeds = 1.;                  // merge 2 seeds to their average if their distance^2 is below the threshold
+
+  ClassDefNV(NA6PDCAFitterN, 1);
+};
+
+///_________________________________________________________________________
+template <int N, typename... Args>
+template <class... Tr>
+int NA6PDCAFitterN<N, Args...>::process(const Tr&... args)
+{
+  // This is a main entry point: fit PCA of N tracks
+  static_assert(sizeof...(args) == N, "incorrect number of input tracks");
+  assign(0, args...);
+  clear();
+  for (int i = 0; i < N; i++) {
+    std::array<float, 3> par =mOrigTrPtr[i]->getCircleParams(mBy);
+    mTrAux[i][NA6PHelixHelper::kR] = par[0];
+    mTrAux[i][NA6PHelixHelper::kX] = par[1];
+    mTrAux[i][NA6PHelixHelper::kZ] = par[2];
+  }
+  if (!mCrossings.set(mTrAux[0], *mOrigTrPtr[0], mTrAux[1], *mOrigTrPtr[1], mMaxDXZIni, mIsCollinear)) { // even for N>2 it should be enough to test just 1 loop
+    mFitStatus[mCurHyp] = FitStatus::NoCrossing;
+    return 0;
+  }
+  if (mCrossings.nDCA == MAXHYP) { // if there are 2 candidates and they are too close, chose their mean as a starting point
+    auto dst2 = (mCrossings.xDCA[0] - mCrossings.xDCA[1]) * (mCrossings.xDCA[0] - mCrossings.xDCA[1]) +
+                (mCrossings.zDCA[0] - mCrossings.zDCA[1]) * (mCrossings.zDCA[0] - mCrossings.zDCA[1]);
+    if (dst2 < mMaxDist2ToMergeSeeds) {
+      mCrossings.nDCA = 1;
+      mCrossings.xDCA[0] = 0.5 * (mCrossings.xDCA[0] + mCrossings.xDCA[1]);
+      mCrossings.zDCA[0] = 0.5 * (mCrossings.zDCA[0] + mCrossings.zDCA[1]);
+    }
+  }
+  // check all crossings
+  for (int ic = 0; ic < mCrossings.nDCA; ic++) {
+    // check if radius is acceptable
+    if (mCrossings.zDCA[ic] > mMaxVertZ ||
+        mCrossings.zDCA[ic] < mMinVertZ ||
+        std::abs(mCrossings.xDCA[ic]) > mMaxVertX) {
+      mFitStatus[mCurHyp] = FitStatus::RejFiducialVol;
+      continue;
+    }
+    mCrossIDCur = ic;
+    mCrossIDAlt = (mCrossings.nDCA == 2 && mAllowAltPreference) ? 1 - ic : -1; // works for max 2 crossings
+    mPCA[mCurHyp][0] = mCrossings.xDCA[ic];
+    mPCA[mCurHyp][2] = mCrossings.zDCA[ic];
+
+    if (mUseAbsDCA ? minimizeChi2NoErr() : minimizeChi2()) {
+      mOrder[mCurHyp] = mCurHyp;
+      if (mPropagateToPCA && !propagateTracksToVertex(mCurHyp)) {
+        continue; // discard candidate if failed to propagate to it
+      }
+      mCurHyp++;
+    }
+  }
+
+  for (int i = mCurHyp; i--;) { // order in quality
+    for (int j = i; j--;) {
+      if (mChi2[mOrder[i]] < mChi2[mOrder[j]]) {
+        std::swap(mOrder[i], mOrder[j]);
+      }
+    }
+  }
+  if (mUseAbsDCA && mWeightedFinalPCA) {
+    for (int i = mCurHyp; i--;) {
+      recalculatePCAWithErrors(i);
+    }
+  }
+  return mCurHyp;
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+bool NA6PDCAFitterN<N, Args...>::calcPCACoefs()
+{
+  //< calculate Ti matrices for global vertex decomposition to V = sum_{0<i<N} Ti pi, see EQ.T in the ref
+  if (!calcInverseWeight()) {
+    mFitStatus[mCurHyp] = FitStatus::FailInvWeight;
+    return false;
+  }
+  for (int i = N; i--;) { // build Mi*Ei matrix
+    const auto& taux = mTrAux[i];
+    const auto& tcov = mTrcEInv[mCurHyp][i];
+    MatStd3D miei;
+    miei[0][0] = tcov.sxx;
+    miei[0][1] = tcov.sxy;
+    miei[0][2] = 0;
+    miei[1][0] = tcov.sxy;
+    miei[1][1] = tcov.syy;
+    miei[1][2] = 0;
+    miei[2][0] = 0;
+    miei[2][1] = 0;
+    miei[2][2] = tcov.szz;
+    mTrCFVT[mCurHyp][i] = mWeightInv * miei;
+  }
+  return true;
+}
+//__________________________________________________________________________
+template <int N, typename... Args>
+bool NA6PDCAFitterN<N, Args...>::calcInverseWeight()
+{
+  //< calculate [sum_{0<j<N} M_j*E_j*M_j^T]^-1 used for Ti matrices, see EQ.T
+  auto* arrmat = mWeightInv.Array();
+  memset(arrmat, 0, sizeof(mWeightInv));
+  enum { XX,
+         XY,
+         YY,
+         XZ,
+         YZ,
+         ZZ };
+  for (int i = N; i--;) {
+    const auto& taux = mTrAux[i];
+    const auto& tcov = mTrcEInv[mCurHyp][i];
+    arrmat[XX] += tcov.sxx;
+    arrmat[XY] += tcov.sxy;
+    arrmat[XZ] += 0;
+    arrmat[YY] += tcov.syy;
+    arrmat[YZ] += 0;
+    arrmat[ZZ] += tcov.szz;
+  }
+  // invert 3x3 symmetrix matrix
+  return mWeightInv.Invert();
+}
+//__________________________________________________________________________
+template <int N, typename... Args>
+void NA6PDCAFitterN<N, Args...>::calcResidDerivatives()
+{
+  //< calculate matrix of derivatives for weighted chi2: residual i vs parameter X of track j
+  for (int i = N; i--;) {                     // residual being differentiated
+    for (int j = N; j--;) {                   // track over which we differentiate
+      const auto& matT = mTrCFVT[mCurHyp][j]; // coefficient matrix for track J
+      const auto& trDz = mTrDer[mCurHyp][j];  // track point derivs over track Z param
+      auto& dr1 = mDResidDz[i][j];
+      auto& dr2 = mD2ResidDz2[i][j];
+
+      // calculate DResid_i/Dz_j = (delta_ij - M_i^tr * T_j) * DTrack_k/Dz_k
+      dr1[0] = -(matT[0][0] * trDz.dxdz + matT[0][1] * trDz.dydz + matT[0][2]);
+      dr1[1] = -(matT[1][0] * trDz.dxdz + matT[1][1] * trDz.dydz + matT[1][2]);
+      dr1[2] = -(matT[2][0] * trDz.dxdz + matT[2][1] * trDz.dydz + matT[2][2]);
+
+      // calculate D2Resid_I/(Dz_J Dz_K) = (delta_ijk - M_i^tr * T_j * delta_jk) * D2Track_k/dx_k^2
+      dr2[0] = -(matT[0][0] * trDz.d2xdz2 + matT[0][1] * trDz.d2ydz2);
+      dr2[1] = -(matT[1][0] * trDz.d2xdz2 + matT[1][1] * trDz.d2ydz2);
+      dr2[2] = -(matT[2][0] * trDz.d2xdz2 + matT[2][1] * trDz.d2ydz2);
+
+      if (i == j) {
+        dr1[0] += trDz.dxdz;
+        dr1[1] += trDz.dydz;
+        dr1[2] += 1.;
+
+        dr2[0] += trDz.d2xdz2;
+        dr2[1] += trDz.d2ydz2;
+        // dr2[2] += 0 (Since d2z/dz2 is identically zero)
+      }
+    } // track over which we differentiate
+  }   // residual being differentiated
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+void NA6PDCAFitterN<N, Args...>::calcResidDerivativesNoErr()
+{
+  //< calculate matrix of derivatives for absolute distance chi2: residual i vs parameter X of track j
+  constexpr double NInv1 = 1. - NInv;       // profit from Rii = I/Ninv
+  for (int i = N; i--;) {                   // residual being differentiated
+    const auto& trDzi = mTrDer[mCurHyp][i]; // track point derivs over track Z param
+    auto& dr1ii = mDResidDz[i][i];
+    auto& dr2ii = mD2ResidDz2[i][i];
+    dr1ii[0] = NInv1 * trDzi.dxdz;
+    dr1ii[1] = NInv1 * trDzi.dydz;
+    dr1ii[2] = NInv1;
+
+    dr2ii[0] = NInv1 * trDzi.d2xdz2;
+    dr2ii[1] = NInv1 * trDzi.d2ydz2;
+    dr2ii[2] = 0;
+
+    for (int j = i; j--;) { // track over which we differentiate
+      auto& dr1ij = mDResidDz[i][j];
+      auto& dr1ji = mDResidDz[j][i];
+      const auto& trDzj = mTrDer[mCurHyp][j]; // track point derivs over track Z param
+
+      // calculate DResid_i/Dz_j = (delta_ij - R_ij) * DTrack_j/Dz_j  for j<i
+      dr1ij[0] = -trDzj.dxdz * NInv;
+      dr1ij[1] = -trDzj.dydz * NInv;
+      dr1ij[2] = -NInv;
+
+      // calculate DResid_j/Dz_i = (delta_ij - R_ji) * DTrack_i/Dz_i  for j<i
+      dr1ji[0] = -trDzi.dxdz * NInv;
+      dr1ji[1] = -trDzi.dydz * NInv;
+      dr1ji[2] = -NInv;
+
+      auto& dr2ij = mD2ResidDz2[i][j];
+      auto& dr2ji = mD2ResidDz2[j][i];
+      // calculate D2Resid_I/(Dz_J Dz_K) = (delta_ij - Rij) * D2Track_j/dz_j^2 * delta_jk for j<i
+      dr2ij[0] = -trDzj.d2xdz2 * NInv;
+      dr2ij[1] = -trDzj.d2ydz2 * NInv;
+      dr2ij[2] = 0;
+
+      // calculate D2Resid_j/(Dx_i Dx_k) = (delta_ij - Rji) * D2Track_i/dx_i^2 * delta_ik for j<i
+      dr2ji[0] = -trDzi.d2xdz2 * NInv;
+      dr2ji[1] = -trDzi.d2ydz2 * NInv;
+      dr2ji[2] = 0;
+
+    } // track over which we differentiate
+  }   // residual being differentiated
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+void NA6PDCAFitterN<N, Args...>::calcChi2Derivatives()
+{
+  //< calculate 1st and 2nd derivatives of wighted DCA (chi2) over track parameters X, see EQ.Chi2 in the ref
+  std::array<std::array<Vec3D, N>, N> covIDrDz; // tempory vectors of covI_j * dres_j/dz_i
+
+  // chi2 1st derivative
+  for (int i = N; i--;) {
+    auto& dchi1 = mDChi2Dz[i]; // DChi2/Dz_i = sum_j { res_j * covI_j * Dres_j/Dz_i }
+    dchi1 = 0;
+    for (int j = N; j--;) {
+      const auto& res = mTrRes[mCurHyp][j];    // vector of residuals of track j
+      const auto& covI = mTrcEInv[mCurHyp][j]; // inverse cov matrix of track j
+      const auto& dr1 = mDResidDz[j][i];       // vector of j-th residuals 1st derivative over Z param of track i
+      auto& cidr = covIDrDz[i][j];             // vector covI_j * dres_j/dz_i, save for 2nd derivative calculation
+      cidr[0] = covI.sxx * dr1[0] + covI.sxy * dr1[1];
+      cidr[1] = covI.sxy * dr1[0] + covI.syy * dr1[1];
+      cidr[2] = covI.szz * dr1[2];
+      // calculate res_i * covI_j * dres_j/dx_i
+      dchi1 += ROOT::Math::Dot(res, cidr);
+    }
+  }
+  // chi2 2nd derivative
+  for (int i = N; i--;) {
+    for (int j = i + 1; j--;) {       // symmetric matrix
+      auto& dchi2 = mD2Chi2Dz2[i][j]; // D2Chi2/Dz_i/Dz_j = sum_k { Dres_k/Dz_j * covI_k * Dres_k/Dz_i + res_k * covI_k * D2res_k/Dz_i/Dz_j }
+      dchi2 = 0;
+      for (int k = N; k--;) {
+        const auto& dr1j = mDResidDz[k][j];  // vector of k-th residuals 1st derivative over Z param of track j
+        const auto& cidrkj = covIDrDz[i][k]; // vector covI_k * dres_k/dz_i
+        dchi2 += ROOT::Math::Dot(dr1j, cidrkj);
+        if (k == j) {
+          const auto& res = mTrRes[mCurHyp][k];    // vector of residuals of track k
+          const auto& covI = mTrcEInv[mCurHyp][k]; // inverse cov matrix of track k
+          const auto& dr2ij = mD2ResidDz2[k][j];   // vector of k-th residuals 2nd derivative over Z params of track j
+          dchi2 += res[0] * (covI.sxx * dr2ij[0] + covI.sxy * dr2ij[1]) + res[1] * (covI.sxy * dr2ij[0] + covI.syy * dr2ij[1]) + res[2] * covI.szz * dr2ij[2];
+        }
+      }
+    }
+  }
+}
+//__________________________________________________________________________
+template <int N, typename... Args>
+void NA6PDCAFitterN<N, Args...>::calcChi2DerivativesNoErr()
+{
+  //< calculate 1st and 2nd derivatives of abs DCA (chi2) over track parameters X, see (6) in the ref
+  for (int i = N; i--;) {
+    auto& dchi1 = mDChi2Dz[i]; // DChi2/Dz_i = sum_j { res_j * Dres_j/Dz_i }
+    dchi1 = 0;                 // chi2 1st derivative
+    for (int j = N; j--;) {
+      const auto& res = mTrRes[mCurHyp][j]; // vector of residuals of track j
+      const auto& dr1 = mDResidDz[j][i];    // vector of j-th residuals 1st derivative over Z param of track i
+      dchi1 += ROOT::Math::Dot(res, dr1);
+      if (i >= j) { // symmetrix matrix
+        // chi2 2nd derivative
+        auto& dchi2 = mD2Chi2Dz2[i][j]; // D2Chi2/Dz_i/Dz_j = sum_k { Dres_k/Dz_j * covI_k * Dres_k/Dz_i + res_k * covI_k * D2res_k/Dz_i/Dz_j }
+        dchi2 = ROOT::Math::Dot(mTrRes[mCurHyp][i], mD2ResidDz2[i][j]);
+        for (int k = N; k--;) {
+          dchi2 += ROOT::Math::Dot(mDResidDz[k][i], mDResidDz[k][j]);
+        }
+      }
+    }
+  }
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+void NA6PDCAFitterN<N, Args...>::calcPCA()
+{
+  // calculate point of closest approach for N prongs
+  mPCA[mCurHyp] = mTrCFVT[mCurHyp][N - 1] * mTrPos[mCurHyp][N - 1];
+  for (int i = N - 1; i--;) {
+    mPCA[mCurHyp] += mTrCFVT[mCurHyp][i] * mTrPos[mCurHyp][i];
+  }
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+bool NA6PDCAFitterN<N, Args...>::recalculatePCAWithErrors(int cand)
+{
+  // recalculate PCA as a cov-matrix weighted mean, even if absDCA method was used
+  if (isPropagateTracksToVertexDone(cand) && !propagateTracksToVertex(cand)) {
+    return false;
+  }
+  int saveCurHyp = mCurHyp;
+  mCurHyp = mOrder[cand];
+  if (mUseAbsDCA) {
+    for (int i = N; i--;) {
+      if (!mTrcEInv[mCurHyp][i].set(mCandTr[mCurHyp][i], ZerrFactor)) { // prepare inverse cov.matrices at starting point
+        mFitStatus[mCurHyp] = FitStatus::FailInvCov;
+        if (mBadCovPolicy == Discard) {
+          return false;
+        } else if (mBadCovPolicy == OverrideAndFlag) {
+          mPropFailed[mCurHyp] = true;
+        } // otherwise, just use overridden errors w/o flagging
+      }
+    }
+    if (!calcPCACoefs()) {
+      mCurHyp = saveCurHyp;
+      return false;
+    }
+  }
+  auto oldPCA = mPCA[mOrder[cand]];
+  calcPCA();
+  mCurHyp = saveCurHyp;
+  return true;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+void NA6PDCAFitterN<N, Args...>::calcPCANoErr()
+{
+  // calculate point of closest approach for N prongs w/o errors
+  auto& pca = mPCA[mCurHyp];
+  pca[0] = 0.;
+  pca[1] = 0.;
+  pca[2] = 0.;
+  for (int i = 0; i < N; ++i) {
+    pca[0] += mTrPos[mCurHyp][i][0];
+    pca[1] += mTrPos[mCurHyp][i][1];
+    pca[2] += mTrPos[mCurHyp][i][2];
+  }
+  pca[0] *= NInv;
+  pca[1] *= NInv;
+  pca[2] *= NInv;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>> NA6PDCAFitterN<N, Args...>::calcPCACovMatrix(int cand) const
+{
+  // calculate covariance matrix for the point of closest approach
+  MatSym3D covmSum;
+  int ord = mOrder[cand];
+  for (int i = N; i--;) {
+    const auto& tcov = mTrcEInv[ord][i];
+    covmSum(0, 0) += tcov.sxx;
+    covmSum(1, 0) += tcov.sxy;
+    covmSum(1, 1) += tcov.syy;
+    covmSum(2, 2) += tcov.szz;
+  }
+  if (covmSum.Invert()) {
+    return covmSum;
+  }
+  // fall back on identity diagonal matrix with 1 cm error
+  covmSum(0, 0) = 1.;
+  covmSum(1, 0) = 0.;
+  covmSum(1, 1) = 1.;
+  covmSum(2, 2) = 1.;
+  return covmSum;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+void NA6PDCAFitterN<N, Args...>::calcTrackResiduals()
+{
+  // calculate residuals in the global frame
+  for (int i = N; i--;) {
+    mTrRes[mCurHyp][i] = mTrPos[mCurHyp][i] - mPCA[mCurHyp];
+  }
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+void NA6PDCAFitterN<N, Args...>::calcTrackDerivatives()
+{
+  // calculate track derivatives over Z param
+  for (int i = N; i--;) {
+    mTrDer[mCurHyp][i].set(mCandTr[mCurHyp][i], mBy);
+  }
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+double NA6PDCAFitterN<N, Args...>::calcChi2() const
+{
+  // calculate current chi2
+  double chi2 = 0;
+  for (int i = N; i--;) {
+    const auto& res = mTrRes[mCurHyp][i];
+    const auto& covI = mTrcEInv[mCurHyp][i];
+    chi2 += res[0] * res[0] * covI.sxx + res[1] * res[1] * covI.syy + res[2] * res[2] * covI.szz + 2. * res[0] * res[1] * covI.sxy;
+  }
+  return chi2;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+double NA6PDCAFitterN<N, Args...>::calcChi2NoErr() const
+{
+  // calculate current chi2 of abs. distance minimization
+  double chi2 = 0;
+  for (int i = N; i--;) {
+    const auto& res = mTrRes[mCurHyp][i];
+    chi2 += res[0] * res[0] + res[1] * res[1] + res[2] * res[2];
+  }
+  return chi2;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+bool NA6PDCAFitterN<N, Args...>::correctTracks(const VecND& corrZ)
+{
+  // propagate tracks to updated Z
+  for (int i = N; i--;) {
+    const auto& trDer = mTrDer[mCurHyp][i];
+    auto dz2h = 0.5 * corrZ[i] * corrZ[i];
+    mTrPos[mCurHyp][i][0] -= trDer.dxdz * corrZ[i] - dz2h * trDer.d2xdz2;
+    mTrPos[mCurHyp][i][1] -= trDer.dydz * corrZ[i] - dz2h * trDer.d2ydz2;
+    mTrPos[mCurHyp][i][2] -= corrZ[i];
+  }
+  return true;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+bool NA6PDCAFitterN<N, Args...>::propagateTracksToVertex(int icand)
+{
+  // propagate tracks to current vertex
+  int ord = mOrder[icand];
+  if (mTrPropDone[ord]) {
+    return true;
+  }
+
+  // need to refit taking as a seed already found vertex
+  if (mRefitWithMatCorr) {
+    int curHypSav = mCurHyp, curCrosIDAlt = mCrossIDAlt; // save
+    mCurHyp = ord;
+    mCrossIDAlt = -1; // disable alternative check
+    auto restore = [this, curHypSav, curCrosIDAlt]() { this->mCurHyp = curHypSav; this->mCrossIDAlt = curCrosIDAlt; };
+    if (!(mUseAbsDCA ? minimizeChi2NoErr() : minimizeChi2())) { // do final propagation
+      restore();
+      return false;
+    }
+    restore();
+  }
+
+  for (int i = N; i--;) {
+    if (mUseAbsDCA || mUsePropagator /*|| mMatCorr != o2::base::Propagator::MatCorrType::USEMatCorrNONE*/) { // TODO: update after merging the recNative branch
+      mCandTr[ord][i] = *mOrigTrPtr[i];                                                                      // fetch the track again, as mCandTr might have been propagated w/o errors or material corrections might be wrong
+    }
+    auto z = mPCA[ord][2]; // z of PCA
+    if (!propagateToZ(mCandTr[ord][i], z)) {
+      return false;
+    }
+  }
+
+  mTrPropDone[ord] = true;
+  return true;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+double NA6PDCAFitterN<N, Args...>::getAbsMax(const VecND& v)
+{
+  double mx = -1;
+  for (int i = N; i--;) {
+    auto vai = std::abs(v[i]);
+    if (mx < vai) {
+      mx = vai;
+    }
+  }
+  return mx;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+bool NA6PDCAFitterN<N, Args...>::minimizeChi2()
+{
+  // find best chi2 (weighted DCA) of N tracks in the vicinity of the seed PCA
+  for (int i = N; i--;) {
+    mCandTr[mCurHyp][i] = *mOrigTrPtr[i];
+    auto z = mPCA[mCurHyp][2];
+    if (z > mMaxVertZ || z < mMinVertZ) {
+      mFitStatus[mCurHyp] = FitStatus::RejTrackZ;
+      return false;
+    }
+    if (!propagateToZ(mCandTr[mCurHyp][i], z)) {
+      return false;
+    }
+    setTrackPos(mTrPos[mCurHyp][i], mCandTr[mCurHyp][i]);             // prepare positions
+    if (!mTrcEInv[mCurHyp][i].set(mCandTr[mCurHyp][i], ZerrFactor)) { // prepare inverse cov.matrices at starting point
+      mFitStatus[mCurHyp] = FitStatus::FailInvCov;
+      if (mBadCovPolicy == Discard) {
+        return false;
+      } else if (mBadCovPolicy == OverrideAndFlag) {
+        mPropFailed[mCurHyp] = true;
+      } // otherwise, just use overridden errors w/o flagging
+    }
+  }
+
+  if (mMaxDZIni > 0 && !roughDZCut()) { // apply rough cut on tracks Z difference
+    mFitStatus[mCurHyp] = FitStatus::RejTrackRoughZ;
+    return false;
+  }
+
+  if (!calcPCACoefs()) { // prepare tracks contribution matrices to the global PCA
+    return false;
+  }
+  calcPCA();            // current PCA
+  calcTrackResiduals(); // current track residuals
+  float chi2Upd, chi2 = calcChi2();
+  do {
+    calcTrackDerivatives(); // current track derivatives (1st and 2nd)
+    calcResidDerivatives(); // current residals derivatives (1st and 2nd)
+    calcChi2Derivatives();  // current chi2 derivatives (1st and 2nd)
+
+    // do Newton-Rapson iteration with corrections = - dchi2/d{x0..xN} * [ d^2chi2/d{x0..xN}^2 ]^-1
+    if (!mD2Chi2Dz2.Invert()) {
+      mFitStatus[mCurHyp] = FitStatus::FailInv2ndDeriv;
+      return false;
+    }
+    VecND dz = mD2Chi2Dz2 * mDChi2Dz;
+    if (!correctTracks(dz)) {
+      mFitStatus[mCurHyp] = FitStatus::FailCorrTracks;
+      return false;
+    }
+    calcPCA(); // updated PCA
+    if (mCrossIDAlt >= 0 && closerToAlternative()) {
+      mFitStatus[mCurHyp] = FitStatus::FailCloserAlt;
+      mAllowAltPreference = false;
+      return false;
+    }
+    calcTrackResiduals(); // updated residuals
+    chi2Upd = calcChi2(); // updated chi2
+    if (getAbsMax(dz) < mMinParamChange || chi2Upd > chi2 * mMinRelChi2Change) {
+      chi2 = chi2Upd;
+      mFitStatus[mCurHyp] = FitStatus::Converged;
+      break; // converged
+    }
+    chi2 = chi2Upd;
+  } while (++mNIters[mCurHyp] < mMaxIter);
+  if (mNIters[mCurHyp] == mMaxIter) {
+    mFitStatus[mCurHyp] = FitStatus::MaxIter;
+  }
+  //
+  mChi2[mCurHyp] = chi2 * NInv;
+  if (mChi2[mCurHyp] >= mMaxChi2) {
+    mFitStatus[mCurHyp] = FitStatus::RejChi2Max;
+    return false;
+  }
+  return true;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+bool NA6PDCAFitterN<N, Args...>::minimizeChi2NoErr()
+{
+  // find best chi2 (absolute DCA) of N tracks in the vicinity of the PCA seed
+
+  for (int i = N; i--;) {
+    mCandTr[mCurHyp][i] = *mOrigTrPtr[i];
+    auto z = mPCA[mCurHyp][2];
+    if (z > mMaxVertZ || z < mMinVertZ) {
+      mFitStatus[mCurHyp] = FitStatus::RejTrackZ;
+      return false;
+    }
+    if (!propagateParamToZ(mCandTr[mCurHyp][i], z)) {
+      return false;
+    }
+    setTrackPos(mTrPos[mCurHyp][i], mCandTr[mCurHyp][i]); // prepare positions
+  }
+  if (mMaxDZIni > 0 && !roughDZCut()) { // apply rough cut on tracks Z difference
+    mFitStatus[mCurHyp] = FitStatus::RejTrackRoughZ;
+    return false;
+  }
+
+  calcPCANoErr();       // current PCA
+  calcTrackResiduals(); // current track residuals
+  float chi2Upd, chi2 = calcChi2NoErr();
+  do {
+    calcTrackDerivatives();      // current track derivatives (1st and 2nd)
+    calcResidDerivativesNoErr(); // current residals derivatives (1st and 2nd)
+    calcChi2DerivativesNoErr();  // current chi2 derivatives (1st and 2nd)
+
+    // do Newton-Rapson iteration with corrections = - dchi2/d{x0..xN} * [ d^2chi2/d{x0..xN}^2 ]^-1
+    if (!mD2Chi2Dz2.Invert()) {
+      mFitStatus[mCurHyp] = FitStatus::FailInv2ndDeriv;
+      return false;
+    }
+    VecND dz = mD2Chi2Dz2 * mDChi2Dz;
+    if (!correctTracks(dz)) {
+      mFitStatus[mCurHyp] = FitStatus::FailCorrTracks;
+      return false;
+    }
+    calcPCANoErr(); // updated PCA
+    if (mCrossIDAlt >= 0 && closerToAlternative()) {
+      mFitStatus[mCurHyp] = FitStatus::FailCloserAlt;
+      mAllowAltPreference = false;
+      return false;
+    }
+    calcTrackResiduals();      // updated residuals
+    chi2Upd = calcChi2NoErr(); // updated chi2
+    if (getAbsMax(dz) < mMinParamChange || chi2Upd > chi2 * mMinRelChi2Change) {
+      chi2 = chi2Upd;
+      mFitStatus[mCurHyp] = FitStatus::Converged;
+      break; // converged
+    }
+    chi2 = chi2Upd;
+  } while (++mNIters[mCurHyp] < mMaxIter);
+  if (mNIters[mCurHyp] == mMaxIter) {
+    mFitStatus[mCurHyp] = FitStatus::MaxIter;
+  }
+  //
+  mChi2[mCurHyp] = chi2 * NInv;
+  if (mChi2[mCurHyp] >= mMaxChi2) {
+    mFitStatus[mCurHyp] = FitStatus::RejChi2Max;
+    return false;
+  }
+  return true;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+bool NA6PDCAFitterN<N, Args...>::roughDZCut() const
+{
+  // apply rough cut on DZ between the tracks in the seed point
+  bool accept = true;
+  for (int i = N; accept && i--;) {
+    for (int j = i; j--;) {
+      if (std::abs(mCandTr[mCurHyp][i].getZ() - mCandTr[mCurHyp][j].getZ()) > mMaxDZIni) {
+        accept = false;
+        break;
+      }
+    }
+  }
+  return accept;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+bool NA6PDCAFitterN<N, Args...>::closerToAlternative() const
+{
+  // check if the point current PCA point is closer to the seeding XY point being tested or to alternative see (if any)
+  auto dxCur = mPCA[mCurHyp][0] - mCrossings.xDCA[mCrossIDCur], dzCur = mPCA[mCurHyp][2] - mCrossings.zDCA[mCrossIDCur];
+  auto dxAlt = mPCA[mCurHyp][0] - mCrossings.xDCA[mCrossIDAlt], dzAlt = mPCA[mCurHyp][2] - mCrossings.zDCA[mCrossIDAlt];
+  return dxCur * dxCur + dzCur * dzCur > dxAlt * dxAlt + dzAlt * dzAlt;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+NA6PTrack NA6PDCAFitterN<N, Args...>::createParentTrackParCov(int cand) const
+{
+  std::array<float, 21> covV = {0.};
+  std::array<float, 3> pvecV = {0.};
+  int q = 0;
+  for (int it = 0; it < N; it++) {
+    const auto& trc = getTrack(it, cand);
+    auto pvecT = trc.getPXYZ();
+    std::array<float, 21> covT = {0.};
+    covT[0] = trc.getSigmaX2(); // TODO: update with new parameterization!
+    covT[1] = trc.getSigmaXY();
+    covT[2] = trc.getSigmaY2();
+    covT[9] = trc.getSigmaPX2();
+    covT[14] = trc.getSigmaPY2();
+    covT[20] = trc.getSigmaPZ2();
+    constexpr int MomInd[6] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
+    for (int i = 0; i < 6; i++) {
+      covV[MomInd[i]] += covT[MomInd[i]];
+    }
+    for (int i = 0; i < 3; i++) {
+      pvecV[i] += pvecT[i];
+    }
+    q += trc.getCharge();
+  }
+  auto covVtxV = calcPCACovMatrix(cand);
+  covV[0] = covVtxV(0, 0);
+  covV[1] = covVtxV(1, 0);
+  covV[2] = covVtxV(1, 1);
+  covV[3] = covVtxV(2, 0);
+  covV[4] = covVtxV(2, 1);
+  covV[5] = covVtxV(2, 2);
+  NA6PTrack tr; // TODO: update adding covariance matrix
+  tr.init(getPCACandidatePos(cand), pvecV, q);
+  return tr;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+NA6PTrack NA6PDCAFitterN<N, Args...>::createParentTrackPar(int cand) const
+{
+  const auto& wvtx = getPCACandidate(cand);
+  std::array<float, 3> pvecV = {0.};
+  int q = 0;
+  for (int it = 0; it < N; it++) {
+    const auto& trc = getTrack(it, cand);
+    auto pvecT = trc.getPXYZ();
+    for (int i = 0; i < 3; i++) {
+      pvecV[i] += pvecT[i];
+    }
+    q += trc.getCharge();
+  }
+  const std::array<float, 3> vertex = {(float)wvtx[0], (float)wvtx[1], (float)wvtx[2]};
+  NA6PTrack tr;
+  tr.init(vertex, pvecV, q);
+  return tr;
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+inline bool NA6PDCAFitterN<N, Args...>::propagateParamToZ(NA6PTrack& t, float z) const
+{
+  return t.propagateParamToZ(z, mBy);
+}
+//___________________________________________________________________
+template <int N, typename... Args>
+inline bool NA6PDCAFitterN<N, Args...>::propagateToZ(NA6PTrack& t, float z) const
+{
+  return t.propagateToZ(z, mBy);
+}
+
+using NA6PDCAFitter2 = NA6PDCAFitterN<2, NA6PTrack>;
+using NA6PDCAFitter3 = NA6PDCAFitterN<3, NA6PTrack>;
+
+#endif

--- a/test/CheckDecayVertices.C
+++ b/test/CheckDecayVertices.C
@@ -1,0 +1,680 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <TTree.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TF1.h>
+#include <TCanvas.h>
+#include <TLatex.h>
+#include <TPaveStats.h>
+#include <TParticle.h>
+#include "NA6PTrack.h"
+#include "NA6PMCEventHeader.h"
+#include "NA6PDCAFitterN.h"
+#include "MagneticField.h"
+#include "ConfigurableParam.h"
+#endif
+
+void FillMeanAndRms(TH2F* h2D, TH1F* hMean, TH1F* hRms, TH1F* hSig)
+{
+  if (!h2D || !hMean || !hRms || !hSig) {
+    printf("One of pointers is not set: h2D=%p hMean=%p hRms=%p hSig=%p\n", h2D, hMean, hRms, hSig);
+    return;
+  }
+  int nBins = h2D->GetXaxis()->GetNbins();
+  hMean->SetStats(0);
+  hRms->SetStats(0);
+  hSig->SetStats(0);
+  for (int jp = 1; jp <= nBins; jp++) {
+    TH1D* htmp1 = h2D->ProjectionY("htmp1", jp, jp);
+    double mean = htmp1->GetMean();
+    double emean = htmp1->GetMeanError();
+    double rms = htmp1->GetRMS();
+    double erms = htmp1->GetRMSError();
+    hMean->SetBinContent(jp, mean);
+    hMean->SetBinError(jp, emean);
+    hRms->SetBinContent(jp, rms);
+    hRms->SetBinError(jp, erms);
+    double gw = rms;
+    double egw = erms;
+    if (htmp1->GetEntries() > 20.) {
+      int fitStatus = htmp1->Fit("gaus", "N0Q", "", mean - 3. * rms, mean + 3. * rms);
+      if (fitStatus == 0) {
+        TF1* fg = (TF1*)htmp1->GetListOfFunctions()->FindObject("gaus");
+        if (fg) {
+          gw = fg->GetParameter(2);
+          egw = fg->GetParError(2);
+        }
+      }
+    }
+    hSig->SetBinContent(jp, gw);
+    hSig->SetBinError(jp, egw);
+    delete htmp1;
+  }
+}
+
+void printDecay(TParticle& mothPart,
+                std::vector<TParticle>* mcArr)
+{
+
+  int nDau = mothPart.GetNDaughters();
+  int pdg = mothPart.GetPdgCode();
+  printf("%d (zprod = %f) ->", pdg, mothPart.Vz());
+  for (int jd = 0; jd < nDau; ++jd) {
+    int indexDau = mothPart.GetFirstDaughter() + jd;
+    auto dauPart = mcArr->at(indexDau);
+    int pdgDau = dauPart.GetPdgCode();
+    printf(" %d (zprod = %f)", pdgDau, dauPart.Vz());
+    int nGranDau = dauPart.GetNDaughters();
+    if (nGranDau > 0) {
+      printf(" [ ");
+      printDecay(dauPart, mcArr);
+      printf(" ] ");
+    }
+  }
+}
+
+bool CheckCharmDecay(TParticle& mothPart,
+                     std::vector<TParticle>* mcArr,
+                     int pdgProngs[5],
+                     int idDau[5],
+                     float decvert[3])
+{
+
+  bool okDau[5] = {false, false, false, false, false};
+  int pdg = mothPart.GetPdgCode();
+  int nDau = mothPart.GetNDaughters();
+  int finalProngs = nDau;
+  int nExpectedProngs = 0;
+  for (int i = 0; i < 5; ++i) {
+    if (pdgProngs[i] != 0)
+      nExpectedProngs++;
+  }
+  bool isDecVertSet = false;
+  for (int jd = 0; jd < nDau; ++jd) {
+    bool isExpected = false;
+    int indexDau = mothPart.GetFirstDaughter() + jd;
+    auto& dauPart = mcArr->at(indexDau);
+    int pdgDau = dauPart.GetPdgCode();
+    int absPdgDau = std::abs(pdgDau);
+    for (int ld = 0; ld < 5; ++ld) {
+      if (pdgDau == pdgProngs[ld]) {
+        isExpected = true;
+        break;
+      }
+    }
+    if (absPdgDau == 313 || absPdgDau == 333)
+      isExpected = true;
+    if (isExpected && !isDecVertSet) {
+      decvert[0] = dauPart.Vx();
+      decvert[1] = dauPart.Vy();
+      decvert[2] = dauPart.Vz();
+      isDecVertSet = true;
+    }
+  }
+  if (!isDecVertSet)
+    return false;
+  for (int jd = 0; jd < nDau; ++jd) {
+    int indexDau = mothPart.GetFirstDaughter() + jd;
+    auto& dauPart = mcArr->at(indexDau);
+    int pdgDau = dauPart.GetPdgCode();
+    int absPdgDau = std::abs(pdgDau);
+    float dist2 = (dauPart.Vx() - decvert[0]) * (dauPart.Vx() - decvert[0]) +
+                  (dauPart.Vy() - decvert[1]) * (dauPart.Vy() - decvert[1]) +
+                  (dauPart.Vz() - decvert[2]) * (dauPart.Vz() - decvert[2]);
+
+    if (pdgDau == 11 && dist2 > 1e-8) {
+      // delta electron, should not count as daughter
+      finalProngs--;
+      continue;
+    }
+    bool found = false;
+    for (int ld = 0; ld < 5; ++ld) {
+      if (pdgDau == pdgProngs[ld] && okDau[ld] == false) {
+        okDau[ld] = true;
+        idDau[ld] = indexDau;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      if (absPdgDau == 313 || absPdgDau == 333) {
+        int nDauRes = dauPart.GetNDaughters();
+        finalProngs = finalProngs - 1 + nDauRes;
+        for (int kd = 0; kd < nDauRes; ++kd) {
+          int indexDau2 = dauPart.GetFirstDaughter() + kd;
+          auto dauPart2 = mcArr->at(indexDau2);
+          int pdgDau2 = dauPart2.GetPdgCode();
+          for (int ld = 0; ld < 5; ++ld) {
+            if (pdgDau2 == pdgProngs[ld] && okDau[ld] == false) {
+              okDau[ld] = true;
+              idDau[ld] = indexDau2;
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (finalProngs != nExpectedProngs)
+    return false;
+
+  for (int ld = 0; ld < 5; ++ld) {
+    if (pdgProngs[ld] != 0 && !okDau[ld])
+      return false;
+  }
+  return true;
+}
+
+void CheckDecayVertices(const char* part = "D0",
+                        const char* dirSimu = ".")
+{
+  na6p::conf::ConfigurableParam::updateFromFile(Form("%s/na6pLayout.ini",dirSimu), "", true);
+  if (TGeoGlobalMagField::Instance()->GetField() == nullptr) {
+    auto magField = new MagneticField();
+    magField->loadField();
+    magField->setAsGlobalField();
+  }
+
+  int pdgPart = 421;
+  int nProngs = 2;
+  int pdgProngs[5] = {0, 0, 0, 0, 0};
+  float maxDL = 5000.;
+  std::string decay;
+  if (strcmp(part, "D0") == 0) {
+    pdgPart = 421;
+    nProngs = 2;
+    pdgProngs[0] = 211;
+    pdgProngs[1] = -321;
+    maxDL = 1000.;
+    decay = "D^{0} #rightarrow K^{-} #pi^{+}";
+  } else if (strcmp(part, "D0bar") == 0) {
+    pdgPart = -421;
+    nProngs = 2;
+    pdgProngs[0] = -211;
+    pdgProngs[1] = 321;
+    maxDL = 1000.;
+    decay = "#bar{D^{0}} #rightarrow K^{+} #pi^{-}";
+  } else if (strcmp(part, "Dplus") == 0) {
+    pdgPart = 411;
+    nProngs = 3;
+    pdgProngs[0] = 211;
+    pdgProngs[1] = 211;
+    pdgProngs[2] = -321;
+    maxDL = 3000.;
+    decay = "D^{+} #rightarrow K^{-} #pi^{+} #pi^{+}";
+  } else if (strcmp(part, "Dminus") == 0) {
+    pdgPart = -411;
+    nProngs = 3;
+    pdgProngs[0] = -211;
+    pdgProngs[1] = -211;
+    pdgProngs[2] = 321;
+    maxDL = 3000.;
+    decay = "D^{-} #rightarrow K^{+} #pi^{-} #pi^{-}";
+  } else if (strcmp(part, "Ds") == 0) {
+    pdgPart = 431;
+    nProngs = 3;
+    pdgProngs[0] = 211;
+    pdgProngs[1] = 321;
+    pdgProngs[2] = -321;
+    maxDL = 1000.;
+    decay = "D_{s}^{+} #rightarrow K^{-} K^{+} #pi^{+}";
+  } else if (strcmp(part, "DsMinus") == 0) {
+    pdgPart = -431;
+    nProngs = 3;
+    pdgProngs[0] = -211;
+    pdgProngs[1] = 321;
+    pdgProngs[2] = -321;
+    maxDL = 1000.;
+    decay = "D_{s}^{-} #rightarrow K^{-} K^{+} #pi^{-}";
+  } else if (strcmp(part, "LambdaC") == 0 || strcmp(part, "LcPlus") == 0) {
+    pdgPart = 4122;
+    nProngs = 3;
+    pdgProngs[0] = 2212;
+    pdgProngs[1] = 211;
+    pdgProngs[2] = -321;
+    maxDL = 1000.;
+    decay = "#Lambda_{c}^{+} #rightarrow p K^{-} #pi^{+}";
+  } else if (strcmp(part, "antiLambdaC") == 0 || strcmp(part, "LcMinus") == 0) {
+    pdgPart = -4122;
+    nProngs = 3;
+    pdgProngs[0] = -2212;
+    pdgProngs[1] = -211;
+    pdgProngs[2] = 321;
+    maxDL = 1000.;
+    decay = "#bar{#Lambda}_{c}^{-} #rightarrow #bar{p} K^{+} #pi^{-}";
+  }
+
+  TFile* ft = new TFile(Form("%s/TracksVerTel.root", dirSimu));
+  if (!ft)
+    return;
+  TTree* trTree = (TTree*)ft->Get("tracksVerTel");
+  std::vector<NA6PTrack>* trArr = nullptr;
+  trTree->SetBranchAddress("VerTel", &trArr);
+  TFile* fk = new TFile(Form("%s/MCKine.root", dirSimu));
+  TTree* mcTree = (TTree*)fk->Get("mckine");
+  std::vector<TParticle>* mcArr = nullptr;
+  mcTree->SetBranchAddress("tracks", &mcArr);
+  NA6PMCEventHeader* mcHead = nullptr;
+  mcTree->SetBranchAddress("header", &mcHead);
+
+  NA6PDCAFitterN<2> df2;
+  df2.setPropagateToPCA(true);
+  df2.setUseAbsDCA(true);
+  NA6PDCAFitterN<3> df3;
+  df3.setPropagateToPCA(true);
+  df3.setUseAbsDCA(true);
+
+  TH1F* hGenVsRap = new TH1F("hGenVsRap", ";y;entries", 20, 1., 5.);
+  TH1F* hGenVsPt = new TH1F("hGenVsPt", ";p_{T} (GeV/c);entries", 20, 0., 5.);
+  TH1F* hRecoVsRap = new TH1F("hRecoVsRap", ";y;entries", 20, 1., 5.);
+  TH1F* hRecoVsPt = new TH1F("hRecoVsPt", ";p_{T} (GeV/c);entries", 20, 0., 5.);
+  TH1F* hDecLen = new TH1F("hDecLen", "; decay length L_{xyz} (#mum); entries", 100, 0., 5 * maxDL);
+  TH1F* hPseudoPropDecLen = new TH1F("hPseudoPropDecLen", "; L_{xyz} M / p (#mum); entries", 100, 0., maxDL);
+  TH1F* hInvMass = new TH1F("hInvMass", ";M (GeV/c^{2});entries", 200, 1.7, 2.5);
+  TH2F* hInvMassVsRap = new TH2F("hInvMassVsRap", ";y;M (GeV/c^{2});entries", 20, 1., 5., 200, 1.7, 2.5);
+  TH1F* hSecVx = new TH1F("hSecVx", ";x_{sec vert} (cm);entries", 100, -1., 1.);
+  TH1F* hSecVy = new TH1F("hSecVy", ";y_{sec vert} (cm);entries", 100, -1., 1.);
+  TH1F* hSecVz = new TH1F("hSecVz", ";z_{sec vert} (cm);entries", 100, -5., 5.);
+  TH1F* hDeltaVx = new TH1F("hDeltaVx", ";x_{rec} - x_{true} (#mum);entries", 100, -500., 500.);
+  TH1F* hDeltaVy = new TH1F("hDeltaVy", ";y_{rec} - y_{true} (#mum);entries", 100, -500., 500.);
+  TH1F* hDeltaVz = new TH1F("hDeltaVz", ";z_{rec} - z_{true} (#mum);entries", 100, -500., 500.);
+  TH2F* hDeltaVxVsRap = new TH2F("hDeltaVxVsRap", ";y;x_{rec} - x_{true} (#mum);entries", 20, 1., 5., 100, -500., 500.);
+  TH2F* hDeltaVyVsRap = new TH2F("hDeltaVyVsRap", ";y;y_{rec} - y_{true} (#mum);entries", 20, 1., 5., 100, -500., 500.);
+  TH2F* hDeltaVzVsRap = new TH2F("hDeltaVzVsRap", ";y;z_{rec} - z_{true} (#mum);entries", 20, 1., 5., 100, -500., 500.);
+
+  int nGenerated = 0, nGoodNdau = 0, nGoodDecay = 0, nReconstructed = 0;
+
+  int nEv = trTree->GetEntries();
+  printf("Number of events = %d\n", nEv);
+  for (int jEv = 0; jEv < nEv; jEv++) {
+    mcTree->GetEvent(jEv);
+    trTree->GetEvent(jEv);
+    int nPart = mcArr->size();
+    int nTracks = trArr->size();
+    double xPrimVertGen = mcHead->getVX();
+    double yPrimVertGen = mcHead->getVY();
+    double zPrimVertGen = mcHead->getVZ();
+    double bxyz[3];
+    double xyz[3] = {xPrimVertGen, yPrimVertGen, zPrimVertGen};
+    TGeoGlobalMagField::Instance()->Field(xyz, bxyz);
+    df2.setBy(bxyz[1]);
+    df3.setBy(bxyz[1]);
+    if ((jEv % 1000) == 0)
+      printf("--- Event %d particles %d ---\n", jEv, nPart);
+    for (int jp = 0; jp < nPart; jp++) {
+      auto curPart = mcArr->at(jp);
+      int pdg = curPart.GetPdgCode();
+      if (pdg != pdgPart)
+        continue;
+      float prodvert[3] = {(float)curPart.Vx(), (float)curPart.Vy(), (float)curPart.Vz()};
+      float genmom = curPart.P();
+      float genpt = curPart.Pt();
+      float geny = curPart.Y();
+      float mass = curPart.GetMass();
+      ++nGenerated;
+      int nDau = curPart.GetNDaughters();
+      if (nDau == nProngs) {
+        ++nGoodNdau;
+      }
+      int idDau[5] = {-1, -1, -1, -1, -1};
+      float decvert[3] = {0., 0., -9999.};
+      bool decOk = CheckCharmDecay(curPart, mcArr, pdgProngs, idDau, decvert);
+      if (!decOk) {
+        // printf(" Decay not ok\n");
+        // printDecay(curPart, mcArr);
+        // printf("\n");
+        continue;
+      }
+      ++nGoodDecay;
+      hGenVsRap->Fill(geny);
+      hGenVsPt->Fill(genpt);
+      float decLen = std::sqrt((decvert[0] - prodvert[0]) * (decvert[0] - prodvert[0]) +
+                               (decvert[1] - prodvert[1]) * (decvert[1] - prodvert[1]) +
+                               (decvert[2] - prodvert[2]) * (decvert[2] - prodvert[2]));
+
+      hDecLen->Fill(decLen * 1e4);
+      float ppdl = decLen * 1e4 * mass / genmom;
+      hPseudoPropDecLen->Fill(ppdl);
+
+      std::vector<NA6PTrack> prongs;
+      int nRecoDau = 0;
+      for (int kd = 0; kd < nProngs; ++kd) {
+        for (int jTr = 0; jTr < nTracks; ++jTr) {
+          NA6PTrack tr = trArr->at(jTr);
+          uint32_t clumap = tr.getClusterMap();
+          int nVTClusters = 0;
+          for (int j = 0 ; j < 5; j++) {
+            if (clumap & (1 << j)) ++nVTClusters;
+          }
+          if (nVTClusters < 5)
+            continue;
+          int mcLabel = tr.getParticleID();
+          if (mcLabel == idDau[kd]) {
+            prongs.push_back(tr);
+            ++nRecoDau;
+          }
+        }
+      }
+      if (nRecoDau != nProngs)
+        continue;
+      ++nReconstructed;
+      hRecoVsRap->Fill(geny);
+      hRecoVsPt->Fill(genpt);
+      int n = 0;
+      if (nProngs == 2) {
+        n = df2.process(prongs[0], prongs[1]);
+      } else if (nProngs == 3) {
+        n = df3.process(prongs[0], prongs[1], prongs[2]);
+      }
+      if (n == 0)
+        continue;
+      const auto& secondaryVertex = (nProngs == 2) ? df2.getPCACandidate() : df3.getPCACandidate();
+      float dvx = (secondaryVertex[0] - decvert[0]) * 1e4;
+      float dvy = (secondaryVertex[1] - decvert[1]) * 1e4;
+      float dvz = (secondaryVertex[2] - decvert[2]) * 1e4;
+
+      float sumPx = 0., sumPy = 0., sumPz = 0., sumE = 0.;
+      for (int kd = 0; kd < nProngs; ++kd) {
+        sumPx += prongs[kd].getPx();
+        sumPy += prongs[kd].getPy();
+        sumPz += prongs[kd].getPz();
+        float mom = prongs[kd].getP();
+        auto mcPart = mcArr->at(prongs[kd].getParticleID());
+        float mass = mcPart.GetMass();
+        float energy = std::sqrt(mass * mass + mom * mom);
+        sumE += energy;
+      }
+      float mom2 = sumPx * sumPx + sumPy * sumPy + sumPz * sumPz;
+      float invMass = std::sqrt(sumE * sumE - mom2);
+
+      hInvMass->Fill(invMass);
+      hInvMassVsRap->Fill(geny, invMass);
+      hSecVx->Fill(secondaryVertex[0]);
+      hSecVy->Fill(secondaryVertex[1]);
+      hSecVz->Fill(secondaryVertex[2]);
+      hDeltaVx->Fill(dvx);
+      hDeltaVy->Fill(dvy);
+      hDeltaVz->Fill(dvz);
+      hDeltaVxVsRap->Fill(geny, dvx);
+      hDeltaVyVsRap->Fill(geny, dvy);
+      hDeltaVzVsRap->Fill(geny, dvz);
+    }
+  }
+  printf("Number of generated %s = %d\n", part, nGenerated);
+  printf("Number of %s with %d daughters = %d\n", part, nProngs, nGoodNdau);
+  printf("Number of %s with selected decay = %d\n", part, nGoodDecay);
+  printf("Number of %s with reconstructed daughters = %d\n", part, nReconstructed);
+
+  TH1F* hEffVsRap = (TH1F*)hRecoVsRap->Clone("hEffVsRap");
+  hEffVsRap->Divide(hRecoVsRap, hGenVsRap, 1., 1., "B");
+  hEffVsRap->GetYaxis()->SetTitle("Acceptance x Efficiency");
+  hEffVsRap->SetStats(0);
+  TH1F* hEffVsPt = (TH1F*)hRecoVsPt->Clone("hEffVsPt");
+  hEffVsPt->Divide(hRecoVsPt, hGenVsPt, 1., 1., "B");
+  hEffVsPt->GetYaxis()->SetTitle("Acceptance x Efficiency");
+  hEffVsPt->SetStats(0);
+
+  TH1F* hInvMassMean = new TH1F("hInvMassMean", ";y;<M> (GeV/c^{2})", hInvMassVsRap->GetNbinsX(), hInvMassVsRap->GetXaxis()->GetXmin(), hInvMassVsRap->GetXaxis()->GetXmax());
+  TH1F* hInvMassRms = new TH1F("hInvMassRms", ";y;rms (M) (GeV/c^{2})", hInvMassVsRap->GetNbinsX(), hInvMassVsRap->GetXaxis()->GetXmin(), hInvMassVsRap->GetXaxis()->GetXmax());
+  TH1F* hInvMassSig = new TH1F("hInvMassSig", ";y;#sigma(M) (GeV/c^{2})", hInvMassVsRap->GetNbinsX(), hInvMassVsRap->GetXaxis()->GetXmin(), hInvMassVsRap->GetXaxis()->GetXmax());
+  FillMeanAndRms(hInvMassVsRap, hInvMassMean, hInvMassRms, hInvMassSig);
+
+  TH1F* hDeltaVxMean = new TH1F("hDeltaVxMean", ";y;<x_{reco} - x_{gen}> (#mum)", hDeltaVxVsRap->GetNbinsX(), hDeltaVxVsRap->GetXaxis()->GetXmin(), hDeltaVxVsRap->GetXaxis()->GetXmax());
+  TH1F* hDeltaVxRms = new TH1F("hDeltaVxRms", ";y;rms (x_{reco} - x_{gen}) (#mum)", hDeltaVxVsRap->GetNbinsX(), hDeltaVxVsRap->GetXaxis()->GetXmin(), hDeltaVxVsRap->GetXaxis()->GetXmax());
+  TH1F* hDeltaVxSig = new TH1F("hDeltaVxSig", ";y;#sigma(x_{reco} - x_{gen}) (#mum)", hDeltaVxVsRap->GetNbinsX(), hDeltaVxVsRap->GetXaxis()->GetXmin(), hDeltaVxVsRap->GetXaxis()->GetXmax());
+  TH1F* hDeltaVyMean = new TH1F("hDeltaVyMean", ";y;<y_{reco} - y_{gen}> (#mum)", hDeltaVyVsRap->GetNbinsX(), hDeltaVyVsRap->GetXaxis()->GetXmin(), hDeltaVyVsRap->GetXaxis()->GetXmax());
+  TH1F* hDeltaVyRms = new TH1F("hDeltaVyRms", ";y;rms (y_{reco} - y_{gen}) (#mum)", hDeltaVyVsRap->GetNbinsX(), hDeltaVyVsRap->GetXaxis()->GetXmin(), hDeltaVyVsRap->GetXaxis()->GetXmax());
+  TH1F* hDeltaVySig = new TH1F("hDeltaVySig", ";y;#sigma(y_{reco} - y_{gen}) (#mum)", hDeltaVyVsRap->GetNbinsX(), hDeltaVyVsRap->GetXaxis()->GetXmin(), hDeltaVyVsRap->GetXaxis()->GetXmax());
+  TH1F* hDeltaVzMean = new TH1F("hDeltaVzMean", ";y;<z_{reco} - z_{gen}> (#mum)", hDeltaVzVsRap->GetNbinsX(), hDeltaVzVsRap->GetXaxis()->GetXmin(), hDeltaVzVsRap->GetXaxis()->GetXmax());
+  TH1F* hDeltaVzRms = new TH1F("hDeltaVzRms", ";y;rms (z_{reco} - z_{gen}) (#mum)", hDeltaVzVsRap->GetNbinsX(), hDeltaVzVsRap->GetXaxis()->GetXmin(), hDeltaVzVsRap->GetXaxis()->GetXmax());
+  TH1F* hDeltaVzSig = new TH1F("hDeltaVzSig", ";y;#sigma(z_{reco} - z_{gen}) (#mum)", hDeltaVzVsRap->GetNbinsX(), hDeltaVzVsRap->GetXaxis()->GetXmin(), hDeltaVzVsRap->GetXaxis()->GetXmax());
+  FillMeanAndRms(hDeltaVxVsRap, hDeltaVxMean, hDeltaVxRms, hDeltaVxSig);
+  FillMeanAndRms(hDeltaVyVsRap, hDeltaVyMean, hDeltaVyRms, hDeltaVySig);
+  FillMeanAndRms(hDeltaVzVsRap, hDeltaVzMean, hDeltaVzRms, hDeltaVzSig);
+
+  TLatex* tdec = new TLatex(0.45, 0.83, decay.data());
+  tdec->SetNDC();
+
+  TCanvas* cdl = new TCanvas("cdl", "Decay Length (gen)", 1400, 600);
+  cdl->Divide(2, 1);
+  cdl->cd(1);
+  gPad->SetLogy();
+  hDecLen->Draw();
+  cdl->cd(2);
+  gPad->SetLogy();
+  hPseudoPropDecLen->Draw();
+  tdec->Draw();
+
+  TCanvas* ceff = new TCanvas("ceff", "Acc x Eff", 800, 800);
+  ceff->Divide(2, 2);
+  ceff->cd(1);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hGenVsRap->SetMarkerStyle(21);
+  hGenVsRap->SetMarkerColor(1);
+  hGenVsRap->SetLineColor(1);
+  hRecoVsRap->SetMarkerStyle(20);
+  hRecoVsRap->SetMarkerColor(kGreen + 2);
+  hRecoVsRap->SetLineColor(kGreen + 2);
+  hGenVsRap->SetMinimum(0.);
+  hGenVsRap->Draw("E");
+  gPad->Update();
+  TPaveStats* stg = (TPaveStats*)hGenVsRap->GetListOfFunctions()->FindObject("stats");
+  if (stg) {
+    stg->SetY1NDC(0.72);
+    stg->SetY2NDC(0.92);
+    stg->SetTextColor(hGenVsRap->GetMarkerColor());
+  }
+  hRecoVsRap->Draw("Esames");
+  gPad->Update();
+  TPaveStats* str = (TPaveStats*)hRecoVsRap->GetListOfFunctions()->FindObject("stats");
+  if (str) {
+    str->SetY1NDC(0.51);
+    str->SetY2NDC(0.71);
+    str->SetTextColor(hRecoVsRap->GetMarkerColor());
+  }
+  hRecoVsRap->Draw("Esames");
+  gPad->Modified();
+  ceff->cd(2);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  gPad->SetLogy();
+  hGenVsPt->SetMarkerStyle(21);
+  hGenVsPt->SetMarkerColor(1);
+  hGenVsPt->SetLineColor(1);
+  hRecoVsPt->SetMarkerStyle(20);
+  hRecoVsPt->SetMarkerColor(kGreen + 2);
+  hRecoVsPt->SetLineColor(kGreen + 2);
+  hGenVsPt->Draw("E");
+  gPad->Update();
+  TPaveStats* stg2 = (TPaveStats*)hGenVsPt->GetListOfFunctions()->FindObject("stats");
+  if (stg2) {
+    stg2->SetY1NDC(0.72);
+    stg2->SetY2NDC(0.92);
+    stg2->SetTextColor(hGenVsPt->GetMarkerColor());
+  }
+  hRecoVsPt->Draw("Esames");
+  gPad->Update();
+  TPaveStats* str2 = (TPaveStats*)hRecoVsPt->GetListOfFunctions()->FindObject("stats");
+  if (str2) {
+    str2->SetY1NDC(0.51);
+    str2->SetY2NDC(0.71);
+    str2->SetTextColor(hRecoVsPt->GetMarkerColor());
+  }
+  gPad->Modified();
+  tdec->Draw();
+  ceff->cd(3);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hEffVsRap->SetMarkerStyle(20);
+  hEffVsRap->SetMarkerColor(kGreen + 2);
+  hEffVsRap->SetLineColor(kGreen + 2);
+  hEffVsRap->SetMinimum(0.);
+  hEffVsRap->SetMaximum(1.);
+  hEffVsRap->Draw();
+  ceff->cd(4);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hEffVsPt->SetMarkerStyle(20);
+  hEffVsPt->SetMarkerColor(kGreen + 2);
+  hEffVsPt->SetLineColor(kGreen + 2);
+  hEffVsPt->SetMinimum(0.);
+  hEffVsPt->SetMaximum(1.);
+  hEffVsPt->Draw();
+  ceff->SaveAs(Form("%s-AccEff.png", part));
+
+  TCanvas* cm = new TCanvas("cm", "Inv Mass", 1400, 500);
+  cm->Divide(3, 1);
+  cm->cd(1);
+  gPad->SetLeftMargin(0.13);
+  gPad->SetRightMargin(0.07);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hInvMass->Draw();
+  cm->cd(2);
+  gPad->SetLeftMargin(0.13);
+  gPad->SetRightMargin(0.07);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hInvMassMean->SetStats(0);
+  hInvMassMean->SetMarkerStyle(20);
+  hInvMassMean->SetMarkerColor(1);
+  hInvMassMean->SetLineColor(1);
+  hInvMassMean->SetMinimum(hInvMass->GetMean() - 5. * hInvMass->GetRMS());
+  hInvMassMean->SetMaximum(hInvMass->GetMean() + 5. * hInvMass->GetRMS());
+  hInvMassMean->GetYaxis()->SetTitleOffset(1.7);
+  hInvMassMean->Draw();
+  tdec->Draw();
+  cm->cd(3);
+  gPad->SetLeftMargin(0.13);
+  gPad->SetRightMargin(0.07);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hInvMassSig->SetStats(0);
+  hInvMassSig->SetMarkerStyle(20);
+  hInvMassSig->SetMarkerColor(1);
+  hInvMassSig->SetLineColor(1);
+  hInvMassSig->GetYaxis()->SetTitleOffset(1.7);
+  hInvMassSig->SetMinimum(0.);
+  hInvMassSig->SetMaximum(0.04);
+  hInvMassSig->Draw();
+  cm->SaveAs(Form("%s-InvMass.png", part));
+
+  TCanvas* cps = new TCanvas("cps", "Dec Vert Pos", 1400, 800);
+  cps->Divide(3, 2);
+  cps->cd(1);
+  hSecVx->Draw();
+  cps->cd(2);
+  hSecVy->Draw();
+  cps->cd(3);
+  hSecVz->Draw();
+  cps->cd(4);
+  hDeltaVx->Draw();
+  cps->cd(5);
+  hDeltaVy->Draw();
+  cps->cd(6);
+  hDeltaVz->Draw();
+
+  TCanvas* csig = new TCanvas("csig", "Dec Vert Resid", 1400, 800);
+  csig->Divide(3, 2);
+  csig->cd(1);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hDeltaVxMean->SetStats(0);
+  hDeltaVxMean->SetMarkerStyle(20);
+  hDeltaVxMean->SetMarkerColor(1);
+  hDeltaVxMean->SetLineColor(1);
+  hDeltaVxMean->SetMinimum(-5.);
+  hDeltaVxMean->SetMaximum(5.);
+  hDeltaVxMean->GetYaxis()->SetTitleOffset(1.2);
+  hDeltaVxMean->Draw();
+  csig->cd(2);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hDeltaVyMean->SetStats(0);
+  hDeltaVyMean->SetMarkerStyle(20);
+  hDeltaVyMean->SetMarkerColor(1);
+  hDeltaVyMean->SetLineColor(1);
+  hDeltaVyMean->SetMinimum(-5.);
+  hDeltaVyMean->SetMaximum(5.);
+  hDeltaVyMean->GetYaxis()->SetTitleOffset(1.2);
+  hDeltaVyMean->Draw();
+  tdec->Draw();
+  csig->cd(3);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hDeltaVzMean->SetStats(0);
+  hDeltaVzMean->SetMarkerStyle(20);
+  hDeltaVzMean->SetMarkerColor(1);
+  hDeltaVzMean->SetLineColor(1);
+  hDeltaVzMean->SetMinimum(-20.);
+  hDeltaVzMean->SetMaximum(20.);
+  hDeltaVzMean->GetYaxis()->SetTitleOffset(1.2);
+  hDeltaVzMean->Draw();
+  csig->cd(4);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hDeltaVxSig->SetStats(0);
+  hDeltaVxSig->SetMarkerStyle(20);
+  hDeltaVxSig->SetMarkerColor(1);
+  hDeltaVxSig->SetLineColor(1);
+  hDeltaVxSig->SetMinimum(0.);
+  hDeltaVxSig->SetMaximum(40.);
+  hDeltaVxSig->GetYaxis()->SetTitleOffset(1.2);
+  hDeltaVxSig->Draw();
+  csig->cd(5);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hDeltaVySig->SetStats(0);
+  hDeltaVySig->SetMarkerStyle(20);
+  hDeltaVySig->SetMarkerColor(1);
+  hDeltaVySig->SetLineColor(1);
+  hDeltaVySig->SetMinimum(0.);
+  hDeltaVySig->SetMaximum(40.);
+  hDeltaVySig->GetYaxis()->SetTitleOffset(1.2);
+  hDeltaVySig->Draw();
+  csig->cd(6);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hDeltaVzSig->SetStats(0);
+  hDeltaVzSig->SetMarkerStyle(20);
+  hDeltaVzSig->SetMarkerColor(1);
+  hDeltaVzSig->SetLineColor(1);
+  hDeltaVzSig->SetMinimum(0.);
+  hDeltaVzSig->SetMaximum(200.);
+  hDeltaVzSig->GetYaxis()->SetTitleOffset(1.2);
+  hDeltaVzSig->Draw();
+  csig->SaveAs(Form("%s-DecayVertPos.png", part));
+
+  TFile* fout = new TFile(Form("%s-DecayVert.root", part), "recreate");
+  hDecLen->Write();
+  hPseudoPropDecLen->Write();
+  hInvMassVsRap->Write();
+  hInvMassMean->Write();
+  hInvMassRms->Write();
+  hInvMassSig->Write();
+  hSecVx->Write();
+  hSecVy->Write();
+  hSecVz->Write();
+  hDeltaVxVsRap->Write();
+  hDeltaVyVsRap->Write();
+  hDeltaVzVsRap->Write();
+  hDeltaVxMean->Write();
+  hDeltaVxRms->Write();
+  hDeltaVxSig->Write();
+  hDeltaVyMean->Write();
+  hDeltaVyRms->Write();
+  hDeltaVySig->Write();
+  hDeltaVzMean->Write();
+  hDeltaVzRms->Write();
+  hDeltaVzSig->Write();
+  hGenVsRap->Write();
+  hRecoVsRap->Write();
+  hEffVsRap->Write();
+  hGenVsPt->Write();
+  hRecoVsPt->Write();
+  hEffVsPt->Write();
+  fout->Close();
+}


### PR DESCRIPTION
This is the version of the DCA fitter ported from O2 and tested in NA6PRoot in the branch:
https://github.com/fprino/NA6PRoot/tree/dcafitter
Here I just did some minimal changes needed to match the version of NA6PHelixHelper from origin/main.