### PR TITLE
Fix uncertainties in secondary vertex fitting

### DIFF
--- a/rec/include/NA6PDCAFitterN.h
+++ b/rec/include/NA6PDCAFitterN.h
@@ -1,22 +1,30 @@
 #ifndef _NA6P_DCA_FITTERN_H
 #define _NA6P_DCA_FITTERN_H
 
+#include <algorithm>
+#include <cmath>
+
 #include <Math/SVector.h>
 #include <Math/SMatrix.h>
 #include <fairlogger/Logger.h>
 #include "NA6PTrack.h"
 #include "NA6PHelixHelper.h"
+#include "Propagator.h"
 
 using CircleXZ = NA6PHelixHelper::CircleXZ;
 
 struct TrackCovI {
-  float sxx, syy, sxy, szz;
+  // Independent elements of the symmetric 3D information matrix
+  // H^T Cxy^{-1} H. A track constrains X and Y at a given Z through
+  // H = {{1, 0, -dx/dz}, {0, 1, -dy/dz}}.
+  float sxx, syy, sxy, sxz, syz, szz;
 
-  TrackCovI(const NA6PTrack& trc, float zerrFactor = 1.f) { set(trc, zerrFactor); }
+  TrackCovI(const NA6PTrack& trc) { set(trc); }
   TrackCovI() = default;
-  bool set(const NA6PTrack& trc, float zerrFactor = 1.f)
+  bool set(const NA6PTrack& trc)
   {
-    float cxx = trc.getSigmaX2(), cyy = trc.getSigmaY2(), cxy = trc.getSigmaYX(), czz = cyy * zerrFactor;
+    // Invert the 2D covariance of the measured track position (X,Y).
+    float cxx = trc.getSigmaX2(), cyy = trc.getSigmaY2(), cxy = trc.getSigmaYX();
     float detXY = cxx * cyy - cxy * cxy;
     bool res = true;
     if (detXY <= 0.) {
@@ -28,7 +36,11 @@ struct TrackCovI {
     sxx = cyy * detXYI;
     syy = cxx * detXYI;
     sxy = -cxy * detXYI;
-    szz = 1. / czz;
+    const float sx = trc.getSlopeX();
+    const float sy = trc.getSlopeY();
+    sxz = -(sxx * sx + sxy * sy);
+    syz = -(sxy * sx + syy * sy);
+    szz = sx * sx * sxx + 2.f * sx * sy * sxy + sy * sy * syy;
     return res;
   }
 };
@@ -39,23 +51,22 @@ struct TrackDeriv {
   TrackDeriv(const NA6PTrack& trc, float by) { set(trc, by); }
   void set(const NA6PTrack& trc, float by)
   {
-    auto pxyz = trc.getPXYZ();
-    if (std::abs(pxyz[2]) < 1e-9)
-      return;
-    dxdz = pxyz[0] / pxyz[2];
-    dydz = pxyz[1] / pxyz[2];
-    // Second derivatives:
-    // d^2x/dz^2 = d/dz(px/pz) = 1/pz * (dpx/dz) - px/pz^2 (dpz/dz)
-    // Tangents to circumference of radius R in two points separated by dz
-    // theta = angle spanned by R
-    // dpx/dz = p_xz/R
-    // dpz = pxz*(1-cos(theta)) = pxz*2*sin^2(theta/2) ~ pxz*2*(theta/2)^2 ~ (p_xz/R)*dz^2 / 2
-    // dpz/dz ~ (p_xz/R)*dz/2 --> negligible
-    // d2xdz2 ~ 1/pz * (dpx/dz) = p_xz/pz * 1/R = sqrt((px/pz)^2 + 1) * 1/R
-    float crv2c = trc.getCurvature(by);
-    d2xdz2 = crv2c * std::sqrt(1.f + dxdz * dxdz);
-    //  d^2y/dz^2 = d/dz(py/pz) = 0 (dipole field, py is conserved, and dpz/dz is negligible)
-    d2ydz2 = 0.f;
+    // Track parameters use tx = px/pXZ and ty = py/pXZ, while
+    // cosPsi = pz/pXZ. Therefore dx/dz = tx/cosPsi and
+    // dy/dz = ty/cosPsi for the forward (pz > 0) geometry.
+    const double tx = trc.getTx();
+    const double ty = trc.getTy();
+    const double cosPsi = trc.getCosPsi();
+    const double cosI = 1. / cosPsi;
+    const double cosI3 = cosI * cosI * cosI;
+    const double kappa = trc.getCurvature(by);
+    dxdz = static_cast<float>(tx * cosI);
+    dydz = static_cast<float>(ty * cosI);
+    // In a By-only field, differentiating the helix slopes once more
+    // gives the curvature terms below; the common cosPsi^{-3} accounts
+    // for using Z, rather than arc length, as propagation parameter.
+    d2xdz2 = static_cast<float>(kappa * cosI3);
+    d2ydz2 = static_cast<float>(kappa * ty * tx * cosI3);
   }
 };
 
@@ -66,7 +77,6 @@ class NA6PDCAFitterN
   static constexpr double NMax = 4;
   static constexpr double NInv = 1. / N;
   static constexpr int MAXHYP = 2;
-  static constexpr float ZerrFactor = 5.; // factor for conversion of track covYY to dummy covXX
   using Vec3D = ROOT::Math::SVector<double, 3>;
   using VecND = ROOT::Math::SVector<double, N>;
   using MatSym3D = ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>>;
@@ -160,7 +170,7 @@ class NA6PDCAFitterN
   }
 
   ///< create parent track param with errors for decay vertex
-  NA6PTrack createParentTrackParCov(int cand = 0) const; // TODO: update to use NA6PTRackParCov
+  NA6PTrack createParentTrackParCov(int cand = 0) const;
 
   ///< create parent track param w/o errors for decay vertex
   NA6PTrack createParentTrackPar(int cand = 0) const;
@@ -193,8 +203,13 @@ class NA6PDCAFitterN
   void setUseAbsDCA(bool v) { mUseAbsDCA = v; }
   void setWeightedFinalPCA(bool v) { mWeightedFinalPCA = v; }
   void setMaxDistance2ToMerge(float v) { mMaxDist2ToMergeSeeds = v; }
-  void setUsePropagator(bool v) { mUsePropagator = v; }
-  void setRefitWithMatCorr(bool v) { mRefitWithMatCorr = v; }
+  void setUseFullFieldPropagation(bool v) { mUseFullFieldPropagation = v; }
+  void setRefitWithMatCorr(bool v)
+  {
+    mRefitWithMatCorr = v;
+    mPropOpt.matCorr = v ? Propagator::MatCorrType::USEMatCorrTGeo : Propagator::MatCorrType::USEMatCorrNONE;
+    mUseFullFieldPropagation |= v;
+  }
   void setMaxVertX(float x) { mMaxVertX = x; }
   void setMinVertZ(float z) { mMinVertZ = z; }
   void setMaxVertZ(float z) { mMaxVertZ = z; }
@@ -211,7 +226,7 @@ class NA6PDCAFitterN
   bool getUseAbsDCA() const { return mUseAbsDCA; }
   bool getWeightedFinalPCA() const { return mWeightedFinalPCA; }
   bool getPropagateToPCA() const { return mPropagateToPCA; }
-  bool getUsePropagator() const { return mUsePropagator; }
+  bool getUseFullFieldPropagation() const { return mUseFullFieldPropagation; }
   bool getRefitWithMatCorr() const { return mRefitWithMatCorr; }
   float getMaxVertX() const { return mMaxVertX; }
   float getMinVertZ() const { return mMinVertZ; }
@@ -309,7 +324,7 @@ class NA6PDCAFitterN
   bool mUseAbsDCA = false;                           // use abs. distance minimization rather than chi2
   bool mWeightedFinalPCA = false;                    // recalculate PCA as a cov-matrix weighted mean, even if absDCA method was used
   bool mPropagateToPCA = true;                       // create tracks version propagated to PCA
-  bool mUsePropagator = false;                       // use propagator with 3D B-field, set automatically if material correction is requested
+  bool mUseFullFieldPropagation = false;             // use Propagator with the full 3D field instead of the fast constant-By track transport
   bool mRefitWithMatCorr = false;                    // when doing propagateTracksToVertex, propagate tracks to V0 with material corrections and rerun minimization again
   bool mIsCollinear = false;                         // use collinear fits when there 2 crossing points
   int mMaxIter = 20;                                 // max number of iterations
@@ -323,6 +338,7 @@ class NA6PDCAFitterN
   float mMinRelChi2Change = 0.9;                     // stop iterations is chi2/chi2old > this
   float mMaxChi2 = 100;                              // abs cut on chi2 or abs distance
   float mMaxDist2ToMergeSeeds = 1.;                  // merge 2 seeds to their average if their distance^2 is below the threshold
+  Propagator::PropOpt mPropOpt{nullptr, 2.f, Propagator::MatCorrType::USEMatCorrNONE, false};
 
   ClassDefNV(NA6PDCAFitterN, 1);
 };
