### PR TITLE
Update track vertexer to the new parametrization

### DIFF
--- a/rec/include/NA6PVertexerTracks.h
+++ b/rec/include/NA6PVertexerTracks.h
@@ -16,7 +16,6 @@
 #define NA6P_VERTEXER_TRACKS_H
 
 #include <vector>
-#include <NA6PLine.h>
 #include <NA6PTrack.h>
 #include <NA6PVertex.h>
 
@@ -25,66 +24,17 @@ struct TrackVF {
          kNoVtx = -1,
          kDiscarded = kNoVtx - 1 };
 
-  NA6PLine mLine;      // straight line representation of the track
-  float mSig2XI = 0.f; // XX component of inverse cov.matrix
-  float mSig2YI = 0.f; // YY component of inverse cov.matrix
-  float mSig2ZI = 0.f; // ZZ component of inverse cov matrix
-  float mSigXYI = 0.f; // XY component of inverse cov matrix
-  float mSigXZI = 0.f; // XZ component of inverse cov matrix
-  float mSigYZI = 0.f; // YZ component of inverse cov matrix
-  int trackIndex = -1; // track index
-  float wgh = 0.f;     ///< track weight wrt current vertex seed
-  int vtxID = kNoVtx;  // assigned vertex
+  NA6PTrackParCov mTrack;   ///< track state and covariance at the DCA to the beam line
+  float mZSeedWeight = 0.f; ///< inverse variance of the beam-line Z intercept, used only for peak finding
+  int trackIndex = -1;      ///< track index
+  float wgh = 0.f;          ///< track weight wrt current vertex seed
+  int vtxID = kNoVtx;       ///< assigned vertex
 
   TrackVF() = default;
-  TrackVF(const NA6PTrackParCov& src, int id) : mLine(src)
-  {
-    // NB: src must already be propagated to its DCA to the beam axis
-    // before constructing TrackVF — call propagateToDCABeamAxis() first
-    trackIndex = id;
-    float sxx = src.getSigmaX2(), syy = src.getSigmaY2(), sxy = src.getSigmaYX();
-    float cx = mLine.mCosinesDirector[0];
-    float cy = mLine.mCosinesDirector[1];
-    float cz = mLine.mCosinesDirector[2];
-    float pt2 = cx * cx + cy * cy;
-    float szz = (pt2 > 1e-6f) ? 0.5f * (sxx + syy) * (cz * cz) / pt2 : 1e10f; // RSTODO check the logic
-    float det = sxx * syy - sxy * sxy;
-    if (det <= 1e-20f) {
-      mSig2ZI = -1.f;
-      return;
-    }
-    float detI = 1.f / det;
-    mSig2XI = syy * detI;
-    mSig2YI = sxx * detI;
-    mSigXYI = -sxy * detI;
-    // z weight from error propagation of transverse cov along track direction
-    // xz and yz correlations neglected (mSigXZI = mSigYZI = 0)
-    mSig2ZI = (szz > 0.f) ? 1.f / szz : 0.f;
-  }
-  bool isValid() const { return mSig2ZI > 0.f; }
+  TrackVF(const NA6PTrackParCov& src, int id, float beamX, float beamY);
+  bool isValid() const { return mZSeedWeight > 0.f; }
   bool canUse() const { return vtxID == kNoVtx; }
   bool canAssign() const { return wgh > 0. && vtxID == kNoVtx; }
-
-  std::array<float, 3> getResiduals(const std::array<float, 3>& vtxPos) const
-  {
-    // vector from closest point on line to vtxPos
-    auto comps = mLine.getDCAComponents(vtxPos);
-    return {comps[0], comps[3], comps[5]}; // dx, dy, dz components
-  }
-
-  float evalChi2ToVertex(const std::array<float, 3>& vtxPos) const
-  {
-    const auto res = getResiduals(vtxPos); // track-vertex residuals and chi2
-    return evalChi2ToVertex(res[0], res[1]);
-  }
-
-  float evalChi2ToVertex(float dx, float dy) const
-  {
-    constexpr float NDOF2I = 0.5f;
-    float chi2T = dx * dx * mSig2XI + 2.f * dx * dy * mSigXYI + dy * dy * mSig2YI;
-    chi2T *= NDOF2I;
-    return chi2T;
-  }
 
   ClassDefNV(TrackVF, 1);
 };