@@ -337,7 +353,7 @@ int NA6PDCAFitterN<N, Args...>::process(const Tr&... args)
   assign(0, args...);
   clear();
   for (int i = 0; i < N; i++) {
-    std::array<float, 3> par =mOrigTrPtr[i]->getCircleParams(mBy);
+    std::array<float, 3> par = mOrigTrPtr[i]->getCircleParams(mBy);
     mTrAux[i][NA6PHelixHelper::kR] = par[0];
     mTrAux[i][NA6PHelixHelper::kX] = par[1];
     mTrAux[i][NA6PHelixHelper::kZ] = par[2];
@@ -408,12 +424,12 @@ bool NA6PDCAFitterN<N, Args...>::calcPCACoefs()
     MatStd3D miei;
     miei[0][0] = tcov.sxx;
     miei[0][1] = tcov.sxy;
-    miei[0][2] = 0;
+    miei[0][2] = tcov.sxz;
     miei[1][0] = tcov.sxy;
     miei[1][1] = tcov.syy;
-    miei[1][2] = 0;
-    miei[2][0] = 0;
-    miei[2][1] = 0;
+    miei[1][2] = tcov.syz;
+    miei[2][0] = tcov.sxz;
+    miei[2][1] = tcov.syz;
     miei[2][2] = tcov.szz;
     mTrCFVT[mCurHyp][i] = mWeightInv * miei;
   }
@@ -437,9 +453,9 @@ bool NA6PDCAFitterN<N, Args...>::calcInverseWeight()
     const auto& tcov = mTrcEInv[mCurHyp][i];
     arrmat[XX] += tcov.sxx;
     arrmat[XY] += tcov.sxy;
-    arrmat[XZ] += 0;
+    arrmat[XZ] += tcov.sxz;
     arrmat[YY] += tcov.syy;
-    arrmat[YZ] += 0;
+    arrmat[YZ] += tcov.syz;
     arrmat[ZZ] += tcov.szz;
   }
   // invert 3x3 symmetrix matrix
@@ -545,9 +561,9 @@ void NA6PDCAFitterN<N, Args...>::calcChi2Derivatives()
       const auto& covI = mTrcEInv[mCurHyp][j]; // inverse cov matrix of track j
       const auto& dr1 = mDResidDz[j][i];       // vector of j-th residuals 1st derivative over Z param of track i
       auto& cidr = covIDrDz[i][j];             // vector covI_j * dres_j/dz_i, save for 2nd derivative calculation
-      cidr[0] = covI.sxx * dr1[0] + covI.sxy * dr1[1];
-      cidr[1] = covI.sxy * dr1[0] + covI.syy * dr1[1];
-      cidr[2] = covI.szz * dr1[2];
+      cidr[0] = covI.sxx * dr1[0] + covI.sxy * dr1[1] + covI.sxz * dr1[2];
+      cidr[1] = covI.sxy * dr1[0] + covI.syy * dr1[1] + covI.syz * dr1[2];
+      cidr[2] = covI.sxz * dr1[0] + covI.syz * dr1[1] + covI.szz * dr1[2];
       // calculate res_i * covI_j * dres_j/dx_i
       dchi1 += ROOT::Math::Dot(res, cidr);
     }
@@ -561,11 +577,13 @@ void NA6PDCAFitterN<N, Args...>::calcChi2Derivatives()
         const auto& dr1j = mDResidDz[k][j];  // vector of k-th residuals 1st derivative over Z param of track j
         const auto& cidrkj = covIDrDz[i][k]; // vector covI_k * dres_k/dz_i
         dchi2 += ROOT::Math::Dot(dr1j, cidrkj);
-        if (k == j) {
+        if (i == j) {
           const auto& res = mTrRes[mCurHyp][k];    // vector of residuals of track k
           const auto& covI = mTrcEInv[mCurHyp][k]; // inverse cov matrix of track k
-          const auto& dr2ij = mD2ResidDz2[k][j];   // vector of k-th residuals 2nd derivative over Z params of track j
-          dchi2 += res[0] * (covI.sxx * dr2ij[0] + covI.sxy * dr2ij[1]) + res[1] * (covI.sxy * dr2ij[0] + covI.syy * dr2ij[1]) + res[2] * covI.szz * dr2ij[2];
+          const auto& dr2ij = mD2ResidDz2[k][i];   // vector of k-th residuals 2nd derivative over Z param i
+          dchi2 += res[0] * (covI.sxx * dr2ij[0] + covI.sxy * dr2ij[1] + covI.sxz * dr2ij[2]) +
+                   res[1] * (covI.sxy * dr2ij[0] + covI.syy * dr2ij[1] + covI.syz * dr2ij[2]) +
+                   res[2] * (covI.sxz * dr2ij[0] + covI.syz * dr2ij[1] + covI.szz * dr2ij[2]);
         }
       }
     }
@@ -579,16 +597,23 @@ void NA6PDCAFitterN<N, Args...>::calcChi2DerivativesNoErr()
   for (int i = N; i--;) {
     auto& dchi1 = mDChi2Dz[i]; // DChi2/Dz_i = sum_j { res_j * Dres_j/Dz_i }
     dchi1 = 0;                 // chi2 1st derivative
-    for (int j = N; j--;) {
-      const auto& res = mTrRes[mCurHyp][j]; // vector of residuals of track j
-      const auto& dr1 = mDResidDz[j][i];    // vector of j-th residuals 1st derivative over Z param of track i
+    for (int k = N; k--;) {
+      const auto& res = mTrRes[mCurHyp][k]; // vector of residuals of track k
+      const auto& dr1 = mDResidDz[k][i];    // vector of k-th residuals 1st derivative over Z param of track i
       dchi1 += ROOT::Math::Dot(res, dr1);
-      if (i >= j) { // symmetrix matrix
-        // chi2 2nd derivative
-        auto& dchi2 = mD2Chi2Dz2[i][j]; // D2Chi2/Dz_i/Dz_j = sum_k { Dres_k/Dz_j * covI_k * Dres_k/Dz_i + res_k * covI_k * D2res_k/Dz_i/Dz_j }
-        dchi2 = ROOT::Math::Dot(mTrRes[mCurHyp][i], mD2ResidDz2[i][j]);
-        for (int k = N; k--;) {
-          dchi2 += ROOT::Math::Dot(mDResidDz[k][i], mDResidDz[k][j]);
+    }
+  }
+  for (int i = N; i--;) {
+    for (int j = i + 1; j--;) {
+      auto& dchi2 = mD2Chi2Dz2[i][j];
+      dchi2 = 0.;
+      for (int k = N; k--;) {
+        // Gauss-Newton term, present for diagonal and mixed elements.
+        dchi2 += ROOT::Math::Dot(mDResidDz[k][i], mDResidDz[k][j]);
+        // A trajectory has a second derivative only with respect to its own
+        // Z parameter, hence the curvature term contributes only to H_ii.
+        if (i == j) {
+          dchi2 += ROOT::Math::Dot(mTrRes[mCurHyp][k], mD2ResidDz2[k][i]);
         }
       }
     }
@@ -617,7 +642,7 @@ bool NA6PDCAFitterN<N, Args...>::recalculatePCAWithErrors(int cand)
   mCurHyp = mOrder[cand];
   if (mUseAbsDCA) {
     for (int i = N; i--;) {
-      if (!mTrcEInv[mCurHyp][i].set(mCandTr[mCurHyp][i], ZerrFactor)) { // prepare inverse cov.matrices at starting point
+      if (!mTrcEInv[mCurHyp][i].set(mCandTr[mCurHyp][i])) { // prepare inverse cov.matrices at starting point
         mFitStatus[mCurHyp] = FitStatus::FailInvCov;
         if (mBadCovPolicy == Discard) {
           return false;
@@ -660,25 +685,57 @@ void NA6PDCAFitterN<N, Args...>::calcPCANoErr()
 template <int N, typename... Args>
 ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>> NA6PDCAFitterN<N, Args...>::calcPCACovMatrix(int cand) const
 {
-  // calculate covariance matrix for the point of closest approach
-  MatSym3D covmSum;
-  int ord = mOrder[cand];
+  // Each track measures X and Y at the vertex Z.  With the local slopes
+  // sx = dX/dZ and sy = dY/dZ, its vertex measurement matrix is
+  // H = {{1, 0, -sx}, {0, 1, -sy}}.  The longitudinal information must come
+  // from the track geometry, not from the dummy Z variance in TrackCovI.
+  MatSym3D info;
+  std::fill_n(info.Array(), 6, 0.);
+  const int ord = mOrder[cand];
+  const float zVtx = static_cast<float>(mPCA[ord][2]);
   for (int i = N; i--;) {
-    const auto& tcov = mTrcEInv[ord][i];
-    covmSum(0, 0) += tcov.sxx;
-    covmSum(1, 0) += tcov.sxy;
-    covmSum(1, 1) += tcov.syy;
-    covmSum(2, 2) += tcov.szz;
+    NA6PTrack trc = *mOrigTrPtr[i];
+    if (!propagateToZ(trc, zVtx)) {
+      continue;
+    }
+
+    double cxx = trc.getSigmaX2();
+    double cyy = trc.getSigmaY2();
+    double cxy = trc.getSigmaYX();
+    if (!(cxx > 0.) || !(cyy > 0.)) {
+      continue;
+    }
+    double det = cxx * cyy - cxy * cxy;
+    if (!(det > 0.)) {
+      cxy = std::copysign(0.98 * std::sqrt(cxx * cyy), cxy);
+      det = cxx * cyy - cxy * cxy;
+    }
+    if (!(det > 0.)) {
+      continue;
+    }
+
+    const double detI = 1. / det;
+    const double wxx = cyy * detI;
+    const double wxy = -cxy * detI;
+    const double wyy = cxx * detI;
+    const double sx = trc.getSlopeX();
+    const double sy = trc.getSlopeY();
+    info(0, 0) += wxx;
+    info(1, 0) += wxy;
+    info(1, 1) += wyy;
+    info(2, 0) -= wxx * sx + wxy * sy;
+    info(2, 1) -= wxy * sx + wyy * sy;
+    info(2, 2) += sx * sx * wxx + 2. * sx * sy * wxy + sy * sy * wyy;
   }
-  if (covmSum.Invert()) {
-    return covmSum;
+  if (info.Invert()) {
+    return info;
   }
   // fall back on identity diagonal matrix with 1 cm error
-  covmSum(0, 0) = 1.;
-  covmSum(1, 0) = 0.;
-  covmSum(1, 1) = 1.;
-  covmSum(2, 2) = 1.;
-  return covmSum;
+  std::fill_n(info.Array(), 6, 0.);
+  info(0, 0) = 1.;
+  info(1, 1) = 1.;
+  info(2, 2) = 1.;
+  return info;
 }
 
 //___________________________________________________________________
@@ -696,7 +753,15 @@ void NA6PDCAFitterN<N, Args...>::calcTrackDerivatives()
 {
   // calculate track derivatives over Z param
   for (int i = N; i--;) {
-    mTrDer[mCurHyp][i].set(mCandTr[mCurHyp][i], mBy);
+    const auto& trc = mCandTr[mCurHyp][i];
+    float by = mBy;
+    if (mUseFullFieldPropagation) {
+      const auto* propagator = Propagator::Instance();
+      if (propagator->hasMagFieldSet()) {
+        by = propagator->getBy(trc.getXYZ());
+      }
+    }
+    mTrDer[mCurHyp][i].set(trc, by);
   }
 }
 //___________________________________________________________________
@@ -708,7 +773,8 @@ double NA6PDCAFitterN<N, Args...>::calcChi2() const
   for (int i = N; i--;) {
     const auto& res = mTrRes[mCurHyp][i];
     const auto& covI = mTrcEInv[mCurHyp][i];
-    chi2 += res[0] * res[0] * covI.sxx + res[1] * res[1] * covI.syy + res[2] * res[2] * covI.szz + 2. * res[0] * res[1] * covI.sxy;
+    chi2 += res[0] * res[0] * covI.sxx + res[1] * res[1] * covI.syy + res[2] * res[2] * covI.szz +
+            2. * (res[0] * res[1] * covI.sxy + res[0] * res[2] * covI.sxz + res[1] * res[2] * covI.syz);
   }
   return chi2;
 }
@@ -728,13 +794,17 @@ double NA6PDCAFitterN<N, Args...>::calcChi2NoErr() const
 template <int N, typename... Args>
 bool NA6PDCAFitterN<N, Args...>::correctTracks(const VecND& corrZ)
 {
-  // propagate tracks to updated Z
+  // Propagate the actual candidate tracks to the updated Z. Updating only
+  // mTrPos with a Taylor expansion would leave mCandTr at the seed, so the
+  // derivatives of the next Newton iteration would be evaluated there again.
   for (int i = N; i--;) {
-    const auto& trDer = mTrDer[mCurHyp][i];
-    auto dz2h = 0.5 * corrZ[i] * corrZ[i];
-    mTrPos[mCurHyp][i][0] -= trDer.dxdz * corrZ[i] - dz2h * trDer.d2xdz2;
-    mTrPos[mCurHyp][i][1] -= trDer.dydz * corrZ[i] - dz2h * trDer.d2ydz2;
-    mTrPos[mCurHyp][i][2] -= corrZ[i];
+    auto& trc = mCandTr[mCurHyp][i];
+    const float z = static_cast<float>(mTrPos[mCurHyp][i][2] - corrZ[i]);
+    const bool propagated = mUseAbsDCA ? propagateParamToZ(trc, z) : propagateToZ(trc, z);
+    if (!propagated) {
+      return false;
+    }
+    setTrackPos(mTrPos[mCurHyp][i], trc);
   }
   return true;
 }
@@ -762,8 +832,8 @@ bool NA6PDCAFitterN<N, Args...>::propagateTracksToVertex(int icand)
   }
 
   for (int i = N; i--;) {
-    if (mUseAbsDCA || mUsePropagator /*|| mMatCorr != o2::base::Propagator::MatCorrType::USEMatCorrNONE*/) { // TODO: update after merging the recNative branch
-      mCandTr[ord][i] = *mOrigTrPtr[i];                                                                      // fetch the track again, as mCandTr might have been propagated w/o errors or material corrections might be wrong
+    if (mUseAbsDCA || mUseFullFieldPropagation) {
+      mCandTr[ord][i] = *mOrigTrPtr[i]; // fetch the track again, as mCandTr might have been propagated w/o errors or material corrections might be wrong
     }
     auto z = mPCA[ord][2]; // z of PCA
     if (!propagateToZ(mCandTr[ord][i], z)) {
@@ -802,8 +872,8 @@ bool NA6PDCAFitterN<N, Args...>::minimizeChi2()
     if (!propagateToZ(mCandTr[mCurHyp][i], z)) {
       return false;
     }
-    setTrackPos(mTrPos[mCurHyp][i], mCandTr[mCurHyp][i]);             // prepare positions
-    if (!mTrcEInv[mCurHyp][i].set(mCandTr[mCurHyp][i], ZerrFactor)) { // prepare inverse cov.matrices at starting point
+    setTrackPos(mTrPos[mCurHyp][i], mCandTr[mCurHyp][i]); // prepare positions
+    if (!mTrcEInv[mCurHyp][i].set(mCandTr[mCurHyp][i])) { // prepare inverse cov.matrices at starting point
       mFitStatus[mCurHyp] = FitStatus::FailInvCov;
       if (mBadCovPolicy == Discard) {
         return false;
@@ -968,17 +1038,26 @@ NA6PTrack NA6PDCAFitterN<N, Args...>::createParentTrackParCov(int cand) const
   for (int it = 0; it < N; it++) {
     const auto& trc = getTrack(it, cand);
     auto pvecT = trc.getPXYZ();
-    std::array<float, 21> covT = {0.};
-    covT[0] = trc.getSigmaX2(); // TODO: update with new parameterization!
-    covT[1] = trc.getSigmaXY();
-    covT[2] = trc.getSigmaY2();
-    covT[9] = trc.getSigmaPX2();
-    covT[14] = trc.getSigmaPY2();
-    covT[20] = trc.getSigmaPZ2();
-    constexpr int MomInd[6] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
-    for (int i = 0; i < 6; i++) {
-      covV[MomInd[i]] += covT[MomInd[i]];
-    }
+    const double pxz = trc.getPxz();
+    const double tx = trc.getTx();
+    const double q2pxz = trc.getQ2Pxz();
+    const double cosPsi = trc.getCosPsi();
+    const double dPxdQ = -pvecT[0] / q2pxz;
+    const double dPydQ = -pvecT[1] / q2pxz;
+    const double dPzdTx = -pxz * tx / cosPsi;
+    const double dPzdQ = -pvecT[2] / q2pxz;
+    const double cTxTx = trc.getSigmaTx2();
+    const double cTyTx = trc.getSigmaTyTx();
+    const double cTyTy = trc.getSigmaTy2();
+    const double cQTx = trc.getSigmaQ2PxzTx();
+    const double cQTy = trc.getSigmaQ2PzTy();
+    const double cQQ = trc.getSigmaQ2Pxz2();
+    covV[9] += pxz * pxz * cTxTx + 2. * pxz * dPxdQ * cQTx + dPxdQ * dPxdQ * cQQ;
+    covV[13] += pxz * pxz * cTyTx + pxz * dPydQ * cQTx + dPxdQ * pxz * cQTy + dPxdQ * dPydQ * cQQ;
+    covV[14] += pxz * pxz * cTyTy + 2. * pxz * dPydQ * cQTy + dPydQ * dPydQ * cQQ;
+    covV[18] += dPzdTx * (pxz * cTxTx + dPxdQ * cQTx) + dPzdQ * (pxz * cQTx + dPxdQ * cQQ);
+    covV[19] += dPzdTx * (pxz * cTyTx + dPydQ * cQTx) + dPzdQ * (pxz * cQTy + dPydQ * cQQ);
+    covV[20] += dPzdTx * dPzdTx * cTxTx + 2. * dPzdTx * dPzdQ * cQTx + dPzdQ * dPzdQ * cQQ;
     for (int i = 0; i < 3; i++) {
       pvecV[i] += pvecT[i];
     }
@@ -991,8 +1070,45 @@ NA6PTrack NA6PDCAFitterN<N, Args...>::createParentTrackParCov(int cand) const
   covV[3] = covVtxV(2, 0);
   covV[4] = covVtxV(2, 1);
   covV[5] = covVtxV(2, 2);
-  NA6PTrack tr; // TODO: update adding covariance matrix
+  const double px = pvecV[0], py = pvecV[1], pz = pvecV[2];
+  const double pxz2 = px * px + pz * pz;
+  const double invPxz = 1. / std::sqrt(pxz2);
+  const double tx = px * invPxz;
+  const double ty = py * invPxz;
+  const double cs = pz * invPxz;
+  const double q2pxz = q * invPxz;
+  const double jac[3][3] = {
+    {cs * cs * invPxz, 0., -tx * cs * invPxz},
+    {-ty * tx * invPxz, invPxz, -ty * cs * invPxz},
+    {-q2pxz * tx * invPxz, 0., -q2pxz * cs * invPxz}};
+  const double covP[3][3] = {
+    {covV[9], covV[13], covV[18]},
+    {covV[13], covV[14], covV[19]},
+    {covV[18], covV[19], covV[20]}};
+  double jacCovP[3][3]{};
+  for (int i = 0; i < 3; ++i) {
+    for (int k = 0; k < 3; ++k) {
+      for (int j = 0; j < 3; ++j) {
+        jacCovP[i][k] += jac[i][j] * covP[j][k];
+      }
+    }
+  }
+  NA6PTrackParCov::CovArray cov{};
+  cov[NA6PTrackParCov::kXX] = covV[0];
+  cov[NA6PTrackParCov::kYX] = covV[1];
+  cov[NA6PTrackParCov::kYY] = covV[2];
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j <= i; ++j) {
+      double cij = 0.;
+      for (int k = 0; k < 3; ++k) {
+        cij += jacCovP[i][k] * jac[j][k];
+      }
+      cov[NA6PTrackParCov::CovarMap[i + 2][j + 2]] = cij;
+    }
+  }
+  NA6PTrack tr;
   tr.init(getPCACandidatePos(cand), pvecV, q);
+  tr.setCov(cov);
   return tr;
 }
 //___________________________________________________________________
@@ -1019,12 +1135,20 @@ NA6PTrack NA6PDCAFitterN<N, Args...>::createParentTrackPar(int cand) const
 template <int N, typename... Args>
 inline bool NA6PDCAFitterN<N, Args...>::propagateParamToZ(NA6PTrack& t, float z) const
 {
+  if (mUseFullFieldPropagation) {
+    auto* propagator = Propagator::Instance();
+    return propagator->propagateToZ(static_cast<NA6PTrackPar&>(t), z, mPropOpt);
+  }
   return t.propagateParamToZ(z, mBy);
 }
 //___________________________________________________________________
 template <int N, typename... Args>
 inline bool NA6PDCAFitterN<N, Args...>::propagateToZ(NA6PTrack& t, float z) const
 {
+  if (mUseFullFieldPropagation) {
+    auto* propagator = Propagator::Instance();
+    return propagator->propagateToZ(t, z, mPropOpt);
+  }
   return t.propagateToZ(z, mBy);
 }
 

--- a/rec/include/NA6PDCAFitterN.h
+++ b/rec/include/NA6PDCAFitterN.h
@@ -752,16 +752,9 @@ template <int N, typename... Args>
 void NA6PDCAFitterN<N, Args...>::calcTrackDerivatives()
 {
   // calculate track derivatives over Z param
+  float by = mUseFullFieldPropagation ? Propagator::Instance()->getBy(mCandTr[mCurHyp][0].getXYZ()) : mBy;
   for (int i = N; i--;) {
-    const auto& trc = mCandTr[mCurHyp][i];
-    float by = mBy;
-    if (mUseFullFieldPropagation) {
-      const auto* propagator = Propagator::Instance();
-      if (propagator->hasMagFieldSet()) {
-        by = propagator->getBy(trc.getXYZ());
-      }
-    }
-    mTrDer[mCurHyp][i].set(trc, by);
+    mTrDer[mCurHyp][i].set(mCandTr[mCurHyp][i], by);
   }
 }
 //___________________________________________________________________
@@ -1040,12 +1033,12 @@ NA6PTrack NA6PDCAFitterN<N, Args...>::createParentTrackParCov(int cand) const
     auto pvecT = trc.getPXYZ();
     const double pxz = trc.getPxz();
     const double tx = trc.getTx();
-    const double q2pxz = trc.getQ2Pxz();
+    const double q2pxzI = 1. / trc.getQ2Pxz();
     const double cosPsi = trc.getCosPsi();
-    const double dPxdQ = -pvecT[0] / q2pxz;
-    const double dPydQ = -pvecT[1] / q2pxz;
+    const double dPxdQ = -pvecT[0] * q2pxzI;
+    const double dPydQ = -pvecT[1] * q2pxzI;
     const double dPzdTx = -pxz * tx / cosPsi;
-    const double dPzdQ = -pvecT[2] / q2pxz;
+    const double dPzdQ = -pvecT[2] * q2pxzI;
     const double cTxTx = trc.getSigmaTx2();
     const double cTyTx = trc.getSigmaTyTx();
     const double cTyTy = trc.getSigmaTy2();

--- a/test/CheckDecayVertices.C
+++ b/test/CheckDecayVertices.C
@@ -5,12 +5,16 @@
 #include <TH2F.h>
 #include <TF1.h>
 #include <TCanvas.h>
+#include <TDatabasePDG.h>
+#include <TLegend.h>
+#include <TLine.h>
 #include <TLatex.h>
 #include <TPaveStats.h>
 #include <TParticle.h>
 #include "NA6PTrack.h"
 #include "NA6PMCEventHeader.h"
 #include "NA6PDCAFitterN.h"
+#include "Propagator.h"
 #include "MagneticField.h"
 #include "ConfigurableParam.h"
 #endif
@@ -74,7 +78,7 @@ void printDecay(TParticle& mothPart,
   }
 }
 
-bool CheckCharmDecay(TParticle& mothPart,
+bool CheckDecay(TParticle& mothPart,
                      std::vector<TParticle>* mcArr,
                      int pdgProngs[5],
                      int idDau[5],
@@ -167,20 +171,24 @@ bool CheckCharmDecay(TParticle& mothPart,
   return true;
 }
 
-void CheckDecayVertices(const char* part = "D0",
-                        const char* dirSimu = ".")
+void CheckDecayVertices(const char* part = "Lambda0",
+                           const char* dirSimu = ".",
+                           bool useFullFieldPropagator = true)
 {
   na6p::conf::ConfigurableParam::updateFromFile(Form("%s/na6pLayout.ini",dirSimu), "", true);
-  if (TGeoGlobalMagField::Instance()->GetField() == nullptr) {
-    auto magField = new MagneticField();
-    magField->loadField();
-    magField->setAsGlobalField();
+  if (!Propagator::loadGeometry(Form("%s/geometry.root", dirSimu)) || !Propagator::loadField()) {
+    return;
   }
+  auto* propagator = Propagator::Instance();
 
   int pdgPart = 421;
   int nProngs = 2;
   int pdgProngs[5] = {0, 0, 0, 0, 0};
   float maxDL = 5000.;
+  float invMassMin = 1.7;
+  float invMassMax = 2.5;
+  bool isLongLivedV0 = false;
+  bool validPart = true;
   std::string decay;
   if (strcmp(part, "D0") == 0) {
     pdgPart = 421;
@@ -244,7 +252,61 @@ void CheckDecayVertices(const char* part = "D0",
     pdgProngs[2] = 321;
     maxDL = 1000.;
     decay = "#bar{#Lambda}_{c}^{-} #rightarrow #bar{p} K^{+} #pi^{-}";
+  } else if (strcmp(part, "phi") == 0 || strcmp(part, "Phi") == 0) {
+    pdgPart = 333;
+    nProngs = 2;
+    pdgProngs[0] = 321;
+    pdgProngs[1] = -321;
+    maxDL = 1000.;
+    invMassMin = 0.98;
+    invMassMax = 1.06;
+    decay = "#phi #rightarrow K^{+} K^{-}";
+  } else if (strcmp(part, "K0s") == 0 || strcmp(part, "Kshort") == 0 || strcmp(part, "Ks") == 0) {
+    pdgPart = 310;
+    nProngs = 2;
+    pdgProngs[0] = 211;
+    pdgProngs[1] = -211;
+    maxDL = 200000.;
+    invMassMin = 0.44;
+    invMassMax = 0.56;
+    isLongLivedV0 = true;
+    decay = "K_{S}^{0} #rightarrow #pi^{+} #pi^{-}";
+  } else if (strcmp(part, "Lambda0") == 0 || strcmp(part, "Lambda") == 0) {
+    pdgPart = 3122;
+    nProngs = 2;
+    pdgProngs[0] = 2212;
+    pdgProngs[1] = -211;
+    maxDL = 500000.;
+    invMassMin = 1.08;
+    invMassMax = 1.16;
+    isLongLivedV0 = true;
+    decay = "#Lambda^{0} #rightarrow p #pi^{-}";
+  } else if (strcmp(part, "antiLambda0") == 0 || strcmp(part, "antiLambda") == 0) {
+    pdgPart = -3122;
+    nProngs = 2;
+    pdgProngs[0] = -2212;
+    pdgProngs[1] = 211;
+    maxDL = 500000.;
+    invMassMin = 1.08;
+    invMassMax = 1.16;
+    isLongLivedV0 = true;
+    decay = "#bar{#Lambda}^{0} #rightarrow #bar{p} #pi^{+}";
+  } else if (strcmp(part, "XiMinus") == 0 || strcmp(part, "XiPlus") == 0 ||
+             strcmp(part, "OmegaMinus") == 0 || strcmp(part, "OmegaPlus") == 0) {
+    printf("%s has a cascade decay with a neutral Lambda daughter and cannot be checked with the charged-prong DCA fitter used by this macro.\n", part);
+    return;
+  } else {
+    validPart = false;
   }
+
+  if (!validPart) {
+    printf("Unknown particle '%s'. Supported strange particles: phi, K0s, Lambda0, antiLambda0.\n", part);
+    return;
+  }
+  const double pdgMass = TDatabasePDG::Instance()->GetParticle(pdgPart)->Mass();
+  constexpr float massWindowHalfWidth = 0.1f;
+  invMassMin = pdgMass - massWindowHalfWidth;
+  invMassMax = pdgMass + massWindowHalfWidth;
 
   TFile* ft = new TFile(Form("%s/TracksVerTel.root", dirSimu));
   if (!ft)
@@ -260,30 +322,48 @@ void CheckDecayVertices(const char* part = "D0",
   mcTree->SetBranchAddress("header", &mcHead);
 
   NA6PDCAFitterN<2> df2;
-  df2.setPropagateToPCA(true);
-  df2.setUseAbsDCA(true);
+  df2.setPropagateToPCA(false);
+  df2.setUseAbsDCA(false);
+  df2.setUseFullFieldPropagation(useFullFieldPropagator);
+  df2.setRefitWithMatCorr(true);
+  if (isLongLivedV0) {
+    df2.setMaxDZIni(500.);
+    df2.setMaxVertZ(200.);
+    df2.setMinVertZ(-500.);
+  }
   NA6PDCAFitterN<3> df3;
   df3.setPropagateToPCA(true);
   df3.setUseAbsDCA(true);
+  df3.setUseFullFieldPropagation(useFullFieldPropagator);
+
+  float maxDecLen = isLongLivedV0 ? 20. : 1.;
 
   TH1F* hGenVsRap = new TH1F("hGenVsRap", ";y;entries", 20, 1., 5.);
   TH1F* hGenVsPt = new TH1F("hGenVsPt", ";p_{T} (GeV/c);entries", 20, 0., 5.);
   TH1F* hRecoVsRap = new TH1F("hRecoVsRap", ";y;entries", 20, 1., 5.);
   TH1F* hRecoVsPt = new TH1F("hRecoVsPt", ";p_{T} (GeV/c);entries", 20, 0., 5.);
-  TH1F* hDecLen = new TH1F("hDecLen", "; decay length L_{xyz} (#mum); entries", 100, 0., 5 * maxDL);
-  TH1F* hPseudoPropDecLen = new TH1F("hPseudoPropDecLen", "; L_{xyz} M / p (#mum); entries", 100, 0., maxDL);
-  TH1F* hInvMass = new TH1F("hInvMass", ";M (GeV/c^{2});entries", 200, 1.7, 2.5);
-  TH2F* hInvMassVsRap = new TH2F("hInvMassVsRap", ";y;M (GeV/c^{2});entries", 20, 1., 5., 200, 1.7, 2.5);
-  TH1F* hSecVx = new TH1F("hSecVx", ";x_{sec vert} (cm);entries", 100, -1., 1.);
-  TH1F* hSecVy = new TH1F("hSecVy", ";y_{sec vert} (cm);entries", 100, -1., 1.);
-  TH1F* hSecVz = new TH1F("hSecVz", ";z_{sec vert} (cm);entries", 100, -5., 5.);
+  TH1F* hDecLen = new TH1F("hDecLen", "; decay length L_{xyz} (#mum); entries", 100, 0., 10000*maxDecLen);
+  TH1F* hPseudoPropDecLen = new TH1F("hPseudoPropDecLen", "; L_{xyz} M / p (#mum); entries", 100, 0., 10000*maxDecLen);
+  TH1F* hInvMass = new TH1F("hInvMass", ";M (GeV/c^{2});entries", 200, invMassMin, invMassMax);
+  TH2F* hInvMassVsRap = new TH2F("hInvMassVsRap", ";y;M (GeV/c^{2});entries", 20, 1., 5., 200, invMassMin, invMassMax);
+  TH2F* hInvMassVsDecLen = new TH2F("hInvMassVsDecLen", ";L_{xyz} (cm);M (GeV/c^{2});entries", 100, 0., maxDecLen, 200, invMassMin, invMassMax);
+  const float secVxyMax = isLongLivedV0 ? 4. : 1.;
+  const float secVzMax = isLongLivedV0 ? 10. : 5.;
+  TH1F* hSecVx = new TH1F("hSecVx", ";x_{sec vert} (cm);entries", 100, -secVxyMax, secVxyMax);
+  TH1F* hSecVy = new TH1F("hSecVy", ";y_{sec vert} (cm);entries", 100, -secVxyMax, secVxyMax);
+  TH1F* hSecVz = new TH1F("hSecVz", ";z_{sec vert} (cm);entries", 100, -8, secVzMax);
   TH1F* hDeltaVx = new TH1F("hDeltaVx", ";x_{rec} - x_{true} (#mum);entries", 100, -500., 500.);
   TH1F* hDeltaVy = new TH1F("hDeltaVy", ";y_{rec} - y_{true} (#mum);entries", 100, -500., 500.);
-  TH1F* hDeltaVz = new TH1F("hDeltaVz", ";z_{rec} - z_{true} (#mum);entries", 100, -500., 500.);
+  TH1F* hDeltaVz = new TH1F("hDeltaVz", ";z_{rec} - z_{true} (#mum);entries", 100, -5000., 5000.);
   TH2F* hDeltaVxVsRap = new TH2F("hDeltaVxVsRap", ";y;x_{rec} - x_{true} (#mum);entries", 20, 1., 5., 100, -500., 500.);
   TH2F* hDeltaVyVsRap = new TH2F("hDeltaVyVsRap", ";y;y_{rec} - y_{true} (#mum);entries", 20, 1., 5., 100, -500., 500.);
-  TH2F* hDeltaVzVsRap = new TH2F("hDeltaVzVsRap", ";y;z_{rec} - z_{true} (#mum);entries", 20, 1., 5., 100, -500., 500.);
-
+  TH2F* hDeltaVzVsRap = new TH2F("hDeltaVzVsRap", ";y;z_{rec} - z_{true} (#mum);entries", 20, 1., 5., 100, -5000., 5000.);
+  TH1F* hPullVx = new TH1F("hPullVx", ";(x_{rec} - x_{true})/#sigma_{x};entries", 120, -5, 5.);
+  TH1F* hPullVy = new TH1F("hPullVy", ";(y_{rec} - y_{true})/#sigma_{y};entries", 120, -5, 5.);
+  TH1F* hPullVz = new TH1F("hPullVz", ";(z_{rec} - z_{true})/#sigma_{z};entries", 120, -5, 5.);
+  TH2F* hPullVxVsDecLen = new TH2F("hPullVxVsDecLen", ";L_{xyz} (cm);x pull;entries", 20, 0., maxDecLen, 120, -5., 5.);
+  TH2F* hPullVyVsDecLen = new TH2F("hPullVyVsDecLen", ";L_{xyz} (cm);y pull;entries", 20, 0., maxDecLen, 120, -5., 5.);
+  TH2F* hPullVzVsDecLen = new TH2F("hPullVzVsDecLen", ";L_{xyz} (cm);z pull;entries", 20, 0., maxDecLen, 120, -5., 5.);
   int nGenerated = 0, nGoodNdau = 0, nGoodDecay = 0, nReconstructed = 0;
 
   int nEv = trTree->GetEntries();
@@ -320,7 +400,7 @@ void CheckDecayVertices(const char* part = "D0",
       }
       int idDau[5] = {-1, -1, -1, -1, -1};
       float decvert[3] = {0., 0., -9999.};
-      bool decOk = CheckCharmDecay(curPart, mcArr, pdgProngs, idDau, decvert);
+      bool decOk = CheckDecay(curPart, mcArr, pdgProngs, idDau, decvert);
       if (!decOk) {
         // printf(" Decay not ok\n");
         // printDecay(curPart, mcArr);
@@ -348,10 +428,10 @@ void CheckDecayVertices(const char* part = "D0",
           for (int j = 0 ; j < 5; j++) {
             if (clumap & (1 << j)) ++nVTClusters;
           }
-          if (nVTClusters < 5)
-            continue;
           int mcLabel = tr.getParticleID();
           if (mcLabel == idDau[kd]) {
+            if (nVTClusters < 5)
+              continue;
             prongs.push_back(tr);
             ++nRecoDau;
           }
@@ -370,27 +450,73 @@ void CheckDecayVertices(const char* part = "D0",
       }
       if (n == 0)
         continue;
+      const bool fitConverged = nProngs == 2 ?
+                                  df2.getFitStatus() == NA6PDCAFitterN<2>::FitStatus::Converged :
+                                  df3.getFitStatus() == NA6PDCAFitterN<3>::FitStatus::Converged;
       const auto& secondaryVertex = (nProngs == 2) ? df2.getPCACandidate() : df3.getPCACandidate();
       float dvx = (secondaryVertex[0] - decvert[0]) * 1e4;
       float dvy = (secondaryVertex[1] - decvert[1]) * 1e4;
       float dvz = (secondaryVertex[2] - decvert[2]) * 1e4;
+      const auto vertexCov = nProngs == 2 ? df2.calcPCACovMatrix() : df3.calcPCACovMatrix();
+      const double varVx = vertexCov(0, 0);
+      const double varVy = vertexCov(1, 1);
+      const double varVz = vertexCov(2, 2);
+      if (fitConverged && varVx > 0.) {
+        const double pullVx = (secondaryVertex[0] - decvert[0]) / std::sqrt(varVx);
+        hPullVx->Fill(pullVx);
+        hPullVxVsDecLen->Fill(decLen, pullVx);
+      }
+      if (fitConverged && varVy > 0.) {
+        const double pullVy = (secondaryVertex[1] - decvert[1]) / std::sqrt(varVy);
+        hPullVy->Fill(pullVy);
+        hPullVyVsDecLen->Fill(decLen, pullVy);
+      }
+      if (fitConverged && varVz > 0.) {
+        const double pullVz = (secondaryVertex[2] - decvert[2]) / std::sqrt(varVz);
+        hPullVz->Fill(pullVz);
+        hPullVzVsDecLen->Fill(decLen, pullVz);
+      }
+      if (fitConverged) {
+        const std::array<double, 3> nominalVertex = {secondaryVertex[0], secondaryVertex[1], secondaryVertex[2]};
+        if (nProngs == 2) {
+          const std::array<NA6PTrack, 2> numericalTracks = {prongs[0], prongs[1]};
+        } else if (nProngs == 3) {
+          const std::array<NA6PTrack, 3> numericalTracks = {prongs[0], prongs[1], prongs[2]};
+        }
+      }
 
       float sumPx = 0., sumPy = 0., sumPz = 0., sumE = 0.;
+      bool massPropagationOK = true;
+      Propagator::PropOpt massPropOpt;
+      massPropOpt.matCorr = Propagator::MatCorrType::USEMatCorrTGeo;
       for (int kd = 0; kd < nProngs; ++kd) {
-        sumPx += prongs[kd].getPx();
-        sumPy += prongs[kd].getPy();
-        sumPz += prongs[kd].getPz();
-        float mom = prongs[kd].getP();
+        // The daughter four-momenta must be evaluated at a common point. Use
+        // the full field map and restore the momentum lost in material while
+        // propagating each reconstructed track back to the decay-vertex Z.
+        NA6PTrackPar prongAtVertex = prongs[kd];
+        prongAtVertex.setPID(PID::PDG2PID(pdgProngs[kd]));
+        
+        if (!propagator->propagateToZ(prongAtVertex, secondaryVertex[2], massPropOpt)) {
+          massPropagationOK = false;
+          break;
+        }
+        sumPx += prongAtVertex.getPx();
+        sumPy += prongAtVertex.getPy();
+        sumPz += prongAtVertex.getPz();
+        float mom = prongAtVertex.getP();
         auto mcPart = mcArr->at(prongs[kd].getParticleID());
         float mass = mcPart.GetMass();
         float energy = std::sqrt(mass * mass + mom * mom);
         sumE += energy;
       }
+      if (!massPropagationOK)
+        continue;
       float mom2 = sumPx * sumPx + sumPy * sumPy + sumPz * sumPz;
-      float invMass = std::sqrt(sumE * sumE - mom2);
+      float invMass = std::sqrt(std::max(0.f, sumE * sumE - mom2));
 
       hInvMass->Fill(invMass);
       hInvMassVsRap->Fill(geny, invMass);
+      hInvMassVsDecLen->Fill(decLen, invMass);
       hSecVx->Fill(secondaryVertex[0]);
       hSecVy->Fill(secondaryVertex[1]);
       hSecVz->Fill(secondaryVertex[2]);
@@ -421,6 +547,11 @@ void CheckDecayVertices(const char* part = "D0",
   TH1F* hInvMassSig = new TH1F("hInvMassSig", ";y;#sigma(M) (GeV/c^{2})", hInvMassVsRap->GetNbinsX(), hInvMassVsRap->GetXaxis()->GetXmin(), hInvMassVsRap->GetXaxis()->GetXmax());
   FillMeanAndRms(hInvMassVsRap, hInvMassMean, hInvMassRms, hInvMassSig);
 
+  TH1F* hInvMassMeanVsDecLen = new TH1F("hInvMassMeanVsDecLen", ";L_{xyz} (cm);<M> (GeV/c^{2})", hInvMassVsDecLen->GetNbinsX(), hInvMassVsDecLen->GetXaxis()->GetXmin(), hInvMassVsDecLen->GetXaxis()->GetXmax());
+  TH1F* hInvMassRmsVsDecLen = new TH1F("hInvMassRmsVsDecLen", ";L_{xyz} (cm);rms (M) (GeV/c^{2})", hInvMassVsDecLen->GetNbinsX(), hInvMassVsDecLen->GetXaxis()->GetXmin(), hInvMassVsDecLen->GetXaxis()->GetXmax());
+  TH1F* hInvMassSigVsDecLen = new TH1F("hInvMassSigVsDecLen", ";L_{xyz} (cm);#sigma(M) (GeV/c^{2})", hInvMassVsDecLen->GetNbinsX(), hInvMassVsDecLen->GetXaxis()->GetXmin(), hInvMassVsDecLen->GetXaxis()->GetXmax());
+  FillMeanAndRms(hInvMassVsDecLen, hInvMassMeanVsDecLen, hInvMassRmsVsDecLen, hInvMassSigVsDecLen);
+
   TH1F* hDeltaVxMean = new TH1F("hDeltaVxMean", ";y;<x_{reco} - x_{gen}> (#mum)", hDeltaVxVsRap->GetNbinsX(), hDeltaVxVsRap->GetXaxis()->GetXmin(), hDeltaVxVsRap->GetXaxis()->GetXmax());
   TH1F* hDeltaVxRms = new TH1F("hDeltaVxRms", ";y;rms (x_{reco} - x_{gen}) (#mum)", hDeltaVxVsRap->GetNbinsX(), hDeltaVxVsRap->GetXaxis()->GetXmin(), hDeltaVxVsRap->GetXaxis()->GetXmax());
   TH1F* hDeltaVxSig = new TH1F("hDeltaVxSig", ";y;#sigma(x_{reco} - x_{gen}) (#mum)", hDeltaVxVsRap->GetNbinsX(), hDeltaVxVsRap->GetXaxis()->GetXmin(), hDeltaVxVsRap->GetXaxis()->GetXmax());
@@ -434,7 +565,20 @@ void CheckDecayVertices(const char* part = "D0",
   FillMeanAndRms(hDeltaVyVsRap, hDeltaVyMean, hDeltaVyRms, hDeltaVySig);
   FillMeanAndRms(hDeltaVzVsRap, hDeltaVzMean, hDeltaVzRms, hDeltaVzSig);
 
-  TLatex* tdec = new TLatex(0.45, 0.83, decay.data());
+  TH1F* hPullVxMeanVsDecLen = new TH1F("hPullVxMeanVsDecLen", ";L_{xyz} (cm);mean x pull", 20, 0., maxDecLen);
+  TH1F* hPullVxRmsVsDecLen = new TH1F("hPullVxRmsVsDecLen", ";L_{xyz} (cm);RMS x pull", 20, 0., maxDecLen);
+  TH1F* hPullVxSigVsDecLen = new TH1F("hPullVxSigVsDecLen", ";L_{xyz} (cm);#sigma x pull", 20, 0., maxDecLen);
+  TH1F* hPullVyMeanVsDecLen = new TH1F("hPullVyMeanVsDecLen", ";L_{xyz} (cm);mean y pull", 20, 0., maxDecLen);
+  TH1F* hPullVyRmsVsDecLen = new TH1F("hPullVyRmsVsDecLen", ";L_{xyz} (cm);RMS y pull", 20, 0., maxDecLen);
+  TH1F* hPullVySigVsDecLen = new TH1F("hPullVySigVsDecLen", ";L_{xyz} (cm);#sigma y pull", 20, 0., maxDecLen);
+  TH1F* hPullVzMeanVsDecLen = new TH1F("hPullVzMeanVsDecLen", ";L_{xyz} (cm);mean z pull", 20, 0., maxDecLen);
+  TH1F* hPullVzRmsVsDecLen = new TH1F("hPullVzRmsVsDecLen", ";L_{xyz} (cm);RMS z pull", 20, 0., maxDecLen);
+  TH1F* hPullVzSigVsDecLen = new TH1F("hPullVzSigVsDecLen", ";L_{xyz} (cm);#sigma z pull", 20, 0., maxDecLen);
+  FillMeanAndRms(hPullVxVsDecLen, hPullVxMeanVsDecLen, hPullVxRmsVsDecLen, hPullVxSigVsDecLen);
+  FillMeanAndRms(hPullVyVsDecLen, hPullVyMeanVsDecLen, hPullVyRmsVsDecLen, hPullVySigVsDecLen);
+  FillMeanAndRms(hPullVzVsDecLen, hPullVzMeanVsDecLen, hPullVzRmsVsDecLen, hPullVzSigVsDecLen);
+
+  TLatex* tdec = new TLatex(0.45, 0.76, decay.data());
   tdec->SetNDC();
 
   TCanvas* cdl = new TCanvas("cdl", "Decay Length (gen)", 1400, 600);
@@ -546,6 +690,18 @@ void CheckDecayVertices(const char* part = "D0",
   hInvMassMean->SetMaximum(hInvMass->GetMean() + 5. * hInvMass->GetRMS());
   hInvMassMean->GetYaxis()->SetTitleOffset(1.7);
   hInvMassMean->Draw();
+  auto* pdgMassVsRap = new TLine(hInvMassMean->GetXaxis()->GetXmin(), pdgMass,
+                                 hInvMassMean->GetXaxis()->GetXmax(), pdgMass);
+  pdgMassVsRap->SetLineColor(kRed + 1);
+  pdgMassVsRap->SetLineStyle(2);
+  pdgMassVsRap->SetLineWidth(2);
+  pdgMassVsRap->Draw("same");
+  auto* pdgMassLabelVsRap = new TLatex(hInvMassMean->GetXaxis()->GetXmin() + 0.05 * (hInvMassMean->GetXaxis()->GetXmax() - hInvMassMean->GetXaxis()->GetXmin()),
+                                       pdgMass - 0.8 * hInvMass->GetRMS(), Form("PDG value = %.6f GeV/c^{2}", pdgMass));
+  pdgMassLabelVsRap->SetTextColor(kRed + 1);
+  pdgMassLabelVsRap->SetTextSize(0.035);
+  pdgMassLabelVsRap->SetTextAlign(13);
+  pdgMassLabelVsRap->Draw("same");
   tdec->Draw();
   cm->cd(3);
   gPad->SetLeftMargin(0.13);
@@ -561,6 +717,55 @@ void CheckDecayVertices(const char* part = "D0",
   hInvMassSig->SetMaximum(0.04);
   hInvMassSig->Draw();
   cm->SaveAs(Form("%s-InvMass.png", part));
+
+  TCanvas* cmDL = new TCanvas("cmDL", "Invariant Mass vs Decay Length", 1400, 500);
+  cmDL->Divide(3, 1);
+  cmDL->cd(1);
+  gPad->SetLeftMargin(0.13);
+  gPad->SetRightMargin(0.14);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hInvMassVsDecLen->Draw("colz");
+  cmDL->cd(2);
+  gPad->SetLeftMargin(0.13);
+  gPad->SetRightMargin(0.07);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hInvMassMeanVsDecLen->SetStats(0);
+  hInvMassMeanVsDecLen->SetMarkerStyle(20);
+  hInvMassMeanVsDecLen->SetMarkerColor(1);
+  hInvMassMeanVsDecLen->SetLineColor(1);
+  hInvMassMeanVsDecLen->SetMinimum(hInvMass->GetMean() - 5. * hInvMass->GetRMS());
+  hInvMassMeanVsDecLen->SetMaximum(hInvMass->GetMean() + 5. * hInvMass->GetRMS());
+  hInvMassMeanVsDecLen->GetYaxis()->SetTitleOffset(1.7);
+  hInvMassMeanVsDecLen->Draw();
+  auto* pdgMassVsDecLen = new TLine(hInvMassMeanVsDecLen->GetXaxis()->GetXmin(), pdgMass,
+                                    hInvMassMeanVsDecLen->GetXaxis()->GetXmax(), pdgMass);
+  pdgMassVsDecLen->SetLineColor(kRed + 1);
+  pdgMassVsDecLen->SetLineStyle(2);
+  pdgMassVsDecLen->SetLineWidth(2);
+  pdgMassVsDecLen->Draw("same");
+  auto* pdgMassLabelVsDecLen = new TLatex(hInvMassMeanVsDecLen->GetXaxis()->GetXmin() + 0.05 * (hInvMassMeanVsDecLen->GetXaxis()->GetXmax() - hInvMassMeanVsDecLen->GetXaxis()->GetXmin()),
+                                          pdgMass - 0.8 * hInvMass->GetRMS(), Form("PDG value = %.6f GeV/c^{2}", pdgMass));
+  pdgMassLabelVsDecLen->SetTextColor(kRed + 1);
+  pdgMassLabelVsDecLen->SetTextSize(0.035);
+  pdgMassLabelVsDecLen->SetTextAlign(13);
+  pdgMassLabelVsDecLen->Draw("same");
+  tdec->Draw();
+  cmDL->cd(3);
+  gPad->SetLeftMargin(0.13);
+  gPad->SetRightMargin(0.07);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  hInvMassSigVsDecLen->SetStats(0);
+  hInvMassSigVsDecLen->SetMarkerStyle(20);
+  hInvMassSigVsDecLen->SetMarkerColor(1);
+  hInvMassSigVsDecLen->SetLineColor(1);
+  hInvMassSigVsDecLen->SetMinimum(0.);
+  hInvMassSigVsDecLen->SetMaximum(0.04);
+  hInvMassSigVsDecLen->GetYaxis()->SetTitleOffset(1.7);
+  hInvMassSigVsDecLen->Draw();
+  cmDL->SaveAs(Form("%s-InvMassVsDecLen.png", part));
 
   TCanvas* cps = new TCanvas("cps", "Dec Vert Pos", 1400, 800);
   cps->Divide(3, 2);
@@ -586,8 +791,8 @@ void CheckDecayVertices(const char* part = "D0",
   hDeltaVxMean->SetMarkerStyle(20);
   hDeltaVxMean->SetMarkerColor(1);
   hDeltaVxMean->SetLineColor(1);
-  hDeltaVxMean->SetMinimum(-5.);
-  hDeltaVxMean->SetMaximum(5.);
+  hDeltaVxMean->SetMinimum(-10.);
+  hDeltaVxMean->SetMaximum(10.);
   hDeltaVxMean->GetYaxis()->SetTitleOffset(1.2);
   hDeltaVxMean->Draw();
   csig->cd(2);
@@ -597,8 +802,8 @@ void CheckDecayVertices(const char* part = "D0",
   hDeltaVyMean->SetMarkerStyle(20);
   hDeltaVyMean->SetMarkerColor(1);
   hDeltaVyMean->SetLineColor(1);
-  hDeltaVyMean->SetMinimum(-5.);
-  hDeltaVyMean->SetMaximum(5.);
+  hDeltaVyMean->SetMinimum(-10.);
+  hDeltaVyMean->SetMaximum(10.);
   hDeltaVyMean->GetYaxis()->SetTitleOffset(1.2);
   hDeltaVyMean->Draw();
   tdec->Draw();
@@ -609,8 +814,8 @@ void CheckDecayVertices(const char* part = "D0",
   hDeltaVzMean->SetMarkerStyle(20);
   hDeltaVzMean->SetMarkerColor(1);
   hDeltaVzMean->SetLineColor(1);
-  hDeltaVzMean->SetMinimum(-20.);
-  hDeltaVzMean->SetMaximum(20.);
+  hDeltaVzMean->SetMinimum(-50.);
+  hDeltaVzMean->SetMaximum(50.);
   hDeltaVzMean->GetYaxis()->SetTitleOffset(1.2);
   hDeltaVzMean->Draw();
   csig->cd(4);
@@ -621,7 +826,7 @@ void CheckDecayVertices(const char* part = "D0",
   hDeltaVxSig->SetMarkerColor(1);
   hDeltaVxSig->SetLineColor(1);
   hDeltaVxSig->SetMinimum(0.);
-  hDeltaVxSig->SetMaximum(40.);
+  hDeltaVxSig->SetMaximum(100.);
   hDeltaVxSig->GetYaxis()->SetTitleOffset(1.2);
   hDeltaVxSig->Draw();
   csig->cd(5);
@@ -632,7 +837,7 @@ void CheckDecayVertices(const char* part = "D0",
   hDeltaVySig->SetMarkerColor(1);
   hDeltaVySig->SetLineColor(1);
   hDeltaVySig->SetMinimum(0.);
-  hDeltaVySig->SetMaximum(40.);
+  hDeltaVySig->SetMaximum(100.);
   hDeltaVySig->GetYaxis()->SetTitleOffset(1.2);
   hDeltaVySig->Draw();
   csig->cd(6);
@@ -643,18 +848,77 @@ void CheckDecayVertices(const char* part = "D0",
   hDeltaVzSig->SetMarkerColor(1);
   hDeltaVzSig->SetLineColor(1);
   hDeltaVzSig->SetMinimum(0.);
-  hDeltaVzSig->SetMaximum(200.);
+  hDeltaVzSig->SetMaximum(1000.);
   hDeltaVzSig->GetYaxis()->SetTitleOffset(1.2);
   hDeltaVzSig->Draw();
   csig->SaveAs(Form("%s-DecayVertPos.png", part));
+
+  auto drawPullWithExpected = [](TH1F* hist, const char* functionName, const char* legendName) {
+    hist->Draw();
+    auto* expected = new TF1(functionName, "[0]*0.3989422804014327*exp(-0.5*x*x)",
+                             hist->GetXaxis()->GetXmin(), hist->GetXaxis()->GetXmax());
+    expected->SetParameter(0, hist->GetEntries() * hist->GetBinWidth(1));
+    expected->SetLineColor(kRed + 1);
+    expected->SetLineStyle(2);
+    expected->SetLineWidth(2);
+    expected->Draw("same");
+    auto* legend = new TLegend(0.55, 0.72, 0.88, 0.88, "", "NDC");
+    legend->SetName(legendName);
+    legend->SetBorderSize(0);
+    legend->SetFillStyle(0);
+    legend->AddEntry(hist, "Data", "l");
+    legend->AddEntry(expected, "Expected distribution", "l");
+    legend->Draw();
+  };
+
+  TCanvas* cpull = new TCanvas("cpull", "Secondary Vertex Pulls", 1400, 500);
+  cpull->Divide(3, 1);
+  cpull->cd(1);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  drawPullWithExpected(hPullVx, "fExpectedPullVx", "legExpectedPullVx");
+  cpull->cd(2);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  drawPullWithExpected(hPullVy, "fExpectedPullVy", "legExpectedPullVy");
+  auto* tdecPull = static_cast<TLatex*>(tdec->Clone());
+  tdecPull->SetX(0.18);
+  tdecPull->Draw();
+  cpull->cd(3);
+  gPad->SetTickx();
+  gPad->SetTicky();
+  drawPullWithExpected(hPullVz, "fExpectedPullVz", "legExpectedPullVz");
+  cpull->SaveAs(Form("%s-DecayVertPulls.png", part));
+
+  TCanvas* cpullVsDecLen = new TCanvas("cpullVsDecLen", "Pull mean and sigma vs Decay Length", 1400, 900);
+  cpullVsDecLen->Divide(3, 2);
+  TH1F* pullMeanVsDecLen[3] = {hPullVxMeanVsDecLen, hPullVyMeanVsDecLen, hPullVzMeanVsDecLen};
+  TH1F* pullSigVsDecLen[3] = {hPullVxSigVsDecLen, hPullVySigVsDecLen, hPullVzSigVsDecLen};
+  for (int i = 0; i < 3; ++i) {
+    cpullVsDecLen->cd(i + 1);
+    gPad->SetTickx();
+    gPad->SetTicky();
+    pullMeanVsDecLen[i]->SetMarkerStyle(20);
+    pullMeanVsDecLen[i]->Draw("E1");
+    cpullVsDecLen->cd(i + 4);
+    gPad->SetTickx();
+    gPad->SetTicky();
+    pullSigVsDecLen[i]->SetMarkerStyle(20);
+    pullSigVsDecLen[i]->Draw("E1");
+  }
+  cpullVsDecLen->SaveAs(Form("%s-DecayVertPullsVsDecLen.png", part));
 
   TFile* fout = new TFile(Form("%s-DecayVert.root", part), "recreate");
   hDecLen->Write();
   hPseudoPropDecLen->Write();
   hInvMassVsRap->Write();
+  hInvMassVsDecLen->Write();
   hInvMassMean->Write();
   hInvMassRms->Write();
   hInvMassSig->Write();
+  hInvMassMeanVsDecLen->Write();
+  hInvMassRmsVsDecLen->Write();
+  hInvMassSigVsDecLen->Write();
   hSecVx->Write();
   hSecVy->Write();
   hSecVz->Write();
@@ -670,6 +934,21 @@ void CheckDecayVertices(const char* part = "D0",
   hDeltaVzMean->Write();
   hDeltaVzRms->Write();
   hDeltaVzSig->Write();
+  hPullVx->Write();
+  hPullVy->Write();
+  hPullVz->Write();
+  hPullVxVsDecLen->Write();
+  hPullVyVsDecLen->Write();
+  hPullVzVsDecLen->Write();
+  hPullVxMeanVsDecLen->Write();
+  hPullVxRmsVsDecLen->Write();
+  hPullVxSigVsDecLen->Write();
+  hPullVyMeanVsDecLen->Write();
+  hPullVyRmsVsDecLen->Write();
+  hPullVySigVsDecLen->Write();
+  hPullVzMeanVsDecLen->Write();
+  hPullVzRmsVsDecLen->Write();
+  hPullVzSigVsDecLen->Write();
   hGenVsRap->Write();
   hRecoVsRap->Write();
   hEffVsRap->Write();


### PR DESCRIPTION
This PR: 
- Removes the dummy uncertainty on z and uses the track slopes to compute it
- Fix the second-order track derivatives
- Uses the full covariance matrix in the vertex fit
- Implements createParentTrackParCov
- Add option to use all 3 components of the B field (important for long-lived particles)
- Add pull, strange particles, and fix the mass computation in the test macro

For the reconstruction of the decay vertices of long-lived particles, vtPropagateTracksToPV should be set to false (the default is true).