@@ -92,7 +42,7 @@ struct TrackVF {
 struct VertexSeed {
   float x = 0.f, y = 0.f, z = 0.f;
   double wghSum = 0.;                                                                              // sum of tracks weights
-  double wghChi2 = 0.;                                                                             // sum of tracks weighted chi2's
+  double wghChi2 = 0.;                                                                             // sum of weighted chi2 per residual
   double cxx = 0., cyy = 0., czz = 0., cxy = 0., cxz = 0., cyz = 0., cx0 = 0., cy0 = 0., cz0 = 0.; // elements of lin.equation matrix
   float scaleSigma2 = 1.;                                                                          // scaling parameter on top of Tukey param
   float scaleSigma2Prev = 1.;
@@ -196,27 +146,27 @@ class NA6PVertexerTracks
   void finalizeVertex(NA6PVertex& vtx, std::vector<NA6PVertex>& vertices);
 
  private:
-  std::vector<TrackVF> mTracksPool;               ///< tracks in internal representation used for vertexing
-  float mBeamX = 0.;                              ///< beam transverse coordindates
-  float mBeamY = 0.;                              ///< beam transverse coordindates
-  float mMaxDCA = 0.05;                           ///< cut on DCA of track to beam line (cm)
-  float mZMin = -20.0;                            ///< z range, min, cm
-  float mZMax = 5.;                               ///< z range, max, cm
-  int mNBinsForPeakFind = 250;                    ///< 0.1 cm per bin
-  float mZBinWidth = 0.1;                         ///< bin width
-  std::vector<float> mHistZ;                      ///< histogram for the peak finding method
-  std::vector<int> mFilledBinsZ;                  ///< indices of non-empty bins
-  int mMaxVerticesPerCluster = 5;                 ///< one vertex per target
-  int mMaxTrialsPerCluster = 100;                 //
-  static constexpr float kAlmost0F = 1e-7f;       ///< tiny float
+  std::vector<TrackVF> mTracksPool;         ///< tracks in internal representation used for vertexing
+  float mBeamX = 0.;                        ///< beam transverse coordinates
+  float mBeamY = 0.;                        ///< beam transverse coordinates
+  float mMaxDCA = 0.05;                     ///< cut on DCA of track to beam line (cm)
+  float mZMin = -20.0;                      ///< z range, min, cm
+  float mZMax = 5.;                         ///< z range, max, cm
+  int mNBinsForPeakFind = 250;              ///< 0.1 cm per bin
+  float mZBinWidth = 0.1;                   ///< bin width
+  std::vector<float> mHistZ;                ///< histogram for the peak finding method
+  std::vector<int> mFilledBinsZ;            ///< indices of non-empty bins
+  int mMaxVerticesPerCluster = 5;           ///< one vertex per target
+  int mMaxTrialsPerCluster = 100;           //
+  static constexpr float kAlmost0F = 1e-7f; ///< tiny float
   //  static constexpr float kScaleStability = 0.1f;  ///< tolerance for scale change
-  static constexpr float kDefTukey = 5.0f;        ///< def.value for tukey constant
+  static constexpr float kDefTukey = 5.0f;        ///< def.value for Tukey constant
   float mTukey2I = 1.f / (kDefTukey * kDefTukey); ///< 1./[Tukey parameter]^2
   float mInitScaleSigma2 = 10.f;                  ///< scaling parameter on top of Tukey param
   int mMaxIterations = 20;                        ///< max iterations per vertex fit
   int mMinTracksPerVtx = 2;                       ///< minimum number of tracks per vertex
   float mMinScale2 = 1.;                          ///< min scaling factor^2
-  float mMaxScale2 = 50.;                         ///< max slaling factor^2
+  float mMaxScale2 = 50.;                         ///< max scaling factor^2
   float mMaxChi2Mean = 30.;                       ///< max mean chi2 of vertex to accept
   int mMaxNScaleIncreased = 5;                    ///< max number of scaling-non-decreasing iterations
   float mSlowConvergenceFactor = 0.5;             ///< consider convergence as slow if ratio new/old scale2 exceeds it

--- a/rec/include/NA6PVertexerTracks.h
+++ b/rec/include/NA6PVertexerTracks.h
@@ -24,8 +24,15 @@ struct TrackVF {
          kNoVtx = -1,
          kDiscarded = kNoVtx - 1 };
 
-  NA6PTrackParCov mTrack;   ///< track state and covariance at the DCA to the beam line
-  float mZSeedWeight = 0.f; ///< inverse variance of the beam-line Z intercept, used only for peak finding
+  double mSxx[3]{};         ///< coefficients of Sxx(dz) = Sxx[0] + dz*Sxx[1] + dz^2*Sxx[2]
+  double mSxy[3]{};         ///< coefficients of Sxy(dz) = Sxy[0] + dz*Sxy[1] + dz^2*Sxy[2]
+  double mSyy[3]{};         ///< coefficients of Syy(dz) = Syy[0] + dz*Syy[1] + dz^2*Syy[2]
+  double mSlopeX = 0.;      ///< dx/dz = tx/cosPsi
+  double mSlopeY = 0.;      ///< dy/dz = ty/cosPsi
+  float mX = 0.f;           ///< track X at the PCA to the beam line
+  float mY = 0.f;           ///< track Y at the PCA to the beam line
+  float mZ = 0.f;           ///< track Z at the PCA to the beam line
+  float mZSeedWeight = 0.f; ///< inverse variance of the beam-line Z PCA, used only for peak finding
   int trackIndex = -1;      ///< track index
   float wgh = 0.f;          ///< track weight wrt current vertex seed
   int vtxID = kNoVtx;       ///< assigned vertex
@@ -36,7 +43,7 @@ struct TrackVF {
   bool canUse() const { return vtxID == kNoVtx; }
   bool canAssign() const { return wgh > 0. && vtxID == kNoVtx; }
 
-  ClassDefNV(TrackVF, 1);
+  ClassDefNV(TrackVF, 2);
 };
 
 struct VertexSeed {

--- a/rec/src/NA6PVertexerTracks.cxx
+++ b/rec/src/NA6PVertexerTracks.cxx
@@ -7,7 +7,38 @@
 
 ClassImp(NA6PVertexerTracks)
 
-  NA6PVertexerTracks::NA6PVertexerTracks()
+  TrackVF::TrackVF(const NA6PTrackParCov& src, int id, float beamX, float beamY) : mTrack(src), trackIndex(id)
+{
+  // The track is already at its transverse DCA to the beam line. Estimate the
+  // uncertainty of that Z PCA only for peak finding. The vertex fit itself
+  // uses the two X/Y residuals and the covariance propagated to the seed Z.
+  double tx = src.getTx(), ty = src.getTy();
+  double den = tx * tx + ty * ty;
+
+  double cosPsi = src.getCosPsi();
+  double dx = beamX - src.getX(), dy = beamY - src.getY();
+  double num = tx * dx + ty * dy;
+  double denI = 1. / den, denI2 = denI * denI;
+
+  // Gradient of zPCA = z + cosPsi*(tx*dx + ty*dy)/(tx^2 + ty^2)
+  // with respect to the state [x, y, tx, ty, q/pXZ]. NA6PTrackPar::kQ2Pxz is not used in the calculation of zPCA, so its gradient is zero.
+  double grad[4];
+  grad[NA6PTrackPar::kX] = -cosPsi * tx * denI;
+  grad[NA6PTrackPar::kY] = -cosPsi * ty * denI;
+  grad[NA6PTrackPar::kTx] = -tx * num * denI / cosPsi + cosPsi * (dx * den - 2. * tx * num) * denI2;
+  grad[NA6PTrackPar::kTy] = cosPsi * (dy * den - 2. * ty * num) * denI2;
+
+  double sigmaZ2 = 0.;
+  for (int i = 0; i < 4; ++i) {
+    sigmaZ2 += grad[i] * grad[i] * src.getCovMatElem(i, i);
+    for (int j = 0; j < i; ++j) {
+      sigmaZ2 += 2. * grad[i] * grad[j] * src.getCovMatElem(i, j);
+    }
+  }
+  mZSeedWeight = static_cast<float>(1. / sigmaZ2);
+}
+
+NA6PVertexerTracks::NA6PVertexerTracks()
 {
   configurePeakFinding(mZMin, mZMax, mNBinsForPeakFind);
 }
@@ -24,7 +55,7 @@ void NA6PVertexerTracks::createTracksPool(const std::vector<NA6PTrack>& tracks)
     if (!prop->propagatePCAToLine(trc, mBeamX, mBeamY, mMaxDCA)) {
       continue;
     }
-    auto& tvf = mTracksPool.emplace_back(trc, i);
+    auto& tvf = mTracksPool.emplace_back(trc, i, mBeamX, mBeamY);
     if (!tvf.isValid()) {
       mTracksPool.pop_back(); // discard bad track
       continue;
@@ -39,12 +70,12 @@ void NA6PVertexerTracks::buildAndFillHistoZ()
   std::fill(mHistZ.begin(), mHistZ.end(), 0.f);
   mFilledBinsZ.clear();
   for (const auto& tvf : mTracksPool) {
-    float z = tvf.mLine.mOriginPoint[2];
+    float z = tvf.mTrack.getZ();
     if (z >= mZMin && z < mZMax) {
       int bin = int((z - mZMin) / mZBinWidth);
       if (mHistZ[bin] == 0.f)
         mFilledBinsZ.push_back(bin);
-      mHistZ[bin] += tvf.mSig2ZI; // weighted fill
+      mHistZ[bin] += tvf.mZSeedWeight; // weighted fill
     }
   }
 }
@@ -177,45 +208,75 @@ NA6PVertexerTracks::FitStatus NA6PVertexerTracks::fitIteration(VertexSeed& vtxSe
 //___________________________________________________________________
 void NA6PVertexerTracks::accountTrack(TrackVF& trc, VertexSeed& vtxSeed) const
 {
-  // deltas defined as track - vertex
-  std::array<float, 3> vtxPos = {vtxSeed.x, vtxSeed.y, vtxSeed.z};
-  auto res = trc.getResiduals(vtxPos);
-  float dx = res[0], dy = res[1];
-  // z intercept residual: z of track at closest transverse approach to (vx, vy)
-  float ox = trc.mLine.mOriginPoint[0];
-  float oy = trc.mLine.mOriginPoint[1];
-  float oz = trc.mLine.mOriginPoint[2];
-  float cx = trc.mLine.mCosinesDirector[0];
-  float cy = trc.mLine.mCosinesDirector[1];
-  float cz = trc.mLine.mCosinesDirector[2];
-  auto norm = cx * cx + cy * cy;
   trc.wgh = 0.f;
-  if (norm < kAlmost0F)
-    return;
-  float t = (cx * (vtxSeed.x - ox) + cy * (vtxSeed.y - oy)) / norm; // RSFIX: added normalization, check if this is correct
-  float dz = oz + cz * t - vtxSeed.z;
 
-  auto chi2T = trc.evalChi2ToVertex(dx, dy);
-  float wghT = (1.f - chi2T * vtxSeed.scaleSig2ITuk2I); // weighted distance to vertex
+  double predX = 0., predY = 0., slopeX = 0., slopeY = 0.;
+  double sxx = 0., syy = 0., sxy = 0.;
+  // Straight-line transport Jacobian from [x,y,tx,ty,q/pXZ] at z0 to X/Y
+  // at the candidate Z. q/pXZ has no first-order contribution.
+  double tx = trc.mTrack.getTx(), ty = trc.mTrack.getTy();
+  double cosPsi = trc.mTrack.getCosPsi();
+  double cosPsiI = 1. / cosPsi;
+  double cosPsiI3 = cosPsiI * cosPsiI * cosPsiI;
+  double dz = vtxSeed.z - trc.mTrack.getZ();
+  slopeX = tx * cosPsiI;
+  slopeY = ty * cosPsiI;
+  predX = trc.mTrack.getX() + slopeX * dz;
+  predY = trc.mTrack.getY() + slopeY * dz;
+  double hX[5] = {1., 0., dz * cosPsiI3, 0., 0.};
+  double hY[5] = {0., 1., dz * ty * tx * cosPsiI3, dz * cosPsiI, 0.};
+  for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+      double cij = trc.mTrack.getCovMatElem(i, j);
+      sxx += hX[i] * cij * hX[j];
+      sxy += hX[i] * cij * hY[j];
+      syy += hY[i] * cij * hY[j];
+    }
+  }
+
+  // Residual convention: track prediction minus vertex position.
+  double rx = predX - vtxSeed.x;
+  double ry = predY - vtxSeed.y;
+  double det = sxx * syy - sxy * sxy;
+  if (det <= 1e-20f) {
+    return;
+  }
+
+  double detI = 1. / det;
+  double wxx = syy * detI;
+  double wyy = sxx * detI;
+  double wxy = -sxy * detI;
+
+  constexpr float NDOF2I = 0.5f;
+  double chi2T = rx * rx * wxx + 2. * rx * ry * wxy + ry * ry * wyy;
+  chi2T *= NDOF2I; // chi2 per residual
+
+  double wghT = 1. - chi2T * vtxSeed.scaleSig2ITuk2I;
   if (wghT < kAlmost0F) {
     return;
   }
   wghT *= wghT;
-  float sxxI = trc.mSig2XI * wghT;
-  float syyI = trc.mSig2YI * wghT;
-  float sxyI = trc.mSigXYI * wghT;
+
+  double wrx = wxx * rx + wxy * ry;
+  double wry = wxy * rx + wyy * ry;
+
   trc.wgh = wghT;
   vtxSeed.wghSum += wghT;
   vtxSeed.wghChi2 += wghT * chi2T;
-  vtxSeed.cxx += sxxI;
-  vtxSeed.cyy += syyI;
-  vtxSeed.cxy += sxyI;
-  vtxSeed.cx0 += sxxI * dx + sxyI * dy;
-  vtxSeed.cy0 += sxyI * dx + syyI * dy;
-  vtxSeed.czz += trc.mSig2ZI * wghT;
-  vtxSeed.cxz += trc.mSigXZI * wghT;
-  vtxSeed.cyz += trc.mSigYZI * wghT;
-  vtxSeed.cz0 += wghT * (trc.mSig2ZI * dz + trc.mSigXZI * dx + trc.mSigYZI * dy);
+
+  // D = d(track-vertex residual)/d(vx,vy,vz)
+  //     = [-1,  0, slopeX]
+  //       [ 0, -1, slopeY].
+  // Accumulate A = D^T W D and b = -D^T W r, then solve A*delta=b.
+  vtxSeed.cxx += wghT * wxx;
+  vtxSeed.cyy += wghT * wyy;
+  vtxSeed.cxy += wghT * wxy;
+  vtxSeed.cxz -= wghT * (wxx * slopeX + wxy * slopeY);
+  vtxSeed.cyz -= wghT * (wxy * slopeX + wyy * slopeY);
+  vtxSeed.czz += wghT * (slopeX * slopeX * wxx + 2. * slopeX * slopeY * wxy + slopeY * slopeY * wyy);
+  vtxSeed.cx0 += wghT * wrx;
+  vtxSeed.cy0 += wghT * wry;
+  vtxSeed.cz0 -= wghT * (slopeX * wrx + slopeY * wry);
 
   vtxSeed.nContributors++;
 }

--- a/rec/src/NA6PVertexerTracks.cxx
+++ b/rec/src/NA6PVertexerTracks.cxx
@@ -7,18 +7,50 @@
 
 ClassImp(NA6PVertexerTracks)
 
-  TrackVF::TrackVF(const NA6PTrackParCov& src, int id, float beamX, float beamY) : mTrack(src), trackIndex(id)
+TrackVF::TrackVF(const NA6PTrackParCov& src, int id, float beamX, float beamY)
+  : mX(src.getX()), mY(src.getY()), mZ(src.getZ()), trackIndex(id)
 {
   // The track is already at its transverse DCA to the beam line. Estimate the
   // uncertainty of that Z PCA only for peak finding. The vertex fit itself
   // uses the two X/Y residuals and the covariance propagated to the seed Z.
-  double tx = src.getTx(), ty = src.getTy();
-  double den = tx * tx + ty * ty;
+  const double tx = src.getTx(), ty = src.getTy();
+  const double den = tx * tx + ty * ty;
+  const double cosPsi = src.getCosPsi();
+  const double cosPsiI = 1. / cosPsi;
+  const double dSlopeXdTx = cosPsiI * cosPsiI * cosPsiI;
+  const double dSlopeYdTx = ty * tx * dSlopeXdTx;
+  const double dSlopeYdTy = cosPsiI;
+  mSlopeX = tx * cosPsiI;
+  mSlopeY = ty * cosPsiI;
 
-  double cosPsi = src.getCosPsi();
-  double dx = beamX - src.getX(), dy = beamY - src.getY();
-  double num = tx * dx + ty * dy;
-  double denI = 1. / den, denI2 = denI * denI;
+  // Precompute S(dz) = H(dz)*C*H(dz)^T as three quadratic polynomials.
+  // Only the [x,y,tx,ty] covariance block contributes in the straight-line model.
+  const double cXX = src.getCovMatElem(NA6PTrackPar::kX, NA6PTrackPar::kX);
+  const double cXY = src.getCovMatElem(NA6PTrackPar::kX, NA6PTrackPar::kY);
+  const double cYY = src.getCovMatElem(NA6PTrackPar::kY, NA6PTrackPar::kY);
+  const double cXTx = src.getCovMatElem(NA6PTrackPar::kX, NA6PTrackPar::kTx);
+  const double cXTy = src.getCovMatElem(NA6PTrackPar::kX, NA6PTrackPar::kTy);
+  const double cYTx = src.getCovMatElem(NA6PTrackPar::kY, NA6PTrackPar::kTx);
+  const double cYTy = src.getCovMatElem(NA6PTrackPar::kY, NA6PTrackPar::kTy);
+  const double cTxTx = src.getCovMatElem(NA6PTrackPar::kTx, NA6PTrackPar::kTx);
+  const double cTxTy = src.getCovMatElem(NA6PTrackPar::kTx, NA6PTrackPar::kTy);
+  const double cTyTy = src.getCovMatElem(NA6PTrackPar::kTy, NA6PTrackPar::kTy);
+
+  mSxx[0] = cXX;
+  mSxx[1] = 2. * dSlopeXdTx * cXTx;
+  mSxx[2] = dSlopeXdTx * dSlopeXdTx * cTxTx;
+
+  mSxy[0] = cXY;
+  mSxy[1] = dSlopeYdTx * cXTx + dSlopeYdTy * cXTy + dSlopeXdTx * cYTx;
+  mSxy[2] = dSlopeXdTx * (dSlopeYdTx * cTxTx + dSlopeYdTy * cTxTy);
+
+  mSyy[0] = cYY;
+  mSyy[1] = 2. * (dSlopeYdTx * cYTx + dSlopeYdTy * cYTy);
+  mSyy[2] = dSlopeYdTx * dSlopeYdTx * cTxTx + 2. * dSlopeYdTx * dSlopeYdTy * cTxTy + dSlopeYdTy * dSlopeYdTy * cTyTy;
+
+  const double dx = beamX - src.getX(), dy = beamY - src.getY();
+  const double num = tx * dx + ty * dy;
+  const double denI = 1. / den, denI2 = denI * denI;
 
   // Gradient of zPCA = z + cosPsi*(tx*dx + ty*dy)/(tx^2 + ty^2)
   // with respect to the state [x, y, tx, ty, q/pXZ]. NA6PTrackPar::kQ2Pxz is not used in the calculation of zPCA, so its gradient is zero.
@@ -70,7 +102,7 @@ void NA6PVertexerTracks::buildAndFillHistoZ()
   std::fill(mHistZ.begin(), mHistZ.end(), 0.f);
   mFilledBinsZ.clear();
   for (const auto& tvf : mTracksPool) {
-    float z = tvf.mTrack.getZ();
+    float z = tvf.mZ;
     if (z >= mZMin && z < mZMax) {
       int bin = int((z - mZMin) / mZBinWidth);
       if (mHistZ[bin] == 0.f)
@@ -210,29 +242,14 @@ void NA6PVertexerTracks::accountTrack(TrackVF& trc, VertexSeed& vtxSeed) const
 {
   trc.wgh = 0.f;
 
-  double predX = 0., predY = 0., slopeX = 0., slopeY = 0.;
-  double sxx = 0., syy = 0., sxy = 0.;
-  // Straight-line transport Jacobian from [x,y,tx,ty,q/pXZ] at z0 to X/Y
-  // at the candidate Z. q/pXZ has no first-order contribution.
-  double tx = trc.mTrack.getTx(), ty = trc.mTrack.getTy();
-  double cosPsi = trc.mTrack.getCosPsi();
-  double cosPsiI = 1. / cosPsi;
-  double cosPsiI3 = cosPsiI * cosPsiI * cosPsiI;
-  double dz = vtxSeed.z - trc.mTrack.getZ();
-  slopeX = tx * cosPsiI;
-  slopeY = ty * cosPsiI;
-  predX = trc.mTrack.getX() + slopeX * dz;
-  predY = trc.mTrack.getY() + slopeY * dz;
-  double hX[5] = {1., 0., dz * cosPsiI3, 0., 0.};
-  double hY[5] = {0., 1., dz * ty * tx * cosPsiI3, dz * cosPsiI, 0.};
-  for (int i = 0; i < 5; ++i) {
-    for (int j = 0; j < 5; ++j) {
-      double cij = trc.mTrack.getCovMatElem(i, j);
-      sxx += hX[i] * cij * hX[j];
-      sxy += hX[i] * cij * hY[j];
-      syy += hY[i] * cij * hY[j];
-    }
-  }
+  const double dz = vtxSeed.z - trc.mZ;
+  const double predX = trc.mX + trc.mSlopeX * dz;
+  const double predY = trc.mY + trc.mSlopeY * dz;
+  const double sxx = std::fma(dz, std::fma(dz, trc.mSxx[2], trc.mSxx[1]), trc.mSxx[0]); // Evaluates Sxx[2]*dz^2 + Sxx[1]*dz + Sxx[0] using fused multiply-add
+  const double sxy = std::fma(dz, std::fma(dz, trc.mSxy[2], trc.mSxy[1]), trc.mSxy[0]); // Evaluates Sxy[2]*dz^2 + Sxy[1]*dz + Sxy[0] using fused multiply-add
+  const double syy = std::fma(dz, std::fma(dz, trc.mSyy[2], trc.mSyy[1]), trc.mSyy[0]); // Evaluates Syy[2]*dz^2 + Syy[1]*dz + Syy[0] using fused multiply-add
+  const double slopeX = trc.mSlopeX;
+  const double slopeY = trc.mSlopeY;
 
   // Residual convention: track prediction minus vertex position.
   double rx = predX - vtxSeed.x;

--- a/test/runVertexerTracks.C
+++ b/test/runVertexerTracks.C
@@ -5,7 +5,7 @@
 #include <TH2F.h>
 #include <TCanvas.h>
 #include <TParticle.h>
-#include "MagneticField.h"
+#include "Propagator.h"
 #include "NA6PVertex.h"
 #include "NA6PVertexerTracks.h"
 #include "NA6PMCEventHeader.h"
@@ -13,9 +13,9 @@
 
 void runVertexerTracks(const char* dirSimu = ".")
 {
-  auto magField = new MagneticField();
-  magField->loadField();
-  magField->setAsGlobalField();
+  if (!Propagator::loadField() || !Propagator::loadGeometry(Form("%s/geometry.root", dirSimu))) {
+    return;
+  }
 
   TFile* ft = new TFile(Form("%s/TracksVerTel.root", dirSimu));
   if (!ft)
@@ -33,12 +33,12 @@ void runVertexerTracks(const char* dirSimu = ".")
 
   TH1F* hncontr = new TH1F("hncontr", ";N_{contributors}", 100, -0.5, 999.5);
   TH1F* hnvert = new TH1F("hnvert", ";Number of reco vertices", 11, -0.5, 10.5);
-  TH2F* hxrecgen = new TH2F("hxrecgen", ";x_{gen} (cm);x_{rec} (cm)", 100, -0.05, 0.05, 100, -0.05, 0.05);
-  TH2F* hyrecgen = new TH2F("hyrecgen", ";y_{gen} (cm);y_{rec} (cm)", 100, -0.05, 0.05, 100, -0.05, 0.05);
-  TH2F* hzrecgen = new TH2F("hzrecgen", ";z_{gen} (cm);z_{rec} (cm)", 100, -4., 4., 100, -4., 4.);
+  TH2F* hxrecgen = new TH2F("hxrecgen", ";x_{gen} (cm);x_{rec} (cm)", 1000, -0.5, 0.5, 1000, -0.5, 0.5);
+  TH2F* hyrecgen = new TH2F("hyrecgen", ";y_{gen} (cm);y_{rec} (cm)", 1000, -0.5, 0.5, 1000, -0.5, 0.5);
+  TH2F* hzrecgen = new TH2F("hzrecgen", ";z_{gen} (cm);z_{rec} (cm)", 100, -6., 1., 100, -6., 1.);
   TH1F* hxrec = new TH1F("hxrec", ";x_{rec,main} (cm)", 100, -0.1, 0.1);
   TH1F* hyrec = new TH1F("hyrec", ";y_{rec,main} (cm)", 100, -0.1, 0.1);
-  TH1F* hzrec = new TH1F("hzrec", ";z_{rec,main} (cm)", 200, -4., 4.);
+  TH1F* hzrec = new TH1F("hzrec", ";z_{rec,main} (cm)", 200, -6., 1.);
   TH1F* hdx = new TH1F("hdx", ";x_{rec} - x_{gen} (#mum)", 100, -40., 40.);
   TH1F* hdy = new TH1F("hdy", ";y_{rec} - y_{gen} (#mum)", 100, -40., 40.);
   TH1F* hdz = new TH1F("hdz", ";z_{rec} - z_{gen} (#mum)", 100, -200., 200.);
@@ -145,6 +145,7 @@ void runVertexerTracks(const char* dirSimu = ".")
   hzrec->SetFillColor(kBlue - 9);
   hzrec->SetFillStyle(1001);
   hzrec->Draw();
+  cv->SaveAs(Form("%s/vertexerSummary.png", dirSimu));
 
   TCanvas* cres = new TCanvas("cres", "", 1400, 800);
   cres->Divide(3, 2);
@@ -166,6 +167,7 @@ void runVertexerTracks(const char* dirSimu = ".")
   hdz->SetFillColor(kOrange + 2);
   hdz->SetFillStyle(1001);
   hdz->Draw();
+  cres->SaveAs(Form("%s/vertexerResiduals.png", dirSimu));
 
   TCanvas* cpull = new TCanvas("cpull", "", 1400, 800);
   cpull->Divide(3, 2);
@@ -190,6 +192,7 @@ void runVertexerTracks(const char* dirSimu = ".")
   hpullz->SetFillColor(kTeal - 7);
   hpullz->SetFillStyle(1001);
   hpullz->Draw();
+  cpull->SaveAs(Form("%s/vertexerPulls.png", dirSimu));
 
   TCanvas* cpil = new TCanvas("cz", "", 1200, 800);
   cpil->Divide(2, 2);
@@ -199,4 +202,5 @@ void runVertexerTracks(const char* dirSimu = ".")
   hcontRatio->Draw();
   cpil->cd(3);
   hzdrc->Draw("colz");
+  cpil->SaveAs(Form("%s/vertexerPileup.png", dirSimu));
 }


### PR DESCRIPTION
This PR adapts NA6PVertexerTracks to the new [x, y, tx, ty, q/pXZ] track parametrization.
For peak finding, the Z-PCA uncertainty is obtained by propagating the [x, y, tx, ty] covariance through the beam-line PCA expression using a local straight-line approximation.
The vertex fit uses two X/Y residuals at the candidate Z, with their covariance propagated through the straight-line Jacobian, including all position–slope correlations. The longitudinal constraint is obtained from the Z dependence of the transverse residuals through the track slopes, rather than from a separately constructed Z-PCA residual.

This provides similar residuals to what Francesco presented but better pulls (see slide 12 https://indico.cern.ch/event/1664364/contributions/6998735/attachments/3239796/5778359/VertexerTracks.pdf )
<img width="1398" height="776" alt="vertexerResiduals" src="https://github.com/user-attachments/assets/edc97c61-0246-4c98-9ab5-38090eb87ec2" />
<img width="1398" height="776" alt="vertexerPulls" src="https://github.com/user-attachments/assets/594e93bc-07cc-4e0f-8f36-1e6756a7adc4" />